### PR TITLE
Add therapist as a pre-commit hook

### DIFF
--- a/.therapist.yml
+++ b/.therapist.yml
@@ -1,0 +1,26 @@
+actions:
+  flake8:
+    run: flake8 {files}
+    include: "*.py"
+
+  eslint:
+    run: $(npm bin)/eslint {files}
+    fix: $(npm bin)/eslint --fix {files}
+    include:
+      - "*.js"
+      - "*.jsx"
+
+  stylelint:
+    run: $(npm bin)/stylelint {files}
+    fix: $(npm bin)/stylelint --fix {files}
+    include:
+      - "*.css"
+      - "*.scss"
+
+shortcuts:
+  all:
+    flags:
+      - use-tracked-files
+      - include-untracked
+    options:
+      action: flake8


### PR DESCRIPTION
Therapist allows us to run linting on modified files before committing.
This is done to limit the amount of error in CI because of linting.

This therapist configuration lint:
    - "js" and "jsx" files using eslint
    - "css" and "scss" files using stylelint
    - "py" files using flake8

**Note: this needs a bugzilla bug number before merging.** 
**Note 2: If we think this is a good idea, I need to write a chunk of documentation about it for kuma.readthedocs.io**

_There has not been a decision about it as far as I am aware, but I found it interesting and it works quite well locally for me, so I thought it was worth talking about it._

@peterbe This was a wonderful idea imho.