### PR TITLE
1552277 GitHub complete login network requests should be retrying

### DIFF
--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -454,20 +454,6 @@ def order_params(original_url):
     return new_url
 
 
-@contextmanager
-def override_urlconf(new_urlconf):
-    """
-    Context manager for temporarily overriding the urlconf for the current
-    thread.
-    """
-    original_urlconf = get_urlconf()
-    set_urlconf(new_urlconf)
-    try:
-        yield
-    finally:
-        set_urlconf(original_urlconf)
-
-
 def requests_retry_session(
     retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504),
 ):

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -7,6 +7,7 @@ import os
 from itertools import islice
 from urllib.parse import parse_qsl, ParseResult, urlparse, urlsplit, urlunsplit
 
+import requests
 from babel import dates, localedata
 from celery import chain, chord
 from django.conf import settings
@@ -20,6 +21,8 @@ from django.utils.translation import ugettext_lazy as _
 from polib import pofile
 from pyquery import PyQuery as pq
 from pytz import timezone
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from taggit.utils import split_strip
 
 from .exceptions import DateTimeFormatError
@@ -449,6 +452,56 @@ def order_params(original_url):
     new_qs = urlencode(qs)
     new_url = urlunsplit((bits.scheme, bits.netloc, bits.path, new_qs, bits.fragment))
     return new_url
+
+
+@contextmanager
+def override_urlconf(new_urlconf):
+    """
+    Context manager for temporarily overriding the urlconf for the current
+    thread.
+    """
+    original_urlconf = get_urlconf()
+    set_urlconf(new_urlconf)
+    try:
+        yield
+    finally:
+        set_urlconf(original_urlconf)
+
+
+def requests_retry_session(
+    retries=3, backoff_factor=0.3, status_forcelist=(500, 502, 504),
+):
+    """Opinionated wrapper that creates a requests session with a
+    HTTPAdapter that sets up a Retry policy that includes connection
+    retries.
+
+    If you do the more naive retry by simply setting a number. E.g.::
+
+        adapter = HTTPAdapter(max_retries=3)
+
+    then it will raise immediately on any connection errors.
+    Retrying on connection errors guards better on unpredictable networks.
+    From http://docs.python-requests.org/en/master/api/?highlight=retries#requests.adapters.HTTPAdapter
+    it says: "By default, Requests does not retry failed connections."
+
+    The backoff_factor is documented here:
+    https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
+    A default of retries=3 and backoff_factor=0.3 means it will sleep like::
+
+        [0.3, 0.6, 1.2]
+    """  # noqa
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
 
 
 def safer_pyquery(*args, **kwargs):

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -129,7 +129,10 @@ class SocialTestMixin(object):
             process='login',
             token_status_code=200,
             profile_status_code=200,
-            email_status_code=200):
+            email_status_code=200,
+            token_exc=None,
+            profile_exc=None,
+            email_exc=None):
         """
         Mock a login to GitHub and return the response.
 
@@ -161,23 +164,40 @@ class SocialTestMixin(object):
         with requests_mock.Mocker() as mock_requests:
             # The callback view will make requests back to Github:
             # The OAuth2 authentication token (or error)
-            mock_requests.post(
-                GitHubOAuth2Adapter.access_token_url,
-                json=token_data or self.github_token_data,
-                headers={'content-type': 'application/json'},
-                status_code=token_status_code)
+            if token_exc:
+                mock_requests.post(
+                    GitHubOAuth2Adapter.access_token_url,
+                    exc=token_exc)
+            else:
+                mock_requests.post(
+                    GitHubOAuth2Adapter.access_token_url,
+                    json=token_data or self.github_token_data,
+                    headers={'content-type': 'application/json'},
+                    status_code=token_status_code)
+
             # The authenticated user's profile data
-            mock_requests.get(
-                GitHubOAuth2Adapter.profile_url,
-                json=profile_data or self.github_profile_data,
-                status_code=profile_status_code)
+            if profile_exc:
+                mock_requests.get(
+                    GitHubOAuth2Adapter.profile_url,
+                    exc=profile_exc)
+            else:
+                mock_requests.get(
+                    GitHubOAuth2Adapter.profile_url,
+                    json=profile_data or self.github_profile_data,
+                    status_code=profile_status_code)
             # The user's emails, which could be an empty list
             if email_data is None:
                 email_data = self.github_email_data
-            mock_requests.get(
-                GitHubOAuth2Adapter.emails_url,
-                json=email_data,
-                status_code=email_status_code)
+
+            if email_exc:
+                mock_requests.get(
+                    GitHubOAuth2Adapter.emails_url,
+                    exc=email_exc)
+            else:
+                mock_requests.get(
+                    GitHubOAuth2Adapter.emails_url,
+                    json=email_data,
+                    status_code=email_status_code)
 
             # Simulate the callback from Github
             data = {'code': 'github_code', 'state': state}

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1145,25 +1145,6 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         doc = pq(resp.content)
         assert 'Account Sign In Failure' in doc.find('h1').text()
 
-    @override_config(RECAPTCHA_PRIVATE_KEY='private_key',
-                     RECAPTCHA_PUBLIC_KEY='public_key')
-    def test_signin_captcha(self):
-        resp = self.github_login()
-        self.assertRedirects(resp, self.signup_url)
-
-        data = {'website': '',
-                'username': 'octocat',
-                'email': 'octo.cat@github-inc.com',
-                'terms': True,
-                'g-recaptcha-response': 'FAILED'}
-
-        with mock.patch('captcha.client.request') as request_mock:
-            request_mock.return_value.read.return_value = '{"success": null}'
-            response = self.client.post(self.signup_url, data=data, follow=True)
-        assert response.status_code == 200
-        assert (response.context['form'].errors ==
-                {'captcha': [u'Incorrect, please try again.']})
-
     def test_matching_user(self):
         self.github_login()
         response = self.client.get(self.signup_url)


### PR DESCRIPTION
(first of all, this PR is not ready because it includes two separate commits. One of which needs to be landed first in [this separate PR](https://github.com/mozilla/kuma/pull/5421). I didn't want to wait for #5421 to land before starting on this because I "had it fresh in my head". Once that other PR lands, I'll clean up this PR)

**This PR is important and not important at the same time.**

It's not important since it's rather harmless little change in something that happens relatively rarely. All it does is protect the completion-view of the signup flow by retrying `request.get` if GitHub was every to respond with a 500, 502 or 504 response. It's the right and a safe thing to do. 

But it's important because this PR introduces an important new utility function. Namely; `requests_retry_session`. It's a function I originally wrote for [tecken](https://github.com/mozilla-services/tecken/blob/master/tecken/base/utils.py#L14) about 2 years ago. It was very well researched and has been running very productively in symbols.mozilla.org for 2 years now. I've since reused in a bunch of places with success. And it's something [I've blogged about](https://www.peterbe.com/plog/best-practice-with-retries-with-requests) and it's a post that's been well received and had over 75k views. 

My hope and intention is to reuse this new utility function in a bunch of places in kuma. Almost all the places where we currently do `requests.get` or `requests.post`. This PR is its "introduction" to kuma. 

