### PR TITLE
chore(editorconfig): Enforce consistent indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Indentiation
-[*.{css,html,js,jsx,json,py,styl}]
 indent_style = space
 indent_size = 4
+
+# Jenkinsfile uses two spaces
+[Jenkinsfile]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ indent_size = 4
 # Jenkinsfile uses two spaces
 [Jenkinsfile]
 indent_size = 2
+
+# git and Makefile use the superior tabs
+[.git*,Makefile,make.bat]
+indent_style = tab


### PR DESCRIPTION
Currently, default indentation for my editor is configured to use tabs, and without this, my editor indents `.scss` files with tabs.

---

This enforces consistent indentation for all files.

I personally prefer tabs though, because they are more space efficient on disk and in memory (4 bytes per pace vs just 1 per tab).