### PR TITLE
Issue#5819 add interpolated with elements

### DIFF
--- a/kuma/javascript/src/__snapshots__/l10n.test.jsx.snap
+++ b/kuma/javascript/src/__snapshots__/l10n.test.jsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Interpolated/> takes element parameters 1`] = `
+Array [
+  "oh a ",
+  <a
+    href="/"
+  >
+    click
+  </a>,
+  " wow",
+]
+`;
+
+exports[`<Interpolated/> takes element parameters 2`] = `
+Array [
+  "wow ",
+  <h1>
+    Beautiful
+  </h1>,
+  " such ",
+  "<body />",
+  " many ",
+  <p
+    className="something"
+  >
+    more
+  </p>,
+  "",
+]
+`;

--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -13,6 +13,7 @@
  *
  * @flow
  */
+import * as React from 'react';
 
 // This is the type of the string catalog that Django creates for a locale.
 type StringCatalog = { [string]: string | Array<string> };
@@ -149,4 +150,33 @@ export function interpolate(s: string, args: Array<any> | { [string]: any }) {
             String(typedArgs[match.slice(2, -2)])
         );
     }
+}
+
+const ELEMENT_REGEXP = /(<\w+\s*\/>)/g;
+/**
+ * Similar to interpolate() it interpolates the given id-string with the given
+ * properties, but it can also work with React Elements. It will replace strings
+ * of the form `<name/>` and return an Array of React Elements.
+ */
+export function Interpolated({
+    id,
+    ...args
+}: {
+    id: string,
+    [key: string]: React.Node
+}): React.Node[] {
+    return id.split(ELEMENT_REGEXP).map((str, i) => {
+        if (!ELEMENT_REGEXP.test(str)) {
+            return str;
+        }
+
+        const element = args[str.slice(1, -2).trim()];
+        if (!element) {
+            return str;
+        }
+
+        return React.cloneElement(element, {
+            key: str + i
+        });
+    });
 }

--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -175,6 +175,13 @@ export function Interpolated({
             return str;
         }
 
+        /**
+         *  This string refers to an element, but is there a corresponding
+         *  element in args?
+         *  `args` contain: privacyLink={<a href="#here">Hello</a>}
+         *  args["<footer/>".slice(1, -2).trim()]; // false
+         *  args["<privacyLink/>".slice(1, -2).trim()]; // true
+         */
         const element = args[str.slice(1, -2).trim()];
         if (!element) {
             return str;

--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -152,6 +152,11 @@ export function interpolate(s: string, args: Array<any> | { [string]: any }) {
     }
 }
 
+/**
+ * ELEMENT_REGEXP.test("This is just a string"); // false
+ * ELEMENT_REGEXP.test("<elem/>"); // true
+ * ELEMENT_REGEXP.test("<elemWithSpace />"); // true
+ */
 const ELEMENT_REGEXP = /(<\w+\s*\/>)/g;
 /**
  * Similar to interpolate() it interpolates the given id-string with the given

--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -157,6 +157,11 @@ const ELEMENT_REGEXP = /(<\w+\s*\/>)/g;
  * Similar to interpolate() it interpolates the given id-string with the given
  * properties, but it can also work with React Elements. It will replace strings
  * of the form `<name/>` and return an Array of React Elements.
+ *
+ * Use it like this (in a React Component):
+ * <Interpolated id="look at this <link/>!" link={<a href="/">site</a>}/>
+ * which renders
+ * ["Look at this ", <a key="<link/>2" href="/">site</a>, "!"]
  */
 export function Interpolated({
     id,

--- a/kuma/javascript/src/l10n.test.jsx
+++ b/kuma/javascript/src/l10n.test.jsx
@@ -176,6 +176,13 @@ describe('interpolate()', () => {
 });
 
 describe('<Interpolated/>', () => {
+    it("doesn't modify strings when no parameters are given", () => {
+        const tree = renderer
+            .create(<Interpolated id="just some text" />)
+            .toJSON();
+        expect(tree).toMatchInlineSnapshot(`"just some text"`);
+    });
+
     it('takes element parameters', () => {
         const tree1 = renderer
             .create(

--- a/kuma/javascript/src/l10n.test.jsx
+++ b/kuma/javascript/src/l10n.test.jsx
@@ -1,6 +1,14 @@
 //@flow
-
-import { localize, getLocale, gettext, ngettext, interpolate } from './l10n.js';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {
+    localize,
+    getLocale,
+    gettext,
+    ngettext,
+    interpolate,
+    Interpolated
+} from './l10n';
 
 // We don't actually want the strings in this file to be extracted
 // for localization, so we're going to use non-standard aliases
@@ -142,7 +150,7 @@ describe('ngettext', () => {
 });
 
 describe('interpolate()', () => {
-    it('two argument form', () => {
+    it('takes an array', () => {
         expect(interpolate('foo', [])).toBe('foo');
         expect(interpolate('%s', [1])).toBe('1');
         expect(interpolate('%s%s%s', [1, 2, 3])).toBe('123');
@@ -152,7 +160,7 @@ describe('interpolate()', () => {
         expect(interpolate('A%sfoo%sZ', ['a', 'z'])).toBe('AafoozZ');
     });
 
-    it('three argument form, with object', () => {
+    it('takes an object with string parameters', () => {
         expect(interpolate('foo', {})).toBe('foo');
         expect(interpolate('%(a)s', { a: 1 })).toBe('1');
         expect(interpolate('%(b)s foo %(a)s', { a: 1, b: true })).toBe(
@@ -164,5 +172,30 @@ describe('interpolate()', () => {
         expect(interpolate('%(a)s%(b)s%(d)s', { a: 1, b: 2, c: 3 })).toBe(
             '12undefined'
         );
+    });
+});
+
+describe('<Interpolated/>', () => {
+    it('takes element parameters', () => {
+        const tree1 = renderer
+            .create(
+                <Interpolated
+                    id="oh a <link/> wow"
+                    link={<a href="/">click</a>}
+                />
+            )
+            .toJSON();
+        expect(tree1).toMatchSnapshot();
+
+        const tree2 = renderer
+            .create(
+                <Interpolated
+                    id="wow <head/> such <body /> many <foot />"
+                    head={<h1>Beautiful</h1>}
+                    foot={<p className="something">more</p>}
+                />
+            )
+            .toJSON();
+        expect(tree2).toMatchSnapshot();
     });
 });

--- a/kuma/javascript/src/newsletter.jsx
+++ b/kuma/javascript/src/newsletter.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useContext, useEffect, useRef, useState } from 'react';
 
 import GAProvider from './ga-provider.jsx';
-import { getLocale, gettext } from './l10n.js';
+import { getLocale, gettext, Interpolated } from './l10n';
 import CloseIcon from './icons/close.svg';
 
 const NEWSLETTER_SUBSCRIBE_URL = 'https://www.mozilla.org/en-US/newsletter/';
@@ -256,13 +256,16 @@ export default function Newsletter() {
                                 required
                             />
                             <label htmlFor="newsletter-privacy-input">
-                                {gettext(
-                                    'I’m okay with Mozilla handling my info as explained in this '
-                                )}
-                                <a href={PRIVACY_POLICY_URL}>
-                                    {gettext('Privacy Policy')}
-                                </a>
-                                .
+                                <Interpolated
+                                    id={gettext(
+                                        'I’m okay with Mozilla handling my info as explained in this <privacyLink/>.'
+                                    )}
+                                    privacyLink={
+                                        <a href={PRIVACY_POLICY_URL}>
+                                            {gettext('Privacy Policy')}
+                                        </a>
+                                    }
+                                />
                             </label>
                         </div>
                         <div className="newsletter-group-submit">


### PR DESCRIPTION
Fixes #5819 

I added a Component that works similar to `interpolate`, except that it returns an array with `React.Node`s in it. That way you can also use it to interpolate elements into a string (without risking XSS).

Longer term I'd like to investigate using [Fluent](https://github.com/projectfluent/fluent.js/) which we used in Common Voice and will soon be the No 1 localization system inside of FF. The things we do in `l10n.jsx` are similar but less powerful to what Fluent offers (pluralization comes to mind).