### PR TITLE
5949 expose the raw kuma html in the document json api

### DIFF
--- a/kuma/api/tasks.py
+++ b/kuma/api/tasks.py
@@ -138,7 +138,7 @@ def publish(doc_pks, log=None, completion_message=None,
             if is_redirect_to_document:
                 kwargs.update(WebsiteRedirectLocation=redirect_url)
             data = document_api_data(redirect_url=redirect_url)
-            kwargs.update(Body=json.dumps(data, indent=2))
+            kwargs.update(Body=json.dumps(data))
         else:
             data = document_api_data(doc)
             kwargs.update(Body=json.dumps(data))

--- a/kuma/api/tasks.py
+++ b/kuma/api/tasks.py
@@ -137,9 +137,8 @@ def publish(doc_pks, log=None, completion_message=None,
             redirect_url, is_redirect_to_document = redirect
             if is_redirect_to_document:
                 kwargs.update(WebsiteRedirectLocation=redirect_url)
-            else:
-                data = document_api_data(redirect_url=redirect_url)
-                kwargs.update(Body=json.dumps(data, indent=2))
+            data = document_api_data(redirect_url=redirect_url)
+            kwargs.update(Body=json.dumps(data, indent=2))
         else:
             data = document_api_data(doc)
             kwargs.update(Body=json.dumps(data))

--- a/kuma/api/tasks.py
+++ b/kuma/api/tasks.py
@@ -139,7 +139,7 @@ def publish(doc_pks, log=None, completion_message=None,
                 kwargs.update(WebsiteRedirectLocation=redirect_url)
             else:
                 data = document_api_data(redirect_url=redirect_url)
-                kwargs.update(Body=json.dumps(data))
+                kwargs.update(Body=json.dumps(data, indent=2))
         else:
             data = document_api_data(doc)
             kwargs.update(Body=json.dumps(data))

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -13,7 +13,7 @@ from kuma.wiki.templatetags.jinja_helpers import absolutify
 
 def test_get_s3_key(root_doc):
     locale, slug = root_doc.locale, root_doc.slug
-    expected_key = 'api/v1/doc/{}/{}'.format(locale, slug)
+    expected_key = 'api/v1/doc/{}/{}.json'.format(locale, slug)
     assert (
         get_s3_key(root_doc) == get_s3_key(locale=locale, slug=slug) ==
         expected_key
@@ -37,7 +37,12 @@ def test_get_content_based_redirect(root_doc, redirect_doc, redirect_to_self,
         expected = None
     elif case == 'redirect':
         doc = redirect_doc
-        expected = (get_s3_key(root_doc, prefix_with_forward_slash=True), True)
+        expected = (
+            get_s3_key(
+                root_doc,
+                prefix_with_forward_slash=True,
+                suffix_file_extension=False),
+            True)
     elif case == 'redirect-to-self':
         doc = redirect_to_self
         expected = None

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -119,8 +119,6 @@ def document_api_data(doc=None, redirect_url=None):
     """
     Returns the JSON data for the document for the document API.
     """
-    print("DOC:", doc)
-    print("redirect_url", redirect_url)
     if redirect_url:
         return {
             'documentData': None,

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -61,7 +61,7 @@ def get_s3_key(doc=None, locale=None, slug=None,
                prefix_with_forward_slash=False):
     if doc:
         locale, slug = doc.locale, doc.slug
-    key = reverse('api.v1.doc', args=(locale, slug))
+    key = reverse('api.v1.doc', args=(locale, slug)) + '.json'
     if prefix_with_forward_slash:
         # Redirects within an S3 bucket must be prefixed with "/".
         return key

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -156,6 +156,7 @@ def document_api_data(doc=None, redirect_url=None):
             'bodyHTML': doc.get_body_html(),
             'quickLinksHTML': doc.get_quick_links_html(),
             'tocHTML': doc.get_toc_html(),
+            'raw': doc.html,
             'parents': [
                 {
                     'url': d.get_absolute_url(),

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -58,10 +58,13 @@ def doc(request, locale, slug):
 
 
 def get_s3_key(doc=None, locale=None, slug=None,
-               prefix_with_forward_slash=False):
+               prefix_with_forward_slash=False,
+               suffix_file_extension=True):
     if doc:
         locale, slug = doc.locale, doc.slug
-    key = reverse('api.v1.doc', args=(locale, slug)) + '.json'
+    key = reverse('api.v1.doc', args=(locale, slug))
+    if suffix_file_extension:
+        key += '.json'
     if prefix_with_forward_slash:
         # Redirects within an S3 bucket must be prefixed with "/".
         return key
@@ -70,7 +73,11 @@ def get_s3_key(doc=None, locale=None, slug=None,
 
 def get_cdn_key(locale, slug):
     """Given a document's locale and slug, return the "key" for the CDN."""
-    return get_s3_key(locale=locale, slug=slug, prefix_with_forward_slash=True)
+    return get_s3_key(
+        locale=locale,
+        slug=slug,
+        prefix_with_forward_slash=True,
+        suffix_file_extension=False)
 
 
 def get_content_based_redirect(document):
@@ -88,7 +95,10 @@ def get_content_based_redirect(document):
         if redirect_document:
             # This is a redirect to another document.
             return (
-                get_s3_key(redirect_document, prefix_with_forward_slash=True),
+                get_s3_key(
+                    redirect_document,
+                    prefix_with_forward_slash=True,
+                    suffix_file_extension=False),
                 True
             )
         # This is a redirect to non-document page. For now, if it's the home
@@ -109,6 +119,8 @@ def document_api_data(doc=None, redirect_url=None):
     """
     Returns the JSON data for the document for the document API.
     """
+    print("DOC:", doc)
+    print("redirect_url", redirect_url)
     if redirect_url:
         return {
             'documentData': None,

--- a/kuma/wiki/management/commands/render_document.py
+++ b/kuma/wiki/management/commands/render_document.py
@@ -37,6 +37,9 @@ class Command(BaseCommand):
             help='Render ALL documents (rather than by path)',
             action='store_true')
         parser.add_argument(
+            '--locale',
+            help='Publish ALL documents in this locale (rather than by path)')
+        parser.add_argument(
             '--min-age',
             help='Documents rendered less than this many seconds ago will be'
                  ' skipped (default 600)',
@@ -53,10 +56,6 @@ class Command(BaseCommand):
         parser.add_argument(
             '--nocache',
             help='Use Cache-Control: no-cache instead of max-age=0',
-            action='store_true')
-        parser.add_argument(
-            '--defer',
-            help='Defer rendering by chaining tasks via celery',
             action='store_true')
         parser.add_argument(
             '--skip-cdn-invalidation',
@@ -83,6 +82,8 @@ class Command(BaseCommand):
             docs = Document.objects.filter(
                 Q(last_rendered_at__isnull=True) |
                 Q(last_rendered_at__lt=min_render_age))
+            if options['locale']:
+                docs = docs.filter(locale=options['locale'])
             docs = docs.order_by('-modified')
             docs = docs.values_list('id', flat=True)
 


### PR DESCRIPTION
@escattone this is NOT urgent. But it's important as the basis of a discussion. Also, I wouldn't mind if we land this in production so I can continue my work with testing this "migration strategy".

This PR is part of a project that spans Kuma, stumptown-content, and stumptown-renderer. 
With this change, I was able to run `render_document --all` and the that populates an S3 bucket. 
Now, because every file gets a unique name (no more `Web` the file and `Web` the "folder" because the file becomes `Web.json`), I can run: `s3cmd sync s3://peterbe-mdn-documents/ kumadocs/ --recursive` and be able to run a Node script that walks this `kumadocs/` directory without problems. 

Part of the [Stumptown Render Kuma AND Stumptown Semi-Dynamically](https://docs.google.com/document/d/1yNJCNJ2iv4H7f8E0OcJlLxDDrP90Pv6os85yMAnX0mI/edit?usp=sharing) project.