### PR TITLE
don't mask all rest framework errors

### DIFF
--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import elasticsearch
 import pytest
 from django.conf import settings
 

--- a/kuma/search/utils.py
+++ b/kuma/search/utils.py
@@ -1,11 +1,7 @@
 import logging
 
-import elasticsearch
 import six
 from django.utils.translation import ugettext_lazy as _
-from rest_framework import status
-from rest_framework.response import Response
-from rest_framework.views import exception_handler
 from urlobject import URLObject
 
 
@@ -69,24 +65,3 @@ class QueryURLObject(URLObject):
             if param and default:
                 clean_params[param] = default
         return clean_params
-
-
-def search_exception_handler(exc, context):
-    # Call REST framework's default exception handler first,
-    # to get the standard error response.
-    response = exception_handler(exc, context)
-
-    if response is None:
-        if isinstance(exc, elasticsearch.ElasticsearchException):
-            # FIXME: This really should return a 503 error instead but Zeus
-            # doesn't let that through and displays a generic error page in that
-            # case which we don't want here
-            log.error('Elasticsearch exception: %s' % exc)
-            return Response({'detail': SEARCH_DOWN_DETAIL},
-                            status=status.HTTP_200_OK)
-        elif isinstance(exc, UnicodeDecodeError):
-            log.error('UnicodeDecodeError exception: %s' % exc)
-            return Response({'detail': SEARCH_ERROR_DETAIL},
-                            status=status.HTTP_404_NOT_FOUND)
-
-    return response

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1747,11 +1747,6 @@ BLOCKABLE_USER_AGENTS = [
     "curl",
 ]
 
-# TODO: Once using DRF more we need to make that exception handler more generic
-REST_FRAMEWORK = {
-    'EXCEPTION_HANDLER': 'kuma.search.utils.search_exception_handler'
-}
-
 SENTRY_DSN = config('SENTRY_DSN', default=None)
 
 if SENTRY_DSN:


### PR DESCRIPTION
Fixes #5982

In the olden days, I think `rest_framework` was only used for the site-search if someone didn't use the website. E.g. `/en-US/search.json`. 
Then we started using `rest_framework` for BCD signalling and various things in `/api/v1/*`. 

What the old code, that I've deleted, tried to do was to turn the server errors into other things that it was not. If Elasticsearch is having a rough moment (perhaps it's in the middle of shard balancing, or upgrading, or restarting) we should pretend that it worked with a "200 OK". 

If we have unicode errors or Elasticsearch errors I'd rather find out about it properly instead of masking it. For example, if we see elevated Sentry errors related to say `elasticsearch.TransportError` might want to wrap the Elasticsearch call in a retry mechanism. 

Generally, this "changes nothing". It just removes the weird cover. 