### PR TITLE
./manage.py runserver instead of gunicorn for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
     <<: *worker
-    command: gunicorn -w ${GUNICORN_WORKERS:-4} --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 --worker-class=meinheld.gmeinheld.MeinheldWorker kuma.wsgi:application
+    command: ./manage.py runserver 0.0.0.0:8000
     depends_on:
       - mysql
       - elasticsearch
@@ -63,7 +63,7 @@ services:
   # API is used by KumaScript for content and metadata
   api:
     <<: *worker
-    command: gunicorn -w ${GUNICORN_WORKERS:-4} --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 kuma.wsgi:application
+    command: ./manage.py runserver 0.0.0.0:8000
     depends_on:
       - mysql
       - elasticsearch


### PR DESCRIPTION
If you put a `--reload` at the end of the existing `gunicorn` line, it'll actually trigger as soon as you edit a .py file in your editor. It'll say:

```
web_1            | [2019-10-24 11:28:25 +0000] [11] [INFO] Worker reloading: /app/kuma/wiki/views/document.py modified
web_1            | [2019-10-24 11:28:25 +0000] [9] [INFO] Worker reloading: /app/kuma/wiki/views/document.py modified
```
in `docker-compose up`.
But it doesn't actually work. I don't know if it's because of the worker class or something else docker related. 

Anyway, this stuff works. It starts faster too. And any edit to a .py file reloads so you don't have to run `docker-compose restart web` anymore. 

I guess we're running `gunicorn` in docker-compose to be more similar to what we run in production, but that's already out of whack with the fact that some much is so different when you're switching `settings.DEBUG` on and off. 

What do you think @escattone ?