### PR TITLE
fix(webpack‑config): Correctly support multi‑entry NODE_PATH

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const webpackMerge = require('webpack-merge');
 //
 // TODO: there ought to be a better way to do this.
 //
-const nodePath = process.env.NODE_PATH || path.join(__dirname, 'node_modules');
+const nodePath = (process.env.NODE_PATH && process.env.NODE_PATH.split(path.delimiter)) || [path.join(__dirname, 'node_modules')];
 const modeConfig = env => require(`./webpack-build-utils/webpack.${env}`)(env);
 const presetsConfig = require('./webpack-build-utils/loadPresets');
 
@@ -37,10 +37,10 @@ module.exports = ({ mode, presets } = { mode: 'production', presets: [] }) => {
                 ]
             },
             resolve: {
-                modules: [nodePath]
+                modules: nodePath
             },
             resolveLoader: {
-                modules: [nodePath]
+                modules: nodePath
             },
             output: {
                 filename: 'react.js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,10 @@ const webpackMerge = require('webpack-merge');
 //
 // TODO: there ought to be a better way to do this.
 //
-const nodePath = (process.env.NODE_PATH && process.env.NODE_PATH.split(path.delimiter)) || [path.join(__dirname, 'node_modules')];
+const nodePath = (process.env.NODE_PATH &&
+    process.env.NODE_PATH.split(path.delimiter)) || [
+    path.join(__dirname, 'node_modules')
+];
 const modeConfig = env => require(`./webpack-build-utils/webpack.${env}`)(env);
 const presetsConfig = require('./webpack-build-utils/loadPresets');
 


### PR DESCRIPTION
In cases where `NODE_PATH` has multiple entries (e.g., [with&nbsp;**pnpm**](https://pnpm.js.org); https://github.com/webpack/webpack/issues/5087), the `webpack.config.js` file wasn’t correctly configured to support that.

There’s also no guarantee that Docker won’t start adding more entries to `NODE_PATH`.