### PR TITLE
don't 500 on overly big ?page in search

### DIFF
--- a/kuma/search/paginator.py
+++ b/kuma/search/paginator.py
@@ -20,7 +20,7 @@ class SearchPaginator(Paginator):
         """
         Validates the given 1-based page number.
 
-        This class overrides the default behavior and ignores the upper bound.
+        We also check that the number isn't too large.
         """
         try:
             number = int(number)
@@ -28,16 +28,7 @@ class SearchPaginator(Paginator):
             raise PageNotAnInteger('That page number is not an integer')
         if number < 1:
             raise EmptyPage('That page number is less than 1')
-        return number
 
-    def page(self, number):
-        """
-        Returns a page object.
-
-        This class overrides the default behavior and ignores "orphans" and
-        assigns the count from the ES result to the Paginator.
-        """
-        number = self.validate_number(number)
         if number >= 1000:
             # Anything >=1,000 will result in a hard error in
             # Elasticsearch which would happen before we even get a chance
@@ -50,6 +41,16 @@ class SearchPaginator(Paginator):
             # See https://github.com/mdn/kuma/issues/6092
             raise InvalidPage('Page number too large')
 
+        return number
+
+    def page(self, number):
+        """
+        Returns a page object.
+
+        This class overrides the default behavior and ignores "orphans" and
+        assigns the count from the ES result to the Paginator.
+        """
+        number = self.validate_number(number)
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
 

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -162,6 +162,14 @@ class ViewTests(ElasticTestCase):
         response = view(request)
         assert response.data['pages'] == 2
 
+    def test_paginate_too_large(self):
+        response = self.client.get('/en-US/search', {'page': 1000},
+                                   HTTP_HOST=settings.WIKI_HOST)
+        # It's a bit odd that an invalid query string parameter
+        # causes a 404 Not Found but that's how the paginator for
+        # rest_framework works.
+        assert response.status_code == 404
+
     def test_tokenize_camelcase_titles(self):
         for q in ('get', 'element', 'by', 'id'):
             response = self.client.get('/en-US/search', {'q': q},


### PR DESCRIPTION
Fixes #6092

If you add `?page=20` to the `rest_framework`, which, by default, is for the SQL ORM you get this:

```sql
...  OFFSET 200 LIMIT 10
```
(because the default page size is 10 so the offset is 20 * 10).

But if that `page` number is crazy like, `?page=2000` instead you get:
```sql
...  OFFSET 20000 LIMIT 10
```

which MySQL can handle and won't choke. However, Elasticsearch is quick to judge. It'll crash on an offset that large. 

Normally, the way pagination works in `rest_framework` is that it evaluates and validates the `page` query string parameter pretty late and that might be happening AFTER then SQL/ES query is attempted. 