### PR TITLE
fix integration tests for Python 3

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def is_local_url(base_url):
     instance (localhost).
     """
     return (base_url and
-            urlsplit(base_url).hostname.split('.')[-1] == 'localhost')
+            'localhost' in urlsplit(base_url).hostname.split('.'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -111,7 +111,7 @@ def test_document(site_url, is_indexed):
     resp = request('get', url)
     assert resp.status_code == 200
     assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
-    meta = META_ROBOTS_RE.search(resp.content)
+    meta = META_ROBOTS_RE.search(resp.text)
     assert meta
     content = meta.group('content')
     if is_indexed:
@@ -127,7 +127,7 @@ def test_user_document(site_url):
     resp = request('get', url)
     assert resp.status_code == 200
     assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
-    meta = META_ROBOTS_RE.search(resp.content)
+    meta = META_ROBOTS_RE.search(resp.text)
     assert meta
     content = meta.group('content')
     # Pages with legacy MindTouch namespaces like 'User:' never get
@@ -168,7 +168,7 @@ def test_home(site_url, is_indexed):
     resp = request('get', url)
     assert resp.status_code == 200
     assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
-    meta = META_ROBOTS_RE.search(resp.content)
+    meta = META_ROBOTS_RE.search(resp.text)
     assert meta
     content = meta.group('content')
     if is_indexed:
@@ -248,7 +248,7 @@ LOCALE_SELECTORS = {
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('expected,accept,cookie,param',
                          LOCALE_SELECTORS.values(),
-                         ids=LOCALE_SELECTORS.keys())
+                         ids=list(LOCALE_SELECTORS))
 @pytest.mark.parametrize(
     'slug', ['/search',
              '/events',

--- a/tests/headless/test_robots.py
+++ b/tests/headless/test_robots.py
@@ -17,9 +17,9 @@ def test_robots(any_host_url):
     urlbits = urlsplit(any_host_url)
     hostname = urlbits.netloc
     if hostname in INDEXED_ATTACHMENT_DOMAINS:
-        assert response.content.strip() == ''
+        assert response.text.strip() == ''
     elif hostname in INDEXED_WEB_DOMAINS:
-        assert 'Sitemap: ' in response.content
-        assert 'Disallow: /admin/\n' in response.content
+        assert 'Sitemap: ' in response.text
+        assert 'Disallow: /admin/\n' in response.text
     else:
-        assert 'Disallow: /\n' in response.content
+        assert 'Disallow: /\n' in response.text

--- a/tests/utils/urls.py
+++ b/tests/utils/urls.py
@@ -122,12 +122,16 @@ def assert_valid_url(url, location=None, status_code=requests.codes.moved_perman
             # strip off query for further comparison
             resp_location = resp_location.split('?')[0]
 
-        assert location == unquote(resp_location).decode()
+        assert location == unquote(resp_location)
 
     if resp_headers and not follow_redirects:
+
+        def convert_to_set(header):
+            return frozenset(d.strip() for d in header.lower().split(','))
+
         for name, value in resp_headers.items():
             assert name in resp.headers
-            assert resp.headers[name].lower() == value.lower()
+            assert convert_to_set(resp.headers[name]) == convert_to_set(value)
 
 
 # https://github.com/mozilla/bedrock/blob/master/tests/redirects/base.py


### PR DESCRIPTION
Fixes #6110 

It also goes a bit beyond #6110 and fixes the `is_local_url` pytest fixture as well.