### PR TITLE
Fixes #6067, remove contributor messaging post signup

### DIFF
--- a/kuma/users/signal_handlers.py
+++ b/kuma/users/signal_handlers.py
@@ -1,14 +1,11 @@
 from allauth.account.signals import email_confirmed, user_signed_up
 from allauth.socialaccount.signals import social_account_removed
-from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models.signals import post_delete, post_save, pre_delete
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
 from waffle import switch_is_active
 
-from kuma.core.urlresolvers import reverse
 from kuma.payments.utils import cancel_stripe_customer_subscription
 from kuma.wiki.jobs import DocumentContributorsJob
 

--- a/kuma/users/signal_handlers.py
+++ b/kuma/users/signal_handlers.py
@@ -21,10 +21,6 @@ def on_user_signed_up(sender, request, user, **kwargs):
     """
     Signal handler to be called when a given user has signed up.
     """
-    url = reverse('wiki.document', args=['MDN/Getting_started'])
-    msg = _('You have completed the first step of '
-            '<a href="%s">getting started with MDN</a>') % url
-    messages.success(request, msg)
     if switch_is_active('welcome_email'):
         # only send if the user has already verified
         # at least one email address

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -3,7 +3,6 @@ from unittest import mock
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from allauth.account.signals import user_signed_up
 from django.conf import settings
-from django.contrib import messages as django_messages
 from django.core import mail
 from django.test import RequestFactory, TestCase
 from waffle.testutils import override_switch
@@ -89,21 +88,6 @@ class TestWelcomeEmails(UserTestCase):
         expected_to = [testuser.email]
         self.assertEqual(expected_to, welcome_email.to)
         self.assertTrue('utm_campaign=welcome' in welcome_email.body)
-
-    def test_signup_getting_started_message(self):
-        testuser = user(username='welcome', email='welcome@tester.com',
-                        password='welcome', save=True)
-        request = self.setup_request_for_messages()
-        messages = self.get_messages(request)
-        self.assertEqual(len(messages), 0)
-
-        user_signed_up.send(sender=testuser.__class__, request=request,
-                            user=testuser)
-
-        queued_messages = list(messages)
-        self.assertEqual(len(queued_messages), 1)
-        self.assertEqual(django_messages.SUCCESS, queued_messages[0].level)
-        self.assertTrue('getting started' in queued_messages[0].message)
 
     @override_switch('welcome_email', True)
     @call_on_commit_immediately


### PR DESCRIPTION
This removes the messaging around contributions post-sign-up.

## Before

![67869535-3ce5a700-fb36-11e9-930b-66b82f6fd141](https://user-images.githubusercontent.com/10350960/69056459-af9cc080-0a18-11ea-8bbe-02b5309d89a7.png)

## After

![Screenshot 2019-11-18 at 15 19 05](https://user-images.githubusercontent.com/10350960/69056481-bb888280-0a18-11ea-9d64-e9ed5868046b.png)

@peterbe r?