### PR TITLE
always track outbound links

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -169,9 +169,6 @@
     {{ providers_media_js() }}
     <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'main' %}
-    <script>
-    if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
-  </script>
     {% for script in scripts %}
       {% javascript script %}
     {% endfor %}

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -136,9 +136,6 @@
   {% block site_js %}
     {{ providers_media_js() }}
     {% javascript 'react-main' %}
-    <script>
-    if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
-  </script>
     {% for script in scripts %}
       {% javascript script %}
     {% endfor %}

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -132,53 +132,6 @@
 
             mdn.analytics.send(data);
         },
-        /*
-            Track all outgoing links
-        */
-        trackOutboundLinks: function(target) {
-            target = target || document.body;
-
-            target.addEventListener('click', function(e) {
-                var link = e.target.closest('a');
-                if (!link) {
-                    // If the click was not on a link there is nothing to track
-                    return;
-                }
-
-                // bug 1222864 - prevent links to data: uris
-                if (link.href.toLowerCase().indexOf('data') === 0) {
-                    e.preventDefault();
-                    analytics.trackError('XSS Attempt', 'data href');
-                    return;
-                }
-
-                // If we explicitly say not to track something, don't
-                if (link.classList.contains('no-track')) {
-                    return;
-                }
-
-                var host = link.hostname;
-                if(host && host !== location.hostname) {
-                    var newTab = (link.target === '_blank' || e.metaKey || e.ctrlKey);
-                    var href = link.href;
-                    var callback = function() {
-                        win.location = href;
-                    };
-                    var data = {
-                        category: 'Outbound Links',
-                        action: href
-                    };
-
-                    if(newTab) {
-                        analytics.trackEvent(data);
-                    } else {
-                        e.preventDefault();
-                        data.hitCallback = callback;
-                        analytics.trackEvent(data, callback);
-                    }
-                }
-            });
-        },
 
         trackLink: function(event, url, data) {
             // ctrl or cmd click or context menu
@@ -251,4 +204,56 @@
             });
         }
     };
+
+    /*
+        Track all outgoing links
+    */
+    function trackOutboundLinks() {
+        document.body.addEventListener('click', function(e) {
+
+            var link = e.target.closest('a');
+            if (!link) {
+                // If the click was not on a link there is nothing to track
+                return;
+            }
+
+            // bug 1222864 - prevent links to data: uris
+            if (link.href.toLowerCase().indexOf('data') === 0) {
+                e.preventDefault();
+                analytics.trackError('XSS Attempt', 'data href');
+                return;
+            }
+
+            // If we explicitly say not to track something, don't
+            if (link.classList.contains('no-track')) {
+                return;
+            }
+
+            var host = link.hostname;
+            if(host && host !== location.hostname) {
+                var newTab = (link.target === '_blank' || e.metaKey || e.ctrlKey);
+                var href = link.href;
+                var callback = function() {
+                    win.location = href;
+                };
+                var data = {
+                    category: 'Outbound Links',
+                    action: href
+                };
+
+                if(newTab) {
+                    analytics.trackEvent(data);
+                } else {
+                    e.preventDefault();
+                    data.hitCallback = callback;
+                    analytics.trackEvent(data, callback);
+                }
+            }
+        });
+    }
+
+
+    /* Some things we always trigger. */
+    trackOutboundLinks();
+
 })(window, document);

--- a/kuma/users/jinja2/socialaccount/base_signup.html
+++ b/kuma/users/jinja2/socialaccount/base_signup.html
@@ -128,9 +128,6 @@
 
     {{ providers_media_js() }}
     {% javascript 'react-main' %}
-    <script>
-        if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
-    </script>
     {% for script in scripts %}
     {% javascript script %}
     {% endfor %}

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -96,10 +96,6 @@
 
   <!-- site js -->
   {% javascript 'react-main' %}
-  <script>
-    if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
-  </script>
-
   {% if waffle.flag('bc-signals') %}
     {% javascript "bcd-signal" %}
   {% endif %}


### PR DESCRIPTION
Fixes #6132

The problem was that we had this:
```html
<script defer type="text/javascript" src="/static/build/js/react-main.3608eae72453.js" charset="utf-8"></script>
<script>
    if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
</script>
```
and deep inside `react-main.3608eae72453.js` it *creates* `window.mdn.analytics`. So the `defer` postpones the creation of `mdn.analytics` and the next couple of lines of inline script will always run before that. Easy mistake. 

But then I noticed there is absolutely no use making `trackOutboundLinks` a "public" function inside `mdn.analytics`. Because it gets called every time all the time. So, I just took it out of the object that `mdn.analytics` is and simply pasted it at the bottom of this closure. There's no need for it being a function actually but being inside a function has it's advantages too. 

My code in this PR:
```javascript
function trackOuntboundLinks() {
  ....THE MEAT...
}
trackOutboundLinks();
```
What I *could* have done is this:
```javascript
/* Start the setting up of tracking outbound links */
....THE MEAT...
/* End the setting up of tracking outbound links */
```

...which looks kind ugly. 
