### PR TITLE
Show warning when an outdated translation is being used

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -140,6 +140,10 @@ def document_api_data(doc=None, redirect_url=None):
         {doc.locale} | set(t.locale for t in other_translations))
 
     doc_absolute_url = doc.get_absolute_url()
+    revision = doc.current_or_latest_revision()
+    translation_status = None
+    if doc.parent_id and revision and revision.localization_in_progress:
+        translation_status = 'outdated' if revision.translation_age >= 10 else 'in-progress'
     return {
         'documentData': {
             'locale': doc.locale,
@@ -164,6 +168,7 @@ def document_api_data(doc=None, redirect_url=None):
                 if doc.is_localizable else
                 None
             ),
+            'translationStatus': translation_status,
             'bodyHTML': doc.get_body_html(),
             'quickLinksHTML': doc.get_quick_links_html(),
             'tocHTML': doc.get_toc_html(),

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -17,6 +17,38 @@ type DocumentProps = {
     document: DocumentData
 };
 
+function TranslationStatus({
+    document: { translationStatus, translateURL }
+}: DocumentProps) {
+    let content;
+
+    if (translationStatus === 'in-progress') {
+        content = gettext('This translation is in progress.');
+    } else if (translationStatus === 'outdated') {
+        content = (
+            <>
+                {gettext(
+                    'You’re reading the English version of this content since no translation exists yet for this locale.'
+                )}
+                &nbsp;
+                <a href={translateURL} rel="nofollow">
+                    {gettext('Help us translate this article!')}
+                </a>
+            </>
+        );
+    }
+
+    if (translationStatus == null || !content) {
+        return null;
+    }
+
+    return (
+        <p className="overheadIndicator translationInProgress">
+            <bdi>{content}</bdi>
+        </p>
+    );
+}
+
 export default function Article({ document }: DocumentProps) {
     const article = useRef(null);
     const userData = useContext(UserProvider.context);
@@ -112,21 +144,7 @@ export default function Article({ document }: DocumentProps) {
                     : 'article text-content'
             }
         >
-            {document.locale !== locale && (
-                <div className="warning">
-                    <p>
-                        <bdi>
-                            {gettext(
-                                'You’re reading the English version of this content since no translation exists yet for this locale.'
-                            )}
-                            &nbsp;
-                            <a href={document.translateURL} rel="nofollow">
-                                {gettext('Help us translate this article!')}
-                            </a>
-                        </bdi>
-                    </p>
-                </div>
-            )}
+            <TranslationStatus document={document} />
             <article
                 id="wikiArticle"
                 dangerouslySetInnerHTML={{ __html: document.bodyHTML }}

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -30,6 +30,7 @@ export type DocumentData = {
     absoluteURL: string,
     wikiURL: string,
     translateURL: string,
+    translationStatus: null | 'in-progress' | 'outdated',
     bodyHTML: string,
     quickLinksHTML: string,
     tocHTML: string,

--- a/kuma/javascript/src/document.test.js
+++ b/kuma/javascript/src/document.test.js
@@ -21,6 +21,7 @@ export const fakeDocumentData = {
     language: 'English (US)',
     hrefLang: 'en',
     absoluteURL: '[fake absolute url]',
+    translationStatus: null,
     translateURL: '[fake translate url]',
     wikiURL:
         'https://wiki.mdn.developer.mozilla.org/en-US/docs/Web/CSS/box-shadow',


### PR DESCRIPTION
Fix #6046 

The partial localization box was already there, but the condition for it being shown didn't make sense. I changed it to be the same as the wiki logic for showing it and also reuse those styles.