### PR TITLE
Fixes #6090, read only badges unreadable

### DIFF
--- a/kuma/static/styles/components/wiki/_indicators.scss
+++ b/kuma/static/styles/components/wiki/_indicators.scss
@@ -458,8 +458,6 @@ Special snowflakes
 .readOnly {
     border-color: #4b4b4b;
     background: #595959;
-    @extend %indicator-text-invert;
-    @extend %indicator-link-invert;
 }
 
 /* heading that goes in with geckoVersionNote */


### PR DESCRIPTION
Fixes the read-only badges.

## Before

![Screenshot 2019-12-02 at 10 46 56](https://user-images.githubusercontent.com/10350960/69945039-69079580-14f1-11ea-8953-1964b050305e.png)

## After

![Screenshot 2019-12-02 at 10 47 08](https://user-images.githubusercontent.com/10350960/69945057-6f960d00-14f1-11ea-961a-6e4c8982edae.png)

@Gregoor r?