### PR TITLE
Add style for highlighting active sidebar-item dynamically

### DIFF
--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -9,6 +9,21 @@ import { AppErrorBoundary } from './error-boundaries.jsx';
 import GAProvider from './ga-provider.jsx';
 import { localize } from './l10n.js';
 
+function addActiveSidebarItemStyle() {
+    const selector = `.sidebar a[href="${location.pathname}"]`;
+    const style = `
+        ${selector} { font-style: italic; color: black; }
+        ${selector}:hover { text-decoration: none }
+    `;
+    const node = document.createElement('style');
+    node.innerHTML = style;
+    if (document.body) {
+        document.body.appendChild(node);
+    }
+}
+
+addActiveSidebarItemStyle();
+
 let container = document.getElementById('react-container');
 if (container) {
     let componentName = container.dataset.componentName;


### PR DESCRIPTION
Fixes #6101 

This adds a function to the client bootstrap script which _dynamically_ creates a stylesheet, selecting the sidebar link for the current slug and styles it as recommended in the issue.

Okay, no doubt this is a little hacky, BUT people didn't seem excited when I asked how they'd feel about reviewing a new KS macro and arguably this is the least amount of code that can accomplish what's wanted.
I also don't feel too bad about it because while not-best-practice, I don't think this is the hack on which we'll build kingdoms, i.e. it's pretty standalone.