### PR TITLE
class="new" is inserted on links that could work

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -474,12 +474,15 @@ class LinkAnnotationFilter(html5lib_Filter):
                                               path_locale=href_locale))
 
                 # Gather up this link for existence check
-                needs_existence_check[locale.lower()][slug.lower()].add(href)
+                slug = slug.lower()
+                if slug.endswith('/'):
+                    # But put it into this dict so it gets considered NOT new
+                    slug = slug[:-1]
+                needs_existence_check[locale.lower()][slug].add(href)
 
         # Perform existence checks for all the links, using one DB query per
         # locale for all the candidate slugs.
         for locale, slug_hrefs in needs_existence_check.items():
-
             existing_slugs = (Document.objects
                               .filter(locale=locale,
                                       slug__in=slug_hrefs.keys())

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -476,7 +476,9 @@ class LinkAnnotationFilter(html5lib_Filter):
                 # Gather up this link for existence check
                 slug = slug.lower()
                 if slug.endswith('/'):
-                    # But put it into this dict so it gets considered NOT new
+                    # If the slug used in the document has a trailing /
+                    # remove that from here so that it stands a better chance
+                    # to match existing Document slugs.
                     slug = slug[:-1]
                 needs_existence_check[locale.lower()][slug].add(href)
 

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -893,7 +893,6 @@ def test_dont_annotate_links_with_trailing_slashes(db, root_doc):
         </ul>
     """
     actual_raw = parse(html).annotateLinks(base_url=AL_BASE_URL).serialize()
-    expected_raw = 'xxx'
     expected_raw = """
         <ul>
         <li><a href="/en-US/docs/Root/">Root</a></li>

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -879,6 +879,31 @@ def test_annotate_links_nonexisting_doc(db, anchor, full_url, has_class):
     assert normalize_html(actual_raw) == normalize_html(expected_raw)
 
 
+def test_dont_annotate_links_with_trailing_slashes(db, root_doc):
+    """
+    Links like this: <a href="/en-US/docs/Root/">Root</a>
+    should NOT become this: <a class="new" href="/en-US/docs/Root/">Root</a>
+    """
+    # Sanity check our fixture
+    assert Document.objects.filter(locale='en-US', slug='Root').exists()
+    html = """
+        <ul>
+        <li><a href="/en-US/docs/Root/">Root</a></li>
+        <li><a href="/en-US/docs/Hopeless/">Hopeless</a></li>
+        </ul>
+    """
+    actual_raw = parse(html).annotateLinks(base_url=AL_BASE_URL).serialize()
+    expected_raw = 'xxx'
+    expected_raw = """
+        <ul>
+        <li><a href="/en-US/docs/Root/">Root</a></li>
+        <li><a class="new" rel="nofollow"
+        href="/en-US/docs/Hopeless/">Hopeless</a></li>
+        </ul>
+    """
+    assert normalize_html(actual_raw) == normalize_html(expected_raw)
+
+
 def test_annotate_links_uilocale_to_existing_doc(root_doc):
     """Links to existing docs with embeded locales are unmodified."""
     assert root_doc.get_absolute_url() == '/en-US/docs/Root'


### PR DESCRIPTION
Fixes #6217

To test; before you check out my branch, take a perfectly fine slug URL and make somet HTML like this:
```html
<a href="/en-US/docs/Web/Learn/">Learn!</a>
```
After edit and publish you'll notice that the rendered HTML becomes
```html
<a class="new" rel="nofollow" href="/en-US/docs/Web/Learn/">Learn!</a>
```
Now check out my branch and edit again. 