### PR TITLE
disable a.new links in read-only mode

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -114,6 +114,28 @@ export default function Article({ document }: DocumentProps) {
         }
     }, [document, userData, ga]);
 
+    /** Any link inside the article that matches `a.new` means it's a
+     * wiki page that hasn't yet been created. Clicking on it will
+     * 404, if you're on the read-only site. If you're viewing HTML
+     * like that on the Wiki and click it, it will take you to the
+     * form to *create* the page. Disable all of that here in the read-only
+     * site.
+     */
+    useEffect(() => {
+        let rootElement = article.current;
+        if (rootElement) {
+            for (let link of rootElement.querySelectorAll('a.new')) {
+                // Makes it not be clickable and no "pointer" cursor when
+                // hovering. Better than clicking on it and being
+                // disappointed.
+                link.removeAttribute('href');
+                if (!link.title) {
+                    link.title = gettext('Page has not yet been created.');
+                }
+            }
+        }
+    }, [document]);
+
     const isArchive =
         document.slug === 'Archive' || document.slug.startsWith('Archive/');
     const locale = getLocale();


### PR DESCRIPTION
Fixes #6163

CC @chrisdavidmills 

We already had a KS solution for links made via [`jsapixref`](https://github.com/mdn/kumascript/blob/9a44f78ea18a807681d1aeb37b7eb42ec3c8dd3a/macros/jsapixref.ejs#L15) that puts a title into these links. It makes these:
<img width="629" alt="Screen Shot 2019-12-06 at 9 05 05 PM" src="https://user-images.githubusercontent.com/26739/70367315-c80c3800-186c-11ea-94ed-f9e6a0030704.png">

I suppose that's only for JS docs. (Yay KumaScript!)
So my PR is gentle and only adds the tooltip for those that don't already have a tooltip. 

Also, the screenshot won't show it but visually there's no difference but now when you hover over it it doesn't make a `pointer` cursor. 