### PR TITLE
SSR Sentry error reporting

### DIFF
--- a/kuma/javascript/ssr-server.js
+++ b/kuma/javascript/ssr-server.js
@@ -15,24 +15,9 @@ if (process.env.NEW_RELIC_LICENSE_KEY && process.env.NEW_RELIC_APP_NAME) {
 
 const express = require('express'); // Express server framework
 const morgan = require('morgan');
-const sentry = require('@sentry/node');
+const Sentry = require('@sentry/node');
 
 const ssr = require('./dist/ssr.js'); // Function to do server-side rendering
-
-// Configure and initialize Sentry if a DSN has been provided.
-if (process.env.SENTRY_DSN) {
-    console.log('Configuring Sentry for the SSR server.');
-    let options = {
-        dsn: process.env.SENTRY_DSN
-    };
-    if (process.env.REVISION_HASH) {
-        options.release = process.env.REVISION_HASH;
-    }
-    if (process.env.SENTRY_ENVIRONMENT) {
-        options.environment = process.env.SENTRY_ENVIRONMENT;
-    }
-    sentry.init(options);
-}
 
 // Configuration
 const PID = process.pid;
@@ -47,6 +32,28 @@ const MAX_BODY_SIZE = 1024 * 1024 * 5; // 5 megabyte max JSON payload
 
 // We're using the Express server framework
 const app = express();
+
+// Configure and initialize Sentry if a DSN has been provided.
+if (process.env.SENTRY_DSN) {
+    console.log('Configuring Sentry for the SSR server.');
+    let options = {
+        dsn: process.env.SENTRY_DSN
+    };
+    if (process.env.REVISION_HASH) {
+        options.release = process.env.REVISION_HASH;
+    }
+    if (process.env.SENTRY_ENVIRONMENT) {
+        options.environment = process.env.SENTRY_ENVIRONMENT;
+    }
+    Sentry.init(options);
+
+    // The request handler must be the first middleware on the app
+    app.use(Sentry.Handlers.requestHandler());
+    // The error handler must be before any other error middleware
+    app.use(Sentry.Handlers.errorHandler());
+} else {
+    console.warn('SENTRY_DSN is not available so sentry is not initialized.');
+}
 
 // Log all requests, so we get timing data for SSR.
 app.use(morgan('tiny'));
@@ -81,7 +88,13 @@ app.get('/readiness/?', (req, res) => {
  * not be parsed, escaped, or displayed as HTML.
  */
 app.post('/ssr/:componentName', (req, res) => {
-    res.json(ssr(req.params.componentName, req.body));
+    try {
+        res.json(ssr(req.params.componentName, req.body));
+    } catch (err) {
+        console.error(`Error running ssr(): ${err.toString()}`);
+        Sentry.captureException(err);
+        res.status(500).json({ error: err.toString() });
+    }
 });
 
 if (require.main === module) {

--- a/kuma/javascript/ssr-server.js
+++ b/kuma/javascript/ssr-server.js
@@ -46,6 +46,8 @@ if (process.env.SENTRY_DSN) {
         options.environment = process.env.SENTRY_ENVIRONMENT;
     }
     Sentry.init(options);
+    // The request handler must be the first middleware on the app
+    app.use(Sentry.Handlers.requestHandler());
 } else {
     console.warn('SENTRY_DSN is not available so sentry is not initialized.');
 }
@@ -89,9 +91,8 @@ app.post('/ssr/:componentName', (req, res) => {
 // Important that this is defined *after* the request handlers have been
 // added otherwise Sentry won't automatically hook in.
 if (process.env.SENTRY_DSN) {
-    // The request handler must be the first middleware on the app
-    app.use(Sentry.Handlers.requestHandler());
-    // The error handler must be before any other error middleware
+    // The error handler must be before any other error middleware and after
+    // all controllers.
     app.use(Sentry.Handlers.errorHandler());
 }
 

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -85,3 +85,6 @@ AWS_DEFAULT_ACL = None
 
 # Use a dedicated minio bucket for tests
 ATTACHMENTS_AWS_STORAGE_BUCKET_NAME = 'test'
+
+# Never enabled in tests.
+SENTRY_DSN = None

--- a/kuma/wiki/templatetags/ssr.py
+++ b/kuma/wiki/templatetags/ssr.py
@@ -134,11 +134,7 @@ def server_side_render(component_name, data):
         result = response.json()
         return _render(component_name, result['html'], result['script'])
 
-    except requests.exceptions.ConnectionError:
-        print("Connection error contacting SSR server.")
-        print("Falling back to client side rendering.")
-        return client_side_render(component_name, data)
-    except requests.exceptions.ReadTimeout:
-        print("Timeout contacting SSR server.")
+    except requests.exceptions.RequestException as exception:
+        print(f"{exception.__class__} error contacting SSR server.")
         print("Falling back to client side rendering.")
         return client_side_render(component_name, data)

--- a/kuma/wiki/tests/test_ssr.py
+++ b/kuma/wiki/tests/test_ssr.py
@@ -99,7 +99,8 @@ def test_client_side_render(mock_get_l10n_data, mock_dumps):
 
 @pytest.mark.parametrize('failure_class', [
     requests.exceptions.ConnectionError,
-    requests.exceptions.ReadTimeout])
+    requests.exceptions.ReadTimeout,
+    requests.exceptions.HTTPError])
 @mock.patch('json.dumps')
 @mock.patch('kuma.wiki.templatetags.ssr.get_localization_data')
 def test_failed_server_side_render(mock_get_l10n_data,
@@ -109,7 +110,7 @@ def test_failed_server_side_render(mock_get_l10n_data,
     localization_data = {'catalog': {'s': 't'}, 'plural': None}
     mock_get_l10n_data.side_effect = lambda l: localization_data
     mock_dumps.side_effect = sorted_json_dumps
-    url = '{}/{}'.format(settings.SSR_URL, 'page')
+    url = f'{settings.SSR_URL}/page'
     mock_requests.post(url, exc=failure_class('message'))
     document_data = {'x': 'one', 'y': 2, 'z': ['a', 'b']}
     path = '/en-US/docs/foo'


### PR DESCRIPTION
Fixes #5981

This was a lot tricker than I first envision. Sorry. 
Also, all of this will go away with Yari. For now, with this fix, it'll tie us over quite a bit in the many months of Kuma still doing the SSR. 

Ultimately, the problem is that if something went horribly wrong inside `ssr-server.jsx` (the express server) it would fail but never report anything to Sentry. All you'd get is a Sentry error in Python for the possible `HTTPError`. E.g.https://github.com/mdn/kuma/issues/5981#issue-506747552

I don't really understand how or why but it seems that if you don't use...
```
try {
  somethignThatCanGoWrong()
} catch (err) {
  Sentry.captureException(err);
}
```
...it wouldn't send to Sentry. I don't see why the [SDK Quickstart for Express](https://sentry.io/for/express/) doesn't mention this. 
Any idea @Gregoor ?

Now, with this change you'll get errors like this: https://sentry.prod.mozaws.net/operations/mdn-stage/issues/6842634/
And nothing in Sentry for Python, because why would you want 2 errors for one and the same problem. Plus any Python errors sent to Sentry would be rather useless anyway. 

Now, what I hate is how our SSR integration code in Python works is that if there's any operational error talking to the Express server it just swallows it and does a client-side rendering. Blah!

Also, where we're currently doing `request.post(...)` there in `template_tags/ssr.py` we ought to use that `requests_retry_session` trick mentioned in some other PR. That way, if there's an unfortunate temporary network error it at least tries again. 

I'll try to comment and justify some changes within the code below. 