### PR TITLE
right locale for wiki site search

### DIFF
--- a/kuma/search/fields.py
+++ b/kuma/search/fields.py
@@ -37,5 +37,4 @@ class SiteURLField(serializers.ReadOnlyField):
         args = [getattr(value, arg) for arg in self.args]
         kwargs = {arg: getattr(value, arg) for arg in self.kwargs}
         locale = getattr(value, 'locale', settings.LANGUAGE_CODE)
-        path = reverse(self.url_name, locale=locale, args=args, kwargs=kwargs)
-        return '%s%s' % (settings.SITE_URL, path)
+        return reverse(self.url_name, locale=locale, args=args, kwargs=kwargs)

--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -22,17 +22,16 @@
 {% block bodyclass %}search-results search-results-no-demo search-navigator-flush{% endblock %}
 
 {% macro doc_block(doc, index) -%}
-  {% set doc_url = wiki_url(doc.slug) %}
   <li class="result-{{ index }}">
     <div class="column-container">
       <div class="column-1">
           {% include 'includes/icons/file-icons/plain-text.svg' %}
       </div>
       <div class="column-5 result-list-item">
-        <h4><a href="{{ doc_url }}"{% if index == 1 %} tabindex="1"{% endif %}>{{ doc.title }}</a></h4>
+        <h4><a href="{{ doc.url }}"{% if index == 1 %} tabindex="1"{% endif %}>{{ doc.title }}</a></h4>
         <p>{{ doc.excerpt|safe }}</p>
-        <p class="search-meta"><a href="{{ doc_url }}">{{ doc_url }}</a>
-        {% if request.user.is_superuser %}Score: {{ doc.score }}{% endif %}
+        <p class="search-meta"><a href="{{ doc.url }}">/{{ doc.locale }}/{{ doc.slug }}</a>
+        {% if request.user.is_superuser %}Score: {{ doc.score|floatformat }}{% endif %}
         {% if doc.parent %}
             {% trans parent_url=doc.parent.url, parent_title=doc.parent.title, parent_language=settings.LOCALES[doc.parent.locale].native %}
             translated from <a href="{{ parent_url }}" title="{{ parent_title }}">{{ parent_title }} ({{ parent_language }})</a>


### PR DESCRIPTION
Fixes #6146

You can't argue with the results!
<img width="1076" alt="Screen Shot 2019-12-16 at 8 25 02 PM" src="https://user-images.githubusercontent.com/26739/70957243-7ff6cd80-2043-11ea-9400-6a4960afa381.png">

To test:

1. Pick a rarely used macro from wiki. For example `DOMAttributeMethods`
2. Then go to a wiki page that has a custom translated slug. E.g. `http://wiki.mdn.localhost:8000/fr/docs/Apprendre/HTML/Introduction_%C3%A0_HTML` if you have it. 
3. Edit it and put in `{{DOMAttributeMethods('stuff')}}`
4. Now search for `http://wiki.mdn.localhost:8000/en-US/search?locale=*&kumascript_macros=DOMAttributeMethods&topic=none`
5. What you might see, before switching to my branch, is the link of that search result goes to `http://wiki.mdn.localhost:8000/en-US/docs/Apprendre/HTML/Introduction_%C3%A0_HTML` which is the wrong locale!
6. Check out my branch and the search should wowkr again. 