### PR TITLE
make welcome email more user focused

### DIFF
--- a/kuma/users/jinja2/users/email/welcome/html.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/html.ltxt
@@ -6,15 +6,10 @@
         <title>{{ _('Take the next step to get involved on MDN!') }}</title>
     </head>
     <body>
-        <p>{{ _('Hi %(username)s!', username=username) }}</p>
+        <p>{{ _('Hey %(username)s!', username=username) }}</p>
         <p>
           {% trans mdn_link=add_utm('https://developer.mozilla.org', 'welcome') %}
-            Thanks for creating a profile on <a href="{{ mdn_link }}">MDN Web Docs</a> - a community making great resources for developers like you.
-          {% endtrans %}
-        </p>
-        <p>
-          {% trans started_link=add_utm('https://developer.mozilla.org/docs/MDN/Getting_started', 'welcome') %}
-            You've completed the first step of <a href="{{ started_link }}">Getting Started on MDN</a> by creating a profile.
+            Thanks for creating an account on <a href="{{ mdn_link }}">MDN Web Docs</a> - a community making great resources for developers like you.
           {% endtrans %}
         </p>
         <p>
@@ -24,11 +19,11 @@
               both_link=add_utm('https://developer.mozilla.org/en-US/docs/MDN/Getting_started#Option_3.3A_I_like_both_words_and_code', 'welcome'),
               translate_link=add_utm('https://developer.mozilla.org/en-US/docs/MDN/Getting_started#Option_4.3A_I_want_MDN_in_my_language', 'welcome')
           %}
-            Now, keep going by picking a task on MDN, and doing it! We have a bunch of intro tasks you can choose from, whether you
+            Soon, we'll share with you opportunities to customize MDN to get the most out of it. In the meantime, MDN is from web developers for web developers, it thrives on contributions from developers like you. We have a bunch of intro tasks you can choose based on your interests, and we can't wait for you to join us. Do you
             <a href="{{ words_link }}">like words</a>,
             <a href="{{ code_link }}">like code</a>,
             <a href="{{ both_link }}">like both words and code</a>,
-            or you want to <a href="{{ translate_link }}">translate MDN to your language</a>.
+            or want to <a href="{{ translate_link }}">translate MDN to your language</a>?
           {% endtrans %}
         </p>
         <strong>{{ _('Talk to us!') }}</strong>

--- a/kuma/users/jinja2/users/email/welcome/html.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/html.ltxt
@@ -3,7 +3,7 @@
 <html lang="en-US" dir="ltr">
     <head>
         <meta charset="utf-8" />
-        <title>{{ _('Take the next step to get involved on MDN!') }}</title>
+        <title>{{ _('Getting started with your new MDN account') }}</title>
     </head>
     <body>
         <p>{{ _('Hey %(username)s!', username=username) }}</p>

--- a/kuma/users/jinja2/users/email/welcome/plain.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/plain.ltxt
@@ -1,13 +1,13 @@
 {% autoescape false %}
 {# Since the ``trans`` tag collapses whitespace and whitespace matters, we're using gettext ``_`` here. #}
 {# L10n: This is an email. Whitespace matters! #}
-{{ _('Hi %(username)s', username=username) }}
+{{ _('Hey %(username)s!', username=username) }}
 
 {# L10n: This is an email. Whitespace matters! #}
-{{ _('Thanks for creating a profile on MDN Web Docs -- a community making great resources for developers like you.') }}
+{{ _('Thanks for creating an account on MDN Web Docs -- a community making great resources for developers like you.') }}
 
 {# L10n: This is an email. Whitespace matters! #}
-{{ _("You've completed the first step of Getting Started on MDN by creating a profile. Now, keep going by picking a task on MDN, and doing it! We have a bunch of intro tasks you can choose based on your interests.") }}
+{{ _("Soon, we'll share with you opportunities to customize MDN to get the most out of it. In the meantime, MDN is from web developers for web developers, it thrives on contributions from developers like you. We have a bunch of intro tasks you can choose based on your interests, and we can't wait for you to join us.") }}
 
 {# Note: If you change this string also change ``WELCOME_EMAIL_STRINGS`` in kuma/users/tasks.py #}
 {# L10n: This is an email. Whitespace matters! #}

--- a/kuma/users/tasks.py
+++ b/kuma/users/tasks.py
@@ -52,7 +52,7 @@ def send_welcome_email(user_pk, locale):
                                         context)
 
             email = EmailMultiAlternatives(
-                _('Take the next step to get involved on MDN!'),
+                _('Getting started with your new MDN account'),
                 content_plain,
                 config.WELCOME_EMAIL_FROM,
                 [user.email],


### PR DESCRIPTION
Fixes https://github.com/mdn/sprints/issues/2425

The `Subject:` line of the email remains `Take the next step to get involved on MDN!`. Is that acceptable?

