### PR TITLE
exclude sidebar from site-search content

### DIFF
--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -76,7 +76,7 @@ class WikiDocumentType(document.Document):
             'summary': obj.get_summary_text(),
             'locale': obj.locale,
             'modified': obj.modified,
-            'content': strip_tags(obj.rendered_html or ''),
+            'content': strip_tags(obj.get_body_html() or ''),
             'tags': [o.name for o in obj.tags.all()],
             'kumascript_macros': cls.case_insensitive_keywords(
                 obj.extract.macro_names()),


### PR DESCRIPTION
Fixes #6261

Tiny change but big effect. Before, [searching for "django"](https://developer.mozilla.org/en-US/search?q=django) would turn up every possible page that has a "Django" link its side bar. Basically crap search results. 
Mind you, on the read-only site the Django pages wouldn't turn up because it's not a topic that's enabled by default. So as of this fix you get:

<img width="924" alt="Screen Shot 2019-12-18 at 3 37 21 PM" src="https://user-images.githubusercontent.com/26739/71121334-4f7e7300-21ac-11ea-889f-1f1db182606e.png">

But on the wiki, if you enable all topics you get:
<img width="1423" alt="Screen Shot 2019-12-18 at 3 38 09 PM" src="https://user-images.githubusercontent.com/26739/71121404-6de46e80-21ac-11ea-98b4-c5f4f8ca914c.png">


Also I downloading 1,000 random documents and compared their `doc.rendered_html` vs. `doc.get_body_html()` and the size in bytes is pretty big:

```
rendered MEAN 9197 bytes MEDIAN 6669 bytes
body     MEAN 7516 bytes MEDIAN 4654 bytes
```
So as of this PR, we'll be putting 20% less data into Elasticsearch. 

Also, think about all the references pages that have a list of things in the sidebar like all the `Array` pages. See: https://developer.mozilla.org/en-US/search?q=unshift
