### PR TITLE
Make signup page dynamic based on auth provider

### DIFF
--- a/kuma/static/styles/minimalist/components/_auth-service-header.scss
+++ b/kuma/static/styles/minimalist/components/_auth-service-header.scss
@@ -8,6 +8,7 @@
     font-weight: bold;
 
     .github-auth,
+    .google-auth,
     .mdn-profile {
         position: relative;
         max-width: 140px;
@@ -18,6 +19,7 @@
     }
 
     .github-auth,
+    .google-auth,
     .mdn-profile {
         img {
             display: block;

--- a/kuma/users/jinja2/socialaccount/signup.html
+++ b/kuma/users/jinja2/socialaccount/signup.html
@@ -9,7 +9,6 @@
 {% endblock %}
 
 {% set provider = account.get_provider() %}
-{% set github_connect_url = provider_login_url('github', process='connect', next=request.session.sociallogin_next_url|default('/')) %}
 
 {% block pageheader %}
 {{ render_react("signupflow", request.LANGUAGE_CODE, request.get_full_path(),
@@ -26,10 +25,17 @@
 <main id="content-main" role="main">
   <article id="browser_register" class="readable-line-length center">
     <ol class="auth-service-header">
-      <li class="github-auth checked">
-        <img src="{{ static('auth/github-auth.svg') }}" width="90px" alt="Github" />
-        {{ _('Authorize with Github') }}
-      </li>
+      {% if provider.name == "GitHub" %}
+        <li class="github-auth checked">
+          <img src="{{ static('auth/github-auth.svg') }}" width="90px" alt="Github" />
+          {{ _('Authorize with Github') }}
+        </li>
+      {% elif provider.name == "Google" %}
+        <li class="google-auth checked">
+          <img src="{{ static('auth/google-auth.svg') }}" width="90px" alt="Google" />
+          {{ _('Authorize with Google') }}
+        </li>
+      {% endif %}
       <li class="mdn-profile">
         <img src="{{ static('auth/mdn-auth.svg') }}" width="90px" alt="{{ _('User avatar') }}" />
         {{ _('Create MDN Profile') }}
@@ -70,10 +76,10 @@
               {% include 'socialaccount/includes/change_username.html' %}
             {% else %}
               <div id="username-static-container" class="username-static">
-                {% set github_username = account.get_provider_account() %}
-                <input type="hidden" name="username" value="{{ github_username }}" />
-                {{ github_username }}
-                <button id="change-username" type="button" class="edit-default" aria-label="{{ _('Your’re current username is %s. Change username?'%(github_username)) }}">{{ _('change username') }}</button>
+                {% set provider_username = account.get_provider_account() %}
+                <input type="hidden" name="username" value="{{ provider_username }}" />
+                {{ provider_username }}
+                <button id="change-username" type="button" class="edit-default" aria-label="{{ _('Your’re current username is %s. Change username?'%(provider_username)) }}">{{ _('change username') }}</button>
               </div>
               {% set is_hidden = true %}
               {% include 'socialaccount/includes/change_username.html' %}


### PR DESCRIPTION
Fixes #6025 

This updates the signup page, where you are redirected after authorizing with the chosen Auth provider, to show the appropriate provider logo in the header. Did some additional cleanup so we use generic variable names and also ensures the copy reads as expected.

## Github

![Screenshot 2019-12-19 at 10 52 18](https://user-images.githubusercontent.com/10350960/71159207-e3ece200-224d-11ea-9970-598b0f9f757e.png)

## Google

![Screenshot 2019-12-19 at 10 52 58](https://user-images.githubusercontent.com/10350960/71159289-04b53780-224e-11ea-8284-7788078ab9f9.png)


@Gregoor r?

