### PR TITLE
disable modal multi-auth if not enabled

### DIFF
--- a/jinja2/includes/style.html
+++ b/jinja2/includes/style.html
@@ -1,3 +1,5 @@
 {% stylesheet 'react-header' %}
-{% stylesheet 'auth-modal' %}
+{% if settings.MULTI_AUTH_ENABLED %}
+    {% stylesheet 'auth-modal' %}
+{% endif %}
 {% stylesheet 'react-mdn' %}

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -133,14 +133,18 @@
   </footer>
 
   {% block auth_modal %}
-    {% include "includes/auth-modal.html" %}
+    {% if settings.MULTI_AUTH_ENABLED %}
+      {% include "includes/auth-modal.html" %}
+    {% endif %}
   {% endblock %}
 
   <!-- site js -->
   {% block site_js %}
     {{ providers_media_js() }}
     {% javascript 'react-main' %}
-    {% javascript 'auth-modal' %}
+    {% if settings.MULTI_AUTH_ENABLED %}
+      {% javascript 'auth-modal' %}
+    {% endif %}
     {% for script in scripts %}
       {% javascript script %}
     {% endfor %}

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -19,7 +19,10 @@ from django.core.validators import validate_email, ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.http import (
-    HttpResponseBadRequest, HttpResponseForbidden, HttpResponseRedirect)
+    Http404,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseRedirect)
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
@@ -545,6 +548,8 @@ def user_delete(request, username):
 
 
 def signin_landing(request):
+    if not settings.MULTI_AUTH_ENABLED:
+        raise Http404("Multi-auth is not enabled.")
     return render(request, "socialaccount/signup-landing.html")
 
 

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -95,13 +95,16 @@
                   document_data)|safe }}
 
   {% block auth_modal %}
-    {% include "includes/auth-modal.html" %}
+    {% if settings.MULTI_AUTH_ENABLED %}
+      {% include "includes/auth-modal.html" %}
+    {% endif %}
   {% endblock %}
 
   <!-- site js -->
   {% javascript 'react-main' %}
-  {% javascript 'auth-modal' %}
-
+  {% if settings.MULTI_AUTH_ENABLED %}
+    {% javascript 'auth-modal' %}
+  {% endif %}
   {% if settings.ENABLE_BCD_SIGNAL %}
     {% javascript "bcd-signal" %}
   {% endif %}


### PR DESCRIPTION
Part of #6294

At least, with this change, the modal can't even being to appear. And any browser extension or whatever that might discove the Google auth link, won't be able to find it any more. 
It's a start. 