### PR TITLE
Remove max-width on search input

### DIFF
--- a/kuma/static/styles/minimalist/components/_search-widget.scss
+++ b/kuma/static/styles/minimalist/components/_search-widget.scss
@@ -22,7 +22,6 @@
         border-width: 0;
         font-size: $tiny-font-size;
         min-width: 60px;
-        max-width: 320px;
 
         &:invalid {
             border: 0;


### PR DESCRIPTION
Small change that will allow the search input fill the parent container. 
Tested in supported browsers using BrowserStack Live. 

Closes #6089. 