### PR TITLE
Issue #6307, interactive examples broken, Failed to execute measure

### DIFF
--- a/kuma/static/js/utils/perf.js
+++ b/kuma/static/js/utils/perf.js
@@ -47,10 +47,15 @@ mdn.perf = {
             return;
         }
 
-        performance.measure(
-            measureData.measureName,
-            measureData.startMark,
-            measureData.endMark
-        );
+        try {
+            performance.measure(
+                measureData.measureName,
+                measureData.startMark,
+                measureData.endMark
+            );
+        } catch (error) {
+            console.error('Error while setting performance measure: ', error);
+        }
+
     }
 };


### PR DESCRIPTION
@peterbe This is part 1 of the items mentioned here:
https://github.com/mdn/kuma/issues/6307#issuecomment-573764829

Related to this error:

```
perf.654b849a6fd9.js:1 Uncaught DOMException: Failed to execute 'measure' on 'Performance': The mark 'interactive-editor-loading' does not exist.
    at Object.setMeasure (https://developer.mozilla.org/static/build/js/perf.654b849a6fd9.js:1:703)
    at handlePerfMarks (https://developer.mozilla.org/static/build/js/perf.654b849a6fd9.js:1:948)
    at perfMsgHandler (https://developer.mozilla.org/static/build/js/perf.654b849a6fd9.js:1:1557)
setMeasure @ perf.654b849a6fd9.js:1
handlePerfMarks @ perf.654b849a6fd9.js:1
perfMsgHandler @ perf.654b849a6fd9.js:1
perf.654b849a6fd9.js:1 Uncaught DOMException: Failed to execute 'measure' on 'Performance': The mark 'interactive-editor-loading' does not exist.
    at Object.setMeasure (https://developer.mozilla.org/static/build/js/perf.654b849a6fd9.js:1:703)
    at handlePerfMarks (https://developer.mozilla.org/static/build/js/perf.654b849a6fd9.js:1:948)
    at perfMsgHandler (https://developer.mozilla.org/static/build/js/perf.654b849a6fd9.js:1:1557)
setMeasure @ perf.654b849a6fd9.js:1
handlePerfMarks @ perf.654b849a6fd9.js:1
perfMsgHandler @ perf.654b849a6fd9.js:1
```