### PR TITLE
Remove structure.scss from documents.scss 

### DIFF
--- a/kuma/static/styles/minimalist/document.scss
+++ b/kuma/static/styles/minimalist/document.scss
@@ -25,7 +25,6 @@ Utitlity classes (reused in a variety of contexts)
 /*
 Components that may appear on most wiki pages
 ====================================================================== */
-@import './base/_structure.scss';
 @import '../components/wiki/_wiki-block.scss';
 @import '../components/wiki/_quick-links.scss';
 @import '../components/wiki/_toc.scss';


### PR DESCRIPTION
`structure.scss` was being included in two places: `documents.scss` and `main.scss`. Both files are included in `react-mdn.scss`. 

This change removes `structure.scss` from `documents.scss`, so it will only live in `main.scss`. 

Closes #6255