### PR TITLE
Use form's username for unchanged signup username display

### DIFF
--- a/kuma/users/jinja2/socialaccount/signup.html
+++ b/kuma/users/jinja2/socialaccount/signup.html
@@ -76,7 +76,7 @@
               {% include 'socialaccount/includes/change_username.html' %}
             {% else %}
               <div id="username-static-container" class="username-static">
-                {% set provider_username = account.get_provider_account() %}
+                {% set provider_username = form.username.value() %}
                 <input type="hidden" name="username" value="{{ provider_username }}" />
                 {{ provider_username }}
                 <button id="change-username" type="button" class="edit-default" aria-label="{{ _('Your’re current username is %s. Change username?'%(provider_username)) }}">{{ _('change username') }}</button>


### PR DESCRIPTION
Fixes #6347 

I'm not sure what the `get_provider_account` I replaced, originally solved for as it also didn't do the correct thing for GitHub for me. So if somebody has some historical context, I'd be curious to hear it :)