### PR TITLE
Limit wiki syntax highlighting to #wikiArticle

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -62,7 +62,7 @@
     /*
         Syntax highlighting scripts
     */
-    if ($('article pre').length && ('querySelectorAll' in doc)) {
+    if ($('#wikiArticle pre').length && ('querySelectorAll' in doc)) {
         if (mdn.assets && mdn.assets.js.hasOwnProperty('syntax-prism')) {
             (function() {
                 mdn.assets.js['syntax-prism'].forEach(function(url, index, array) {


### PR DESCRIPTION
Fixes #6355

This should limit unnecessary highlighting applied while localizing a document with code examples.

It will also reduce this left padding below, which is for line numbers.

![주석 2020-01-18 022925](https://user-images.githubusercontent.com/9212605/72632811-7641ec00-399a-11ea-9331-48e8beac7afa.png)
