### PR TITLE
Fix remove background in operators, strings, utls, etc.

### DIFF
--- a/kuma/static/styles/components/syntax/_base.scss
+++ b/kuma/static/styles/components/syntax/_base.scss
@@ -47,12 +47,12 @@ Enhancements!
 ====================================================================== */
 
 /* don't give operators, strings, etc a background color */
-.token.operator,
-.token.entity,
-.token.url,
-.language-css .token.string,
-.style .token.string {
-    background: none!important;
+span.token.operator,
+span.token.entity,
+span.token.url,
+.language-css span.token.string,
+.style span.token.string {
+    background-color: transparent;
 }
 
 /*

--- a/kuma/static/styles/components/syntax/_base.scss
+++ b/kuma/static/styles/components/syntax/_base.scss
@@ -52,7 +52,7 @@ Enhancements!
 .token.url,
 .language-css .token.string,
 .style .token.string {
-    background-color: transparent;
+    background: none!important;
 }
 
 /*


### PR DESCRIPTION
This was working on previous version of [prism](https://github.com/PrismJS/prism/) but not in the last versions:

For instance, check out the background in the operators on the page: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Invoked_through_call_or_apply
![background in operators](https://user-images.githubusercontent.com/2037792/72635112-c8ebbb80-393a-11ea-8672-1646d8185161.png)

With the fix:

![background in operators fixed](https://user-images.githubusercontent.com/2037792/72635315-5202f280-393b-11ea-9c1b-72bb1ab4d17b.png)


