### PR TITLE
Fix gap left from Edge Mobile in compat data table

### DIFF
--- a/kuma/static/styles/components/compat-tables/_vars.scss
+++ b/kuma/static/styles/components/compat-tables/_vars.scss
@@ -43,12 +43,12 @@ $bc-mobile-browser-width: 220px;
 
 $table-types: (
 	web: (
-		size: 13,
+		size: 12,
 		feature-name-width: 200px,
 		platform-border: (8)
 	),
 	js: (
-		size: 14,
+		size: 13,
 		feature-name-width: 200px,
 		platform-border: (8, 15)
 	),


### PR DESCRIPTION
Last year, BCD had made the decision to remove Edge Mobile from the compatibility data tables, as a) the platform it runs on is deprecated, and b) many users have been confused about whether it referred to the Windows Mobile version (the correct answer), or the iOS/Android versions.  We have already purged Edge Mobile from the entire repository, however a small column-sized gap was left in the table:

<img width="681" alt="Screen Shot 2020-01-18 at 18 35 58" src="https://user-images.githubusercontent.com/5179191/72673585-7e913a00-3a21-11ea-8bd7-30db3d0fb512.png">

This PR aims to fix this styling issue by reducing the column count by one for the "web" and "js" table types (essentially, the two table types that initially displayed Edge Mobile):

<img width="677" alt="Screen Shot 2020-01-18 at 18 40 15" src="https://user-images.githubusercontent.com/5179191/72673619-f8c1be80-3a21-11ea-8ee6-e4096592a621.png">