### PR TITLE
fix token admin user field

### DIFF
--- a/kuma/core/admin.py
+++ b/kuma/core/admin.py
@@ -1,6 +1,5 @@
-
-
 from django.contrib import admin
+from rest_framework.authtoken.admin import TokenAdmin
 
 from kuma.core.models import IPBan
 
@@ -35,3 +34,6 @@ class IPBanAdmin(admin.ModelAdmin):
     actions = None
     readonly_fields = ('deleted',)
     list_display = ('ip', 'created', 'deleted')
+
+
+TokenAdmin.raw_id_fields = ['user']


### PR DESCRIPTION
This PR is a small fix for the Token admin user field. Both stage and prod have so many users (over 400K) that the user field needs to be a raw `id` field rather than a drop-down containing all users.