### PR TITLE
Make BCD Signaling section look more like designs 

### DIFF
--- a/kuma/javascript/src/bcd-signal.jsx
+++ b/kuma/javascript/src/bcd-signal.jsx
@@ -281,7 +281,7 @@ window.activateBCDSignals = (slug: string, locale: string) => {
 
         controlDescription.className = 'control-description';
 
-        controlHeader.appendChild(createStepNumLabel(controlObj.index, true));
+        controlHeader.appendChild(createStepNumLabel(controlObj.index));
         controlHeader.appendChild(document.createTextNode(controlObj.header));
         controlDescription.innerText = controlObj.description;
 
@@ -301,7 +301,6 @@ window.activateBCDSignals = (slug: string, locale: string) => {
             controlInnerWrapper.appendChild(controlObj.el);
         }
 
-        control.appendChild(createStepNumLabel(controlObj.index));
         control.appendChild(controlInnerWrapper);
 
         return control;

--- a/kuma/javascript/src/bcd-signal.jsx
+++ b/kuma/javascript/src/bcd-signal.jsx
@@ -496,7 +496,7 @@ window.activateBCDSignals = (slug: string, locale: string) => {
 
         closeButton.className = 'button close-btn';
         closeButtonWrapper.className = 'close-button-wrapper';
-        leftBlockWrapper.className = 'column-5 left-block';
+        leftBlockWrapper.className = 'column-4 left-block';
         leftBlockHeader.className = 'left-block-header';
         leftBlockImage.className = 'left-block-image';
 
@@ -535,7 +535,7 @@ window.activateBCDSignals = (slug: string, locale: string) => {
         stepsInfoSpan = document.createElement('span');
 
         formControlBlockWrapper.className =
-            'column-7 right-block form-control-block';
+            'column-8 right-block form-control-block';
         stepsInfo.className = 'highlight-spanned';
         stepsInfoSpan.className = 'highlight-span';
 

--- a/kuma/javascript/src/bcd-signal.jsx
+++ b/kuma/javascript/src/bcd-signal.jsx
@@ -267,11 +267,13 @@ window.activateBCDSignals = (slug: string, locale: string) => {
         const control = document.createElement('div');
         const controlInnerWrapper = document.createElement('div');
         const controlHeader = document.createElement('div');
+        const controlInnerHeaderWrapper = document.createElement('div');
         const controlDescription = document.createElement('div');
 
         control.className = 'control';
         controlInnerWrapper.className = 'control-wrap';
         controlHeader.className = 'control-header';
+        controlInnerHeaderWrapper.className = 'control-header-wrap';
         if (controlObj.inline) {
             controlHeader.classList.add('has-control');
         }
@@ -280,9 +282,14 @@ window.activateBCDSignals = (slug: string, locale: string) => {
         }
 
         controlDescription.className = 'control-description';
+        controlInnerHeaderWrapper.appendChild(
+            createStepNumLabel(controlObj.index)
+        );
+        controlInnerHeaderWrapper.appendChild(
+            document.createTextNode(controlObj.header)
+        );
+        controlHeader.appendChild(controlInnerHeaderWrapper);
 
-        controlHeader.appendChild(createStepNumLabel(controlObj.index));
-        controlHeader.appendChild(document.createTextNode(controlObj.header));
         controlDescription.innerText = controlObj.description;
 
         controlInnerWrapper.appendChild(controlHeader);

--- a/kuma/static/styles/components/compat-tables/_bc-signal.scss
+++ b/kuma/static/styles/components/compat-tables/_bc-signal.scss
@@ -134,7 +134,7 @@ div.bc-signal-block {
 
     .left-block {
         box-sizing: border-box;
-        padding: 32px 0 32px 3%; // 3% to match column margin right
+        padding: 32px 0 32px 3%; // 3% to match .column margin right
 
         @media #{$mq-tablet-and-down} {
             padding: 16px;
@@ -315,6 +315,13 @@ div.bc-signal-block {
         margin-top: 20px;
     }
 
+    .control-wrap {
+        width: 92%;
+        @media #{$mq-mobile-and-down} {
+            width: 100%;
+        }
+    }
+
     .control-header {
         width: 100%;
         font-size: 17.6px;
@@ -325,25 +332,44 @@ div.bc-signal-block {
         color: #333333;
         margin-bottom: 8px;
         line-height: 1.31;
+
+
+        &.has-control {
+            display: flex;
+            align-items: center;
+            @media #{$mq-tablet-and-down} {
+                display: block;
+            }
+        }
+
+        &.with-optional-label {
+            display: flex;
+            @media #{$mq-tablet-and-down} {
+                justify-content: space-between;
+            }
+        }
     }
 
     .control-description {
-        margin-top: 10px;
+        margin: 10px 0 16px 32px;
         font-size: 14px;
-        font-weight: normal;
-        font-style: normal;
-        font-stretch: normal;
         line-height: 1.4;
         letter-spacing: normal;
         color: #333333;
-        margin-bottom: 16px;
+        @media #{$mq-mobile-and-down} {
+            margin-left: 0;
+        }
     }
 
     .select-wrapper {
         position: relative;
-
+        margin-left: 32px;
         @media #{$mq-tablet-and-down} {
+            margin-left: 32px;
             width: 100%;
+        }
+        @media #{$mq-mobile-and-down} {
+            margin-left: 0;
         }
     }
 
@@ -385,16 +411,19 @@ div.bc-signal-block {
         box-sizing: border-box;
         border-color: $blue;
         height: 72px;
+        margin-left: 32px;
+        @media #{$mq-mobile-and-down} {
+            margin-left: 0;
+        }
     }
 
     span.optional-text {
         font-size: 17.6px;
         font-weight: normal;
         font-style: italic;
-        font-stretch: normal;
         line-height: normal;
         color: #9a3d3d;
-        margin: 2px 10px;
+        margin: 2px 0 2px 15px;
         float: right;
     }
 }
@@ -420,6 +449,11 @@ div.bc-signal-block {
 .select-browser-block {
     display: flex;
     flex-wrap: wrap;
+    margin-left: 32px;
+
+    @media #{$mq-mobile-and-down} {
+        margin-left: 0;
+    }
 
     & > .browser {
         box-sizing: border-box;

--- a/kuma/static/styles/components/compat-tables/_bc-signal.scss
+++ b/kuma/static/styles/components/compat-tables/_bc-signal.scss
@@ -134,7 +134,7 @@ div.bc-signal-block {
 
     .left-block {
         box-sizing: border-box;
-        padding: 32px;
+        padding: 32px 0 32px 3%; // 3% to match column margin right
 
         @media #{$mq-tablet-and-down} {
             padding: 16px;
@@ -262,6 +262,7 @@ div.bc-signal-block {
 
     .step-num {
         background: $blue;
+        box-sizing: border-box;
         align-items: center;
         justify-content: center;
         width: 24px;
@@ -270,20 +271,13 @@ div.bc-signal-block {
         min-height: 24px;
         border-radius: 50%;
         padding: 2px 3px;
-        font-family: Arial;
         font-size: 14px;
         font-weight: bold;
-        font-style: normal;
-        font-stretch: normal;
-        letter-spacing: normal;
         text-align: center;
         color: #ffffff;
         margin-right: 8px;
         display: flex;
-
-        @media #{$mq-tablet-and-down} {
-            display: none;
-        }
+        float: left;
 
         &.inline {
             display: inline-flex;
@@ -321,10 +315,6 @@ div.bc-signal-block {
         margin-top: 20px;
     }
 
-    .control-wrap {
-        width: 90%;
-    }
-
     .control-header {
         width: 100%;
         font-size: 17.6px;
@@ -335,16 +325,6 @@ div.bc-signal-block {
         color: #333333;
         margin-bottom: 8px;
         line-height: 1.31;
-
-        &.has-control {
-            float: left;
-        }
-
-        &.with-optional-label {
-            @media #{$mq-tablet-and-down} {
-                display: flex;
-            }
-        }
     }
 
     .control-description {
@@ -413,10 +393,9 @@ div.bc-signal-block {
         font-style: italic;
         font-stretch: normal;
         line-height: normal;
-        letter-spacing: normal;
-        text-align: center;
         color: #9a3d3d;
-        margin: 0 10px;
+        margin: 2px 10px;
+        float: right;
     }
 }
 


### PR DESCRIPTION
- Shrink left column
- Center dinosaur logo
- Make numbers round
- Keep "Optional" text from wrapping to a new line

<img width="843" alt="before" src="https://user-images.githubusercontent.com/650/73510439-1db61a00-43b0-11ea-85fd-846781659183.png">

<img width="765" alt="after" src="https://user-images.githubusercontent.com/650/73510481-37576180-43b0-11ea-8193-8cdd3f33434b.png">

Closes #6063 and #6065  