### PR TITLE
Fix django-cacheback deprecation warning

### DIFF
--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -72,7 +72,7 @@ class GenerationKeyJob(Job):
         """Create a unique generation identifier."""
         return crypto.get_random_string(length=12)
 
-    def get_constructor_kwargs(self):
+    def get_init_kwargs(self):
         """
         Get named arguments for re-initialization.
 


### PR DESCRIPTION
Upon startup, I see many instances of the following warning:

    /app/kuma/core/jobs.py:56: RemovedInCacheback13Warning: `GenerationKeyJob.get_constructor_kwargs` method should be renamed `get_init_kwargs`.

This fixes that. No behavior changed in cacheback; it was just a rename:
https://github.com/codeinthehole/django-cacheback/commit/3a47e8c8f68e1ea80ae7b346e3148ce86e10d568