### PR TITLE
Remove dead code related to python-decouple

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -18,13 +18,6 @@ def path(*parts):
     return os.path.join(BASE_DIR, *parts)
 
 
-class TupleCsv(Csv):
-
-    def __call__(self, value):
-        split_values = super(TupleCsv, self).__call__(value)
-        return tuple((value, value) for value in split_values)
-
-
 DEBUG = config('DEBUG', default=False, cast=bool)
 
 # BASE_DIR used by django-extensions, such as ./manage.py notes


### PR DESCRIPTION
Four years ago, we subclassed python-decouple's Csv to make TupleCsv:
https://github.com/mdn/kuma/commit/414dd2107ff5588d9f20c28b6b54389eaf0151d2#diff-61a61acfc5dfb7ad94a50fde2865584eR26-R30

Two years ago, we removed our one use of TupleCsv:
https://github.com/mdn/kuma/commit/20c1f72eb216ea6177e677e6b6920bcef05f6999#diff-61a61acfc5dfb7ad94a50fde2865584eL39

We should remove this unused code.