### PR TITLE
use Authorization header for passing access token for GitHub

### DIFF
--- a/kuma/users/providers/github/views.py
+++ b/kuma/users/providers/github/views.py
@@ -19,11 +19,11 @@ class KumaGitHubOAuth2Adapter(GitHubOAuth2Adapter):
 
     def complete_login(self, request, app, token, **kwargs):
         session = requests_retry_session()
-        params = {'access_token': token.token}
-        profile_data = session.get(self.profile_url, params=params)
+        headers = {'Authorization': f'token {token.token}'}
+        profile_data = session.get(self.profile_url, headers=headers)
         profile_data.raise_for_status()
         extra_data = profile_data.json()
-        email_data = session.get(self.email_url, params=params)
+        email_data = session.get(self.email_url, headers=headers)
         email_data.raise_for_status()
         extra_data['email_addresses'] = email_data.json()
         return self.get_provider().sociallogin_from_response(request,


### PR DESCRIPTION
Fixes #6421 

I tested this locally and it works great.

For additional reference, see https://github.com/pennersr/django-allauth/pull/2458