### PR TITLE
Update whitenoise (3.3.1 -> 5.0.1)

### DIFF
--- a/kuma/wsgi.py
+++ b/kuma/wsgi.py
@@ -1,8 +1,16 @@
-# Fix the settings so that Whitenoise is happy
-import os
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kuma.settings.local')
+"""
+WSGI config for kuma project.
 
-# Enable WhiteNoise
-from django.core.wsgi import get_wsgi_application  # noqa
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kuma.settings.local')
 
 application = get_wsgi_application()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1298,11 +1298,14 @@ category = "main"
 description = "Radically simplified static file serving for WSGI applications"
 name = "whitenoise"
 optional = false
-python-versions = "*"
-version = "3.3.1"
+python-versions = ">=3.5, <4"
+version = "5.0.1"
+
+[package.extras]
+brotli = ["brotli"]
 
 [metadata]
-content-hash = "7abb35f5c5a664a090171ddf9500609418359c174de13d179950c03c3e3ac2c8"
+content-hash = "e00526b2c17f3bfe2fde49bf8face667cfbd26cfc235c09e96387bc6cf07df9f"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1894,6 +1897,6 @@ werkzeug = [
     {file = "Werkzeug-0.16.1.tar.gz", hash = "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"},
 ]
 whitenoise = [
-    {file = "whitenoise-3.3.1-py2.py3-none-any.whl", hash = "sha256:15f43b2e701821b95c9016cf469d29e2a546cb1c7dead584ba82c36f843995cf"},
-    {file = "whitenoise-3.3.1.tar.gz", hash = "sha256:9d81515f2b5b27051910996e1e860b1332e354d9e7bcf30c98f21dcb6713e0dd"},
+    {file = "whitenoise-5.0.1-py2.py3-none-any.whl", hash = "sha256:62556265ec1011bd87113fb81b7516f52688887b7a010ee899ff1fd18fd22700"},
+    {file = "whitenoise-5.0.1.tar.gz", hash = "sha256:0f9137f74bd95fa54329ace88d8dc695fbe895369a632e35f7a136e003e41d73"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ sqlparse = "0.3.0"
 stripe = "^2.42.0"
 urllib3 = "^1.25.7"
 urlobject = "^2.4.3"
-whitenoise = "3.3.1"
+whitenoise = "^5.0.1"
 
 # From default_and_test.txt
 pyquery = "1.4.1"


### PR DESCRIPTION
- Updating whitenoise (3.3.1 -> 5.0.1)
  Raw Changelog: https://github.com/evansd/whitenoise/blob/v5.0.1/docs/changelog.rst
  Rendered: http://whitenoise.evans.io/en/stable/changelog.html

For us, the only meaningful behavioral change is that whitenoise now
generates ETag headers for static assets, using the same algorithm as
nginx. In practice, this shouldn't change anything as our production
builds serve static content from CloudFront with hashes in the filenames
and immutable cache-control headers.

I've also reverted `kuma/wsgi.py` to match what Django generates out of
the box. Once upon a time we had to customize it to enable Whitenoise,
but those changes were backed out over two years ago:

https://github.com/mdn/kuma/commit/2526865ecb6272baff58da03a36b0e7b3b2db95d#diff-0b07db8a3993b2a29af197f02dacb31c