### PR TITLE
Fix dropdown menu position on RTL languages 

### DIFF
--- a/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
@@ -23,14 +23,9 @@ exports[`LanguageMenu snapshot 1`] = `
     </span>
   </button>
   <ul
-    className="dropdown-menu-items"
+    className="dropdown-menu-items right"
     id="language-menu"
     role="menu"
-    style={
-      Object {
-        "right": 0,
-      }
-    }
   >
     <li
       lang="es"

--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -23,13 +23,8 @@ exports[`Login component when user is logged in 1`] = `
       />
     </button>
     <ul
-      className="dropdown-menu-items"
+      className="dropdown-menu-items right"
       role="menu"
-      style={
-        Object {
-          "right": 0,
-        }
-      }
     >
       <li>
         <a

--- a/kuma/javascript/src/header/dropdown.jsx
+++ b/kuma/javascript/src/header/dropdown.jsx
@@ -69,8 +69,7 @@ export default function Dropdown(props: DropdownProps) {
             </button>
             <ul
                 id={props.ariaOwns}
-                className="dropdown-menu-items"
-                style={props.right && { right: 0 }}
+                className={`dropdown-menu-items${props.right ? ' right' : ''}`}
                 role="menu"
             >
                 {props.children}

--- a/kuma/static/styles/minimalist/components/_dropdown.scss
+++ b/kuma/static/styles/minimalist/components/_dropdown.scss
@@ -34,6 +34,21 @@
         min-width: 100%;
         z-index: $menu-zindex;
 
+        // Mirror left and right positions for LTR and RTL languages
+        /* prettier-ignore */
+        @include bidi((
+            (left, 0, auto),
+            (right, auto, 0),
+        ));
+
+        &.right {
+            /* prettier-ignore */
+            @include bidi((
+                (left, auto, 0),
+                (right, 0, auto),
+            ));
+        }
+
         li a,
         li button {
             display: inline-block;


### PR DESCRIPTION
- Move positioning of dropdown menu to SCSS file, so we can use the `bidi` mixin to handle LTR and RTL languages. 
- Affects both the User Avatar dropdown in the header and the language dropdown

**Sample URL:** 
http://localhost.org:8000/ar/docs/Web/CSS/:focus-visible

**Before:**
![menu-before](https://user-images.githubusercontent.com/650/73881921-3babd080-482f-11ea-996c-c5f43fae0d51.gif)

**After:** 
![menu-after](https://user-images.githubusercontent.com/650/73881931-3fd7ee00-482f-11ea-8f28-368c6ad9bc7d.gif)

Closes #6354 
