### PR TITLE
Updating bleach (2.1.4 -> 3.1.0)

### DIFF
--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1108,21 +1108,19 @@ def test_clean_content_stripped_ie_comment():
 
 
 def test_clean_content_iframe_in_script():
-    """iframe in script should be filtered"""
-    content = ('<script><iframe src="data:text/plain,foo">'
-               '</iframe></script>')
-    expected = ('&lt;script&gt;&lt;iframe src="data:text/plain,foo"&gt;'
-                '&lt;/iframe&gt;&lt;/script&gt;')
+    """script tags should not be allowed, and markup inside should be cleaned"""
+    # Note that iframe tags _are_ allowed, but made safe; see ALLOWED_TAGS
+    content = '<script><iframe src="data:text/plain,foo">bar</iframe></script>'
+    expected = '&lt;script&gt;<iframe></iframe>&lt;/script&gt;'
     result = clean_content(content)
     assert normalize_html(expected) == normalize_html(result)
 
 
 def test_clean_content_iframe_in_style():
-    """iframe in style should be filtered"""
-    content = ('<style><iframe src="data:text/plain,foo">'
-               '</iframe></style>')
-    expected = ('&lt;style&gt;&lt;iframe src="data:text/plain,foo"&gt;'
-                '&lt;/iframe&gt;&lt;/style&gt;')
+    """style tags should not be allowed, and markup inside should be cleaned"""
+    # Note that iframe tags _are_ allowed, but made safe; see ALLOWED_TAGS
+    content = '<style><iframe src="data:text/plain,foo">bar</iframe></style>'
+    expected = '&lt;style&gt;<iframe></iframe>&lt;/style&gt;'
     result = clean_content(content)
     assert normalize_html(expected) == normalize_html(result)
 

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -96,7 +96,7 @@ class AkismetHistoricalDataTests(UserTestCase):
     ('<div onclick="alert(\'hacked!\')">click me</div>',
      '<div>click me</div>'),
     ('<svg><circle onload=confirm(3)>',
-     '&lt;svg&gt;&lt;circle onload="confirm(3)"&gt;&lt;/circle&gt;&lt;/svg&gt;')
+     '&lt;svg&gt;&lt;circle onload=confirm(3)&gt;')
 ], ids=('strip', 'escape'))
 def test_form_onload_attr_filter(root_doc, rf, content, expected):
     """

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -524,7 +524,7 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
     ('<div onclick="alert(\'hacked!\')">click me</div>',
      '<div>click me</div>'),
     ('<svg><circle onload=confirm(3)>',
-     '&lt;svg&gt;&lt;circle onload="confirm(3)"&gt;&lt;/circle&gt;&lt;/svg&gt;')
+     '&lt;svg&gt;&lt;circle onload=confirm(3)&gt;')
 ], ids=('strip', 'escape'))
 def test_editor_safety(root_doc, editor_client, content, expected):
     """

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,11 +34,11 @@ description = "An easy safelist-based HTML-sanitizing tool."
 name = "bleach"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.1.4"
+version = "3.1.0"
 
 [package.dependencies]
-html5lib = ">=0.99999999pre,<1.0b1 || >1.0b1,<1.0b2 || >1.0b2,<1.0b3 || >1.0b3,<1.0b4 || >1.0b4,<1.0b5 || >1.0b5,<1.0b6 || >1.0b6,<1.0b7 || >1.0b7,<1.0b8 || >1.0b8"
-six = "*"
+six = ">=1.9.0"
+webencodings = "*"
 
 [[package]]
 category = "main"
@@ -1305,7 +1305,7 @@ version = "5.0.1"
 brotli = ["brotli"]
 
 [metadata]
-content-hash = "e00526b2c17f3bfe2fde49bf8face667cfbd26cfc235c09e96387bc6cf07df9f"
+content-hash = "aa97292a45f2fdf4cf54e50a623fa9ca37b6dcccd9b959e44d6f42a3977eee42"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1322,8 +1322,8 @@ billiard = [
     {file = "billiard-3.6.2.0.tar.gz", hash = "sha256:f4e09366653aa3cb3ae8ed16423f9ba1665ff426f087bcdbbed86bf3664fe02c"},
 ]
 bleach = [
-    {file = "bleach-2.1.4-py2.py3-none-any.whl", hash = "sha256:24754b9a7d530bf30ce7cbc805bc6cce785660b4a10ff3a43633728438c105ab"},
-    {file = "bleach-2.1.4.tar.gz", hash = "sha256:0ee95f6167129859c5dce9b1ca291ebdb5d8cd7e382ca0e237dfd0dad63f63d8"},
+    {file = "bleach-3.1.0-py2.py3-none-any.whl", hash = "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16"},
+    {file = "bleach-3.1.0.tar.gz", hash = "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"},
 ]
 boto3 = [
     {file = "boto3-1.11.10-py2.py3-none-any.whl", hash = "sha256:27e221d3868f35687807e5c920f7e8d4872f722f64196a7fd274a06ad65beec0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.8"
 
 # From default.txt
 babel = "^2.8.0"
-bleach = "2.1.4"
+bleach = "^3.1.0"
 boto3 = "^1.10.37"
 celery = "^4.3.0"
 commonware = "0.5.0"


### PR DESCRIPTION
- Updating bleach (2.1.4 -> 3.1.0)
  https://github.com/mozilla/bleach/blob/v3.1.0/CHANGES

Bleach is now more faithful to the original text, whereas previously it
would ensure that HTML was well-formed before escaping it. Thus, our
some of our tests needed to be updated after this bleach commit:
https://github.com/mozilla/bleach/commit/6b05f3c133e84b0e4ab61e8e117f4c4b333d80d4

Secondly, we were previously testing the escaping of:

    <script><iframe src="data:text/plain,foo"></iframe></script>

Bleach 2.1.4's parser escaped the iframe, since iframe elements aren't
allowed instead script elements, and then escaped the script element
because it's not one of our ALLOWED_TAGS. The result:

    &lt;style&gt;&lt;iframe src="data:text/plain,foo"&gt;&lt;/iframe&gt;&lt;/style&gt;

Bleach 3, on the other hand, first escapes the script tag, yielding a
valid positioning of the iframe element. Because we _do_ allow iframes
in our ALLOWED_TAGS, an unescaped iframe is emitted. Our `clean_content`
function then separately filters the resulting HTML to ensure that any
iframes are safe and only use approved origins. This results in:

    &lt;style&gt;<iframe></iframe>&lt;/style&gt;

Filtering is controlled by two settings, `ALLOW_ALL_IFRAMES` and
`ALLOWED_IFRAME_PATTERNS`, both of which are tested elsewhere in
kuma/wiki/tests/test_content.py