### PR TITLE
Fix deprecation warnings for logger.warn()

### DIFF
--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -51,12 +51,12 @@ class Requester(object):
             try:
                 response = request_function(url, timeout=timeout)
             except requests.exceptions.Timeout as err:
-                logger.warn("Timeout on request %d for %s", attempts, url)
+                logger.warning("Timeout on request %d for %s", attempts, url)
                 time.sleep(timeout)
                 timeout *= 2
                 error = err
             except requests.exceptions.ConnectionError as err:
-                logger.warn("Error request %d for %s: %s", attempts, url, err)
+                logger.warning("Error request %d for %s: %s", attempts, url, err)
                 error = err
             if response is None:
                 if attempts >= self.MAX_ATTEMPTS:
@@ -70,12 +70,12 @@ class Requester(object):
                     pause = max(1, int(pause_raw))
                 except ValueError:
                     pause = 30
-                logger.warn(("Request limit (429) returned for %s."
-                             " Pausing for %d seconds."), url, pause)
+                logger.warning(("Request limit (429) returned for %s."
+                                " Pausing for %d seconds."), url, pause)
                 time.sleep(pause)
             elif response.status_code == 504:
                 retry = True
-                logger.warn("Gateway timeout (504) returned for %s.", url)
+                logger.warning("Gateway timeout (504) returned for %s.", url)
                 time.sleep(timeout)
                 timeout *= 2
 
@@ -147,7 +147,7 @@ class Scraper(object):
     def scrape(self):
         """Scrape data from MDN sources."""
         if not self.sources:
-            logger.warn("No sources to scrape.")
+            logger.warning("No sources to scrape.")
             return self.sources
         first = True     # Always run it once
         repeat = False   # Run another round if there are new sources to scrape
@@ -184,8 +184,8 @@ class Scraper(object):
                 state_counts[source.state] += 1
                 for dep in dependencies:
                     if "%" in dep[1]:
-                        logger.warn('Source "%s" has a percent in deps',
-                                    source_key)
+                        logger.warning('Source "%s" has a percent in deps',
+                                       source_key)
 
                 # Detect unfinished work and report on changed state (in debug)
                 log_func = logger.debug
@@ -229,8 +229,8 @@ class Scraper(object):
                 blocked = True
         duration = int(ceil((datetime.now() - start).total_seconds()))
         if blocked:
-            logger.warn('Dependency block detected. Aborting after %d'
-                        ' second%s.', duration, '' if duration == 1 else 's')
+            logger.warning('Dependency block detected. Aborting after %d'
+                           ' second%s.', duration, '' if duration == 1 else 's')
         else:
             logger.info('Scrape complete in %d second%s.',
                         duration, '' if duration == 1 else 's')

--- a/kuma/scrape/sources/document.py
+++ b/kuma/scrape/sources/document.py
@@ -175,12 +175,12 @@ class DocumentSource(DocumentBaseSource):
                 if key in data:
                     doc_data[key] = data[key]
             if doc_data['slug'] != self.slug:
-                logger.warn(
+                logger.warning(
                     'Meta slug "%s" does not match slug for "%s".',
                     doc_data['slug'], self.path)
                 doc_data['slug'] = self.slug
             if doc_data['locale'] != self.locale:
-                logger.warn(
+                logger.warning(
                     'Meta locale "%s" does not match locale for "%s".',
                     doc_data['locale'], self.path)
                 doc_data['locale'] = self.locale

--- a/kuma/scrape/sources/revision.py
+++ b/kuma/scrape/sources/revision.py
@@ -34,7 +34,7 @@ class RevisionSource(Source):
         try:
             self.locale, self.slug, self.revision_id = self.split_path(path)
         except ValueError as exception:
-            logger.warn(exception)
+            logger.warning(exception)
             self.state = self.STATE_ERROR
 
     @classmethod
@@ -118,10 +118,10 @@ class RevisionSource(Source):
             data['creator'] = creator
             data['document'] = self.document
             if data['is_current'] and data['slug'] != self.document.slug:
-                logger.warn('Current revision %d has slug "%s". Setting'
-                            ' to document slug "%s".',
-                            self.revision_id, data['slug'],
-                            self.document.slug)
+                logger.warning('Current revision %d has slug "%s". Setting'
+                               ' to document slug "%s".',
+                               self.revision_id, data['slug'],
+                               self.document.slug)
                 data['slug'] = self.document.slug
             if data['is_current']:
                 data['review_tags'] = meta.get('review_tags', [])

--- a/kuma/scrape/storage.py
+++ b/kuma/scrape/storage.py
@@ -92,8 +92,8 @@ class Storage(object):
                     document = Document.objects.create(
                         locale=locale, slug=slug, **doc_data)
                 except IntegrityError as error:
-                    logger.warn('On locale "%s", slug "%s", got error %s',
-                                locale, slug, error)
+                    logger.warning('On locale "%s", slug "%s", got error %s',
+                                   locale, slug, error)
                     doc_data.pop('id', None)
             else:
                 for name, value in doc_data.items():

--- a/kuma/scrape/tests/test_scraper.py
+++ b/kuma/scrape/tests/test_scraper.py
@@ -274,7 +274,7 @@ def test_warn_percent_in_param(scraper, mock_logger):
     scraper.add_source('fake', 'loop%0d', depth=1)
     scraper.scrape()
     expected_fmt = 'Source "%s" has a percent in deps'
-    mock_logger.warn.assert_called_once_with(expected_fmt, 'fake:loop%0d')
+    mock_logger.warning.assert_called_once_with(expected_fmt, 'fake:loop%0d')
 
 
 def test_warn_dependency_block(scraper, mock_logger):
@@ -287,4 +287,4 @@ def test_warn_dependency_block(scraper, mock_logger):
     scraper.add_source('fake', 'bad_document', length=2, error=True)
     scraper.scrape()
     expected_msg = 'Dependency block detected. Aborting after %d second%s.'
-    mock_logger.warn.assert_called_once_with(expected_msg, 1, '')
+    mock_logger.warning.assert_called_once_with(expected_msg, 1, '')

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -612,7 +612,7 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
                 # Write a log we can grep to help find pre-existing duplicate
                 # document tags for cleanup.
                 if len(doc_tag) > 1:
-                    log.warn('Found duplicate document tags: %s' % doc_tag)
+                    log.warning('Found duplicate document tags: %s' % doc_tag)
 
                 if doc_tag:
                     if doc_tag[0] != tag and doc_tag[0].lower() == tag.lower():


### PR DESCRIPTION
The `warn()` method on loggers is deprecated. Use `warning()` instead.

https://docs.python.org/3/library/logging.html#logging.Logger.warning