### PR TITLE
Update pytest-django (3.1.2 -> 3.4.8)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1084,11 +1084,15 @@ category = "main"
 description = "A Django plugin for pytest."
 name = "pytest-django"
 optional = false
-python-versions = "*"
-version = "3.1.2"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.4.8"
 
 [package.dependencies]
-pytest = ">=2.9"
+pytest = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["django", "django-configurations (>=2.0)", "six"]
 
 [[package]]
 category = "dev"
@@ -1415,7 +1419,7 @@ version = "5.0.1"
 brotli = ["brotli"]
 
 [metadata]
-content-hash = "875b6a3628489658b323851ce6fe8dafacd5f69e5150d8bb92b8c53da954c1be"
+content-hash = "5d68d67dd3ce5efab3d63addc5b32a3e7f73019cdc714b327c55b0d09c32cfe5"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1928,8 +1932,8 @@ pytest-cov = [
     {file = "pytest_cov-2.4.0-py2.py3-none-any.whl", hash = "sha256:10e37e876f49ddec80d6c83a54b657157f1387ebc0f7755285f8c156130014a1"},
 ]
 pytest-django = [
-    {file = "pytest-django-3.1.2.tar.gz", hash = "sha256:038ccc5a9daa1b1b0eb739ab7dce54e495811eca5ea3af4815a2a3ac45152309"},
-    {file = "pytest_django-3.1.2-py2.py3-none-any.whl", hash = "sha256:00995c2999b884a38ae9cd30a8c00ed32b3d38c1041250ea84caf18085589662"},
+    {file = "pytest-django-3.4.8.tar.gz", hash = "sha256:4d3283e774fe1d40630ee58bf34929b83875e4751b525eeb07a7506996eb42ee"},
+    {file = "pytest_django-3.4.8-py2.py3-none-any.whl", hash = "sha256:30d773f1768e8f214a3106f1090e00300ce6edfcac8c55fd13b675fe1cbd1c85"},
 ]
 pytest-metadata = [
     {file = "pytest-metadata-1.8.0.tar.gz", hash = "sha256:2071a59285de40d7541fde1eb9f1ddea1c9db165882df82781367471238b66ba"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ six = "^1.13.0"
 django-babel = "0.6.2"
 django-querycount = "0.7.0"
 pytest-cov = "2.4.0"
-pytest-django = "3.1.2"
+pytest-django = "~3.4"
 urlwait = "0.4"
 
 # From constraints.txt


### PR DESCRIPTION
- Updating pytest-django (3.1.2 -> 3.4.8)
  https://github.com/pytest-dev/pytest-django/blob/3.4.8/docs/changelog.rst

This is the most recent version we can update to before tests fail.