### PR TITLE
Fix two deprecation warnings

### DIFF
--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -1,8 +1,8 @@
 
 
 import datetime
+import html
 import json
-from html.parser import HTMLParser
 
 import jinja2
 from django.conf import settings
@@ -22,9 +22,6 @@ from urlobject import URLObject
 from ..urlresolvers import reverse, split_path
 from ..utils import (format_date_time, is_untrusted, is_wiki, order_params,
                      urlparams)
-
-
-htmlparser = HTMLParser()
 
 
 # Yanking filters from Django.
@@ -108,7 +105,7 @@ def yesno(boolean_value):
 @library.filter
 def entity_decode(str):
     """Turn HTML entities in a string into unicode."""
-    return htmlparser.unescape(str)
+    return html.unescape(str)
 
 
 @library.global_function

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -318,7 +318,7 @@ def ks_toolbox():
     }
 
     d_json = json.dumps(errors)
-    d_b64 = base64.encodestring(d_json.encode()).decode()
+    d_b64 = base64.encodebytes(d_json.encode()).decode()
     d_lines = [x for x in d_b64.split('\n') if x]
 
     # Headers are case-insensitive, so let's drive that point home.

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1,8 +1,8 @@
 
 
 import datetime
+import html
 import json
-from html.parser import HTMLParser
 from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -1474,7 +1474,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             # Add an some extra characters to the end, since the unescaped length
             # is a little less than the escaped length
             end_of_error = start_of_error + len(collision_err) + 20
-            location_of_error = HTMLParser().unescape(
+            location_of_error = html.unescape(
                 content[start_of_error: end_of_error]
             )
         assert collision_err in location_of_error


### PR DESCRIPTION
- The HTMLParser.unescape() method is a deprecated alias for html.unescape()
- base64.encodestring() is a deprecated alias for .encodebytes()