### PR TITLE
Add system check to verify stripe config

### DIFF
--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -92,9 +92,9 @@ SITE_ID = 1
 ENABLE_BCD_SIGNAL = True
 
 # Stripe API KEY settings
-STRIPE_PUBLIC_KEY = "wubba lubba dub duab"
-STRIPE_SECRET_KEY = "wubba lubba dub dub"
-STRIPE_PLAN_ID = "wubba lubba dub dub"
+STRIPE_PUBLIC_KEY = "testing"
+STRIPE_SECRET_KEY = "testing"
+STRIPE_PLAN_ID = "testing"
 
 # (peterbe) All existing tests will now assume this is always the case.
 # The day the *default* is to set MULTI_AUTH_ENABLED=True in settings/common.py

--- a/kuma/users/apps.py
+++ b/kuma/users/apps.py
@@ -3,6 +3,9 @@ from django.conf import settings
 from django.contrib.auth.apps import AuthConfig
 from django.utils.translation import ugettext_lazy as _
 
+# the checks self-register so we don't need to use anything from the import
+import kuma.users.checks  # noqa: F401
+
 
 class UserConfig(AuthConfig):
     """

--- a/kuma/users/checks.py
+++ b/kuma/users/checks.py
@@ -11,6 +11,9 @@ STRIPE_PLAN_INACTIVE_ERROR = "kuma.users.E002"
 def stripe_check(app_configs, **kwargs):
     errors = []
 
+    # Unfortunately system checks get run with testing settings in our CI,
+    # so we need to check for the testing setting value
+    # Related issue: https://github.com/mdn/kuma/issues/6481
     if settings.STRIPE_SECRET_KEY == "testing" or (
         not settings.STRIPE_SECRET_KEY
         and not settings.STRIPE_PUBLIC_KEY

--- a/kuma/users/checks.py
+++ b/kuma/users/checks.py
@@ -12,7 +12,9 @@ def stripe_check(app_configs, **kwargs):
     errors = []
 
     if settings.STRIPE_SECRET_KEY == "testing" or (
-        not settings.STRIPE_SECRET_KEY and not settings.STRIPE_PLAN_ID
+        not settings.STRIPE_SECRET_KEY
+        and not settings.STRIPE_PUBLIC_KEY
+        and not settings.STRIPE_PLAN_ID
     ):
         return errors
 

--- a/kuma/users/checks.py
+++ b/kuma/users/checks.py
@@ -3,16 +3,31 @@ from django.conf import settings
 from django.core.checks import Error, register
 
 
+STRIPE_ERROR_ID = "kuma.users.E001"
+STRIPE_PLAN_INACTIVE_ERROR = "kuma.users.E002"
+
+
 @register()
 def stripe_check(app_configs, **kwargs):
+    errors = []
+
     if settings.STRIPE_SECRET_KEY == "testing" or (
         not settings.STRIPE_SECRET_KEY and not settings.STRIPE_PLAN_ID
     ):
-        return []
+        return errors
 
     try:
-        stripe.Plan.retrieve(settings.STRIPE_PLAN_ID)
-    except stripe.error.StripeError as e:
-        return [Error(f"invalid stripe config: {str(e)}")]
+        plan = stripe.Plan.retrieve(settings.STRIPE_PLAN_ID)
+        if not plan.active:
+            errors.append(
+                Error(
+                    f"{settings.STRIPE_PLAN_ID} points to an inactive Strip plan",
+                    id=STRIPE_PLAN_INACTIVE_ERROR,
+                )
+            )
+    except stripe.error.StripeError as error:
+        errors.append(
+            Error(f"unable to retrieve stripe plan: {error}", id=STRIPE_ERROR_ID)
+        )
 
-    return []
+    return errors

--- a/kuma/users/checks.py
+++ b/kuma/users/checks.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core.checks import Error, register
 
 
-STRIPE_ERROR_ID = "kuma.users.E001"
+STRIPE_PLAN_ERROR = "kuma.users.E001"
 STRIPE_PLAN_INACTIVE_ERROR = "kuma.users.E002"
 
 
@@ -32,7 +32,7 @@ def stripe_check(app_configs, **kwargs):
             )
     except stripe.error.StripeError as error:
         errors.append(
-            Error(f"unable to retrieve stripe plan: {error}", id=STRIPE_ERROR_ID)
+            Error(f"unable to retrieve stripe plan: {error}", id=STRIPE_PLAN_ERROR)
         )
 
     return errors

--- a/kuma/users/checks.py
+++ b/kuma/users/checks.py
@@ -1,0 +1,18 @@
+import stripe
+from django.conf import settings
+from django.core.checks import Error, register
+
+
+@register()
+def stripe_check(app_configs, **kwargs):
+    if settings.STRIPE_SECRET_KEY == "testing" or (
+        not settings.STRIPE_SECRET_KEY and not settings.STRIPE_PLAN_ID
+    ):
+        return []
+
+    try:
+        stripe.Plan.retrieve(settings.STRIPE_PLAN_ID)
+    except stripe.error.StripeError as e:
+        return [Error(f"invalid stripe config: {str(e)}")]
+
+    return []


### PR DESCRIPTION
Fixes #6405 

I decided to do a lot less than you did in [your system check pull](https://github.com/mdn/kuma/pull/5425) @peterbe, for two reasons:
- system checks are always run on server start and for migrations (in non-deployment mode)
- for deployments I'm entirely ignorant about what the best workflow would be

@escattone I'm really curious to get your take on this. I mistakenly said in the original issue that this an alternative to headless tests. What I meant to say was that it complements our offline tests in such a way that we might not need a stripe headless test (though to be fair what the headless test did test, that isn't checked anymore is whether we got the interaction with stripe itself right).