### PR TITLE
ability to edit whose parent is deleted

### DIFF
--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -30,6 +30,18 @@
       </div>
     </div>
   </div>
+
+  {% if parent.deleted %}
+  <div class="warning">
+    <p>
+      {% trans parent_url=parent.get_absolute_url() %}
+      <b>Note!</b>
+      The <a href="{{ parent_url }}">parent document</a> is deleted.
+      {% endtrans %}
+    </p>
+  </div>
+{% endif %}
+
 {% endblock%}
 
 {% block content %}

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -104,6 +104,13 @@ class DeletedDocumentManager(BaseDocumentManager):
         return super(DeletedDocumentManager, self).get_queryset().filter(deleted=True)
 
 
+class AllDocumentManager(BaseDocumentManager):
+    """
+    Similar to DocumentAdminManager class but more explicit in its name.
+    Use this when you don't want *any* filtering by 'deleted'.
+    """
+
+
 class DocumentAdminManager(BaseDocumentManager):
     """
     A manager used only in the admin site, which does not perform any

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -56,6 +56,7 @@ from .exceptions import (
 )
 from .jobs import DocumentContributorsJob, DocumentTagsJob
 from .managers import (
+    AllDocumentManager,
     DeletedDocumentManager,
     DocumentAdminManager,
     DocumentManager,
@@ -330,6 +331,7 @@ class Document(NotificationsMixin, models.Model):
 
     objects = DocumentManager()
     deleted_objects = DeletedDocumentManager()
+    all_objects = AllDocumentManager()
     admin_objects = DocumentAdminManager()
 
     def __str__(self):

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -54,9 +54,15 @@ def translate(request, document_slug, document_locale):
     # That might help reduce the headache-inducing branchiness.
 
     # The parent document to translate from
-    parent_doc = get_object_or_404(
-        Document, locale=settings.WIKI_DEFAULT_LANGUAGE, slug=document_slug
-    )
+    try:
+        # Use '.deleted_objects' because the parent might have been soft deleted.
+        # And if we don't respect that fact, it would become impossible to
+        # edit a the child of it.
+        parent_doc = Document.deleted_objects.get(
+            locale=settings.WIKI_DEFAULT_LANGUAGE, slug=document_slug
+        )
+    except Document.DoesNotExist:
+        raise Http404("Parent document does not exist")
 
     # Get the mapping here and now so it can be used for input validation
     language_mapping = get_language_mapping()

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -55,10 +55,10 @@ def translate(request, document_slug, document_locale):
 
     # The parent document to translate from
     try:
-        # Use '.deleted_objects' because the parent might have been soft deleted.
+        # Use '.all_objects' because the parent might have been soft deleted.
         # And if we don't respect that fact, it would become impossible to
         # edit a the child of it.
-        parent_doc = Document.deleted_objects.get(
+        parent_doc = Document.all_objects.get(
             locale=settings.WIKI_DEFAULT_LANGUAGE, slug=document_slug
         )
     except Document.DoesNotExist:


### PR DESCRIPTION
Fixes #6445

<img width="1442" alt="Screen Shot 2020-02-10 at 12 36 41 PM" src="https://user-images.githubusercontent.com/26739/74174623-3d481080-4c02-11ea-9cd3-41f32a8946ca.png">

I just poked around to make sure I understood the issue. It was easy to find what the problem was. And it was equally easy to find a quick solution. 

However, because it's not super important, I didn't bother making this PR with a new test. Because,  reasons. 
Hey, at least this gets translated documents unstuck if their parent is soft-deleted. 