### PR TITLE
Straightforward Python dependency updates

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -96,10 +96,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.11.13"
+version = "1.11.14"
 
 [package.dependencies]
-botocore = ">=1.14.13,<1.15.0"
+botocore = ">=1.14.14,<1.15.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -109,7 +109,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.14.13"
+version = "1.14.14"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -420,7 +420,7 @@ description = "Extensions for Django"
 name = "django-extensions"
 optional = false
 python-versions = "*"
-version = "2.2.7"
+version = "2.2.8"
 
 [package.dependencies]
 six = ">=1.2"
@@ -967,7 +967,10 @@ description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.7.1"
+version = "0.13.1"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "main"
@@ -1051,14 +1054,14 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.6.4"
+version = "3.10.1"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
 attrs = ">=17.4.0"
 colorama = "*"
 more-itertools = ">=4.0.0"
-pluggy = ">=0.5,<0.8"
+pluggy = ">=0.7"
 py = ">=1.5.0"
 setuptools = "*"
 six = ">=1.10.0"
@@ -1122,10 +1125,10 @@ description = "pytest plugin to re-run tests to eliminate flaky failures"
 name = "pytest-rerunfailures"
 optional = false
 python-versions = "*"
-version = "5.0"
+version = "7.0"
 
 [package.dependencies]
-pytest = ">=3.6"
+pytest = ">=3.10"
 
 [[package]]
 category = "dev"
@@ -1429,7 +1432,7 @@ version = "5.0.1"
 brotli = ["brotli"]
 
 [metadata]
-content-hash = "1d72d33373ba6fd4aa0446bceced4b07a05dcfd00f50a65b1a19d564efb879c4"
+content-hash = "0508e713d8faa24d84a551addf8457e2af7a0a27f4932853e214be821cbbee0d"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1466,12 +1469,12 @@ bleach = [
     {file = "bleach-3.1.0.tar.gz", hash = "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"},
 ]
 boto3 = [
-    {file = "boto3-1.11.13-py2.py3-none-any.whl", hash = "sha256:664be6e0e20cb064dda4ac3397082e3dcc453abb8b2bd2cf64066677e0fb2266"},
-    {file = "boto3-1.11.13.tar.gz", hash = "sha256:09eccb6cd41381c4ff1d626c3a19884b5b1f1424d15a96004d077b532ef393d1"},
+    {file = "boto3-1.11.14-py2.py3-none-any.whl", hash = "sha256:629ce3be236b6e0aed52358146eea9ffa7679d6cd1cc9b3e12332226270d6499"},
+    {file = "boto3-1.11.14.tar.gz", hash = "sha256:b1351e62136fae29be8fcbb1c4890f1d72017d57e33051d435a8bf9f71212fde"},
 ]
 botocore = [
-    {file = "botocore-1.14.13-py2.py3-none-any.whl", hash = "sha256:6ffb78b331b0954cfe5c51958cb51522ab0e2999442422949b080a3e1bc76ee1"},
-    {file = "botocore-1.14.13.tar.gz", hash = "sha256:6478d9207db6dbcb5106fd4db2cdd5194d0b2dc0b73776019d56877ab802fe87"},
+    {file = "botocore-1.14.14-py2.py3-none-any.whl", hash = "sha256:34ad4d73e6bef5c8ad956c66354611628cdebd431fe2927261ed9c068b9cfb7a"},
+    {file = "botocore-1.14.14.tar.gz", hash = "sha256:6570f2ba046956d5b548ab2346d32f713ecf8b8cb098a839d73fcf832ccfa223"},
 ]
 braceexpand = [
     {file = "braceexpand-0.1.5-py2.py3-none-any.whl", hash = "sha256:ae6b7de1e88d3132177bd6cbda8b22487ea645b25c4ca5b1cf948b326ac27e34"},
@@ -1594,8 +1597,8 @@ django-decorator-include = [
     {file = "django_decorator_include-1.4.1-py2.py3-none-any.whl", hash = "sha256:5514ab61381613959b40321dc97daca3e0449b04b65dac8373534a030f1238fc"},
 ]
 django-extensions = [
-    {file = "django-extensions-2.2.7.tar.gz", hash = "sha256:12064d2f7301b2092639e8cccfc53927966a4967f6e841b4a6be220083f37d3a"},
-    {file = "django_extensions-2.2.7-py2.py3-none-any.whl", hash = "sha256:85adae2a91ebfa67b5b5d1b5d35a3bb2452663de812347b981a37092fb35290b"},
+    {file = "django-extensions-2.2.8.tar.gz", hash = "sha256:2699cc1d6fb4bd393c0b5832fea4bc685f2ace5800b3c9ff222b2080f161ac04"},
+    {file = "django_extensions-2.2.8-py2.py3-none-any.whl", hash = "sha256:1a03c4e8bade575f8c2be6c76456f8a2be3f9b02ab9f47d3535afa9562dc0493"},
 ]
 django-honeypot = [
     {file = "django-honeypot-0.7.0.tar.gz", hash = "sha256:04de2778c60532d664efa1c271e2cee889fb01b1cb8c8934759f879315ce825f"},
@@ -1859,8 +1862,8 @@ pathspec = [
     {file = "pathspec-0.7.0.tar.gz", hash = "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"},
 ]
 pluggy = [
-    {file = "pluggy-0.7.1-py2.py3-none-any.whl", hash = "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1"},
-    {file = "pluggy-0.7.1.tar.gz", hash = "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"},
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 polib = [
     {file = "polib-1.1.0-py2.py3-none-any.whl", hash = "sha256:93b730477c16380c9a96726c54016822ff81acfa553977fdd131f2b90ba858d7"},
@@ -1917,8 +1920,8 @@ pyquery = [
     {file = "pyquery-1.4.1.tar.gz", hash = "sha256:8fcf77c72e3d602ce10a0bd4e65f57f0945c18e15627e49130c27172d4939d98"},
 ]
 pytest = [
-    {file = "pytest-3.6.4-py2.py3-none-any.whl", hash = "sha256:952c0389db115437f966c4c2079ae9d54714b9455190e56acebe14e8c38a7efa"},
-    {file = "pytest-3.6.4.tar.gz", hash = "sha256:341ec10361b64a24accaec3c7ba5f7d5ee1ca4cebea30f76fad3dd12db9f0541"},
+    {file = "pytest-3.10.1-py2.py3-none-any.whl", hash = "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec"},
+    {file = "pytest-3.10.1.tar.gz", hash = "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"},
 ]
 pytest-base-url = [
     {file = "pytest-base-url-1.4.1.tar.gz", hash = "sha256:7425e8163345494ac7f544e99c6f3e5a08f4228bee5e26013b98c462a4d31f6e"},
@@ -1937,8 +1940,8 @@ pytest-metadata = [
     {file = "pytest_metadata-1.8.0-py2.py3-none-any.whl", hash = "sha256:c29a1fb470424926c63154c1b632c02585f2ba4282932058a71d35295ff8c96d"},
 ]
 pytest-rerunfailures = [
-    {file = "pytest-rerunfailures-5.0.tar.gz", hash = "sha256:5601fcec1ae121a56c1b8b0f92e237aea9f701c3c274a8852c0a1dd7e04cfdf4"},
-    {file = "pytest_rerunfailures-5.0-py2.py3-none-any.whl", hash = "sha256:2ff8c6c1f490acafc6cc85ca1005420675680c52a5aada195ca71e48a1e1ceb7"},
+    {file = "pytest-rerunfailures-7.0.tar.gz", hash = "sha256:f3c9cf31339bf87b048c09dadb633a81156fa4899527fffc55cde105d04ed5fd"},
+    {file = "pytest_rerunfailures-7.0-py2.py3-none-any.whl", hash = "sha256:1180a0f98975e1e1a2e055c87c1159cbd3bace8ceb71b1e7ffe4ace6121e7801"},
 ]
 pytest-variables = [
     {file = "pytest-variables-1.9.0.tar.gz", hash = "sha256:f79851e4c92a94c93d3f1d02377b5ac97cc8800392e87d108d2cbfda774ecc2a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ newrelic = "^5.6.0.135"
 oauth2client = "^4.1.3"
 polib = "1.1.0"
 puente = "0.5.0"
-pytest = "~3.6"
+pytest = "~3.10"
 python-dateutil = "^2.8.0"
 python-decouple = "^3.3"
 python-magic = "0.4.15"
@@ -94,7 +94,7 @@ braceexpand = "^0.1.5"
 pytest-base-url = "^1.4.1"
 pytest-cov = "~2.8.1"
 pytest-metadata = "^1.8.0"
-pytest-rerunfailures = "^5.0"
+pytest-rerunfailures = "^7.0"
 pytest-variables = "^1.9.0"
 
 # From linting.txt
@@ -105,13 +105,13 @@ flake8-import-order = "^0.18.1"
 # Pinned Dependencies
 coverage = {extras = ["toml"], version = "^5"} # Use optional toml support
 
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
 [tool.coverage.run]
 source = ["kuma"]
 branch = true
 
 [tool.coverage.report]
 omit = ["*migrations*", "*/management/commands/*"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Pytest:

  - Updating pytest (3.6.4 -> 3.10.1)
    Follows SemVer, and all of our tests pass
    https://github.com/pytest-dev/pytest/blob/3.10.1/CHANGELOG.rst

  - Updating pluggy (0.7.1 -> 0.13.1)
    Dependency of pytest, not used directly
    https://github.com/pytest-dev/pluggy/blob/0.13.1/CHANGELOG.rst

  - Updating pytest-rerunfailures (5.0 -> 7.0)
    No changes aside from changes to supported python / pytest versions
    https://github.com/pytest-dev/pytest-rerunfailures/blob/7.0/CHANGES.rst

AWS treadmill:

  - Updating botocore (1.14.13 -> 1.14.14)
    https://github.com/boto/botocore/blob/1.14.14/CHANGELOG.rst

  - Updating boto3 (1.11.13 -> 1.11.14)
    https://github.com/boto/boto3/blob/1.11.14/CHANGELOG.rst

Other:

  - Updating django-extensions (2.2.7 -> 2.2.8)
    Only a translation update
    https://github.com/django-extensions/django-extensions/blob/2.2.8/CHANGELOG.md