### PR TITLE
Add unified git-style diff feature to revise script

### DIFF
--- a/kuma/wiki/views/utils.py
+++ b/kuma/wiki/views/utils.py
@@ -1,4 +1,7 @@
 import hashlib
+from calendar import timegm
+
+from django.utils.http import http_date
 
 
 def split_slug(slug):
@@ -50,3 +53,7 @@ def document_form_initial(document):
 
 def calculate_etag(content):
     return hashlib.md5(content.encode()).hexdigest()
+
+
+def get_last_modified_header(dt):
+    return http_date(timegm(dt.utctimetuple()))

--- a/scripts/revise/README.md
+++ b/scripts/revise/README.md
@@ -37,6 +37,11 @@ macros:
         - geckoRelease
         - Note
 ```
+- Create and configure your **API token**. If you don't, your `revise commit` command will complain.
+    - Create a new token for yourself via the Django admin
+    - Copy the token and inform `revise` in one of two ways:
+        - via the `MDN_REVISE_TOKEN` environment variable
+        - save it in `$HOME/.revise/token`
 
 ### Render
 - `cd js-docs`
@@ -72,6 +77,13 @@ macros:
 
 - You can also remove your selected macros (the ones listed under the `remove` section of your configuration file) from your selected douments using the `revise remove` command.
 - It will create the same kinds of files (`rev.html`, `ref.html`, and `metadata.yaml`) for each of your selected documents, but of course this time it will remove any trace of each of your selected macros from each of your selected documents (without committing the results, of course).
+
+### Diff
+
+- After running `revise remove` or `revise render` you'll probably want to visually check the differences between each of the `rev.html` and `ref.html` pairs in your results directory. You can do this using `revise diff <results-dir>` or in this case `revise commit results`.
+- It uses `git diff`, so assumes you have `git` installed.
+- By default it paginates the results (i.e., the results are piped into `less`) so you can view a page of differences at a time. Remember that each time you reach the end of the differences for a pair of files, you can use the `q` command to move to the differences for the next pair of files.
+- If you'd prefer to see all the differences for all pairs of files at once, you can use `revise diff --no-pager <results-dir>`.
 
 ### Commit
 

--- a/scripts/revise/revise.py
+++ b/scripts/revise/revise.py
@@ -119,13 +119,13 @@ def do_commit(dir, token, log):
         metadata = get_metadata(rev.with_name("metadata.yaml"), log)
         if not metadata:
             continue
-        etag = metadata["etag"]
+        last_modified = metadata["last_modified"]
         parts = urlsplit(metadata["url"])
         doc = parts.path
         url = urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
         headers = {
-            "If-Match": etag,
             "Authorization": f"Token {token}",
+            "If-Unmodified-Since": last_modified,
         }
         try:
             with rev.open() as f:
@@ -179,7 +179,8 @@ def do_edit(cmd, config_path, output_dir, log):
         rev_url = f"{ref_url}?{qs}"
 
         try:
-            ref_text, rev_text, etag = get_ref_and_rev(ref_url, rev_url)
+            ref_text, rev_text, last_modified = get_ref_and_rev(ref_url,
+                                                                rev_url)
         except requests.HTTPError as e:
             log(f"error: while getting data for {doc} ({str(e)})", fg="red")
             continue
@@ -207,7 +208,7 @@ def do_edit(cmd, config_path, output_dir, log):
 
         log(f"- {metadata_path}")
         with metadata_path.open("w") as f:
-            yaml.dump(dict(url=rev_url, etag=etag), f)
+            yaml.dump(dict(url=rev_url, last_modified=last_modified), f)
 
 
 def get_ref_and_rev(ref_url, rev_url):
@@ -215,12 +216,12 @@ def get_ref_and_rev(ref_url, rev_url):
     while not done:
         ref_resp = get(ref_url)
         ref_resp.raise_for_status()
-        ref_etag = ref_resp.headers.get("etag")
+        ref_last_modified = ref_resp.headers.get("last-modified")
         rev_resp = get(rev_url)
         rev_resp.raise_for_status()
-        rev_etag = rev_resp.headers.get("etag")
-        done = ref_etag == rev_etag
-    return (ref_resp.text, rev_resp.text, rev_etag)
+        rev_last_modified = rev_resp.headers.get("last-modified")
+        done = ref_last_modified == rev_last_modified
+    return (ref_resp.text, rev_resp.text, rev_last_modified)
 
 
 def get_fresh_output_dir(output_dir):
@@ -261,7 +262,7 @@ def get_metadata(path, log):
     except (OSError, yaml.YAMLError) as e:
         log(f"error: {str(e)}", fg="red")
         return None
-    for k in ("etag", "url"):
+    for k in ("last_modified", "url"):
         if not metadata.get(k):
             log(f'error: {path} has no "{k}" key or its value is empty', fg="red")
             return None


### PR DESCRIPTION
Fixes #6389 
 
Provides the following:
- Unified git-style diff of a results directory
- Uses the `Last-Modified`/`If-Unmodified-Since` headers instead of the `ETag`/`If-Match` headers for avoiding revision collisions, only to avoid issues associated with the `ETag` header (strong vs. weak, and that CloudFront strips the `ETag` header from responses handled by behaviors that do compression)
- Ensures that the wiki domain is used for requests even if the read-only domain is specified for the `site`
- Updated `scripts/revise/README.md` documentation

I did this on my own time (i.e., outside of sprint time) in order to get this feature to @wbamberg, @ddbeck, and @Elchi3 as quickly as possible.