### PR TITLE
Remove deprecated wiki test

### DIFF
--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -1298,24 +1298,6 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         assert doc("article#wikiArticle h1").text() == "Test Content"
 
-    @pytest.mark.xfail(reason="broken test")
-    def test_preview_locale(self):
-        """Preview the wiki syntax content."""
-        # Create a test document and translation.
-        d = _create_document()
-        _create_document(title="Prueba", parent=d, locale="es")
-        # Preview content that links to it and verify link is in locale.
-        url = reverse("wiki.preview", locale="es")
-        response = self.client.post(
-            url, {"content": "[[Test Document]]"}, HTTP_HOST=settings.WIKI_HOST
-        )
-        assert response.status_code == 200
-        assert_no_cache_header(response)
-        doc = pq(response.content)
-        link = doc("#doc-content a")
-        assert link.text() == "Prueba"
-        assert "/es/docs/prueba" == link[0].attrib["href"]
-
 
 class SelectLocaleTests(UserTestCase, WikiTestCase):
     """Test the locale selection page"""


### PR DESCRIPTION
Our entire test suite has one test marked as an expected failure.
It's been that way for nine years.
The functionality it's meant to test no longer exists in Kuma.

More details:

Once upon a time, Kuma documents used wiki syntax, where double brackets
create linkes to `[[Article Titles]]`.

There was a bug with this: if you were editing a page in Spanish, and
inserted a link to `[[Foo]]`, then when you previewed the document the
rendered link would point to the English version of Foo, rather than the
Spanish one. See: https://bugzilla.mozilla.org/show_bug.cgi?id=609680

Nine years ago, Ricky Rosario fixed that bug:
https://github.com/mdn/kuma/commit/2168a9aed8fbead0228cd6191ba208d1abf0bc17

Seven months later, when Luke Crouch was implementing a new page editor
template (https://bugzilla.mozilla.org/show_bug.cgi?id=663408), he
overhauled or temporarily disabled many of the related unit tests:
https://github.com/mdn/kuma/commit/a247a31226dae9462025079396e973cf106af941

The following week, he implemented the new design for the editing
preview page (https://bugzilla.mozilla.org/show_bug.cgi?id=664327),
re-enabling ArticlePreviewTests in the process. However, one test was
marked with SkipTest: Ricky's test_preview_locale.
https://github.com/mdn/kuma/commit/ef76c19d9a88e9ae7a3b8c27ca558150c9309fe1

That was in June, 2011.

Four and a half years later, Will Kahn-Greene switched MDN from nose to
pytest as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1239830.

When doing so, he changed various SkipTests to xfail, reasoning in
January of 2016 that an xfail is "closer to what they are (i.e. 'This
thing fails and we don't know why--look at it later')."
https://github.com/mdn/kuma/commit/5d21d34d10b8a3469e579da3a7b239eb4ce1b762

And now here we are in February, 2020, and that xfail is still there.

No more.