### PR TITLE
Small Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
 
         - name: "JavaScript Lints"
           language: node_js
-          node_js: 10
+          node_js: 12
           cache: npm
           script:
             - scripts/ci-jslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ branches:
     only:
         - master
 language: minimal
-services:
-    - docker
 matrix:
     include:
         - language: python
@@ -30,6 +28,7 @@ matrix:
         - language: python
           name: "Python testing"
           python: 3.8
+          services: docker
           env:
             UID=0
             DOCKER_COMPOSE_VERSION=1.23.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ matrix:
           name: "Documentation"
           python: 3.8
           cache: pip
+          install:
+            - pip install -r docs/requirements.txt
           script:
-            - scripts/ci-docs
+            - sphinx-build -b html -d doctrees docs html
         - language: python
           name: "Python linting"
           python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,12 @@ language: minimal
 git: { submodules: false }
 jobs:
     include:
-        - name: "Documentation"
-          language: python
-          python: 3.8
-          cache: pip
-          install:
-            - pip install -r docs/requirements.txt
+        - stage: "Lint"
+          name: "General Lints"
           script:
-            - sphinx-build -b html -d doctrees docs html
-        - name: "Python linting"
+            - "! git grep -n '^<<<<<<< '"  # Check for Git conflict markers
+
+        - name: "Python Lints"
           language: python
           python: 3.8
           cache: pip
@@ -20,12 +17,28 @@ jobs:
               pip install --disable-pip-version-check
               black flake8 flake8-import-order
           script:
-            - "! git grep -n '^<<<<<<< '"  # Check for Git conflict markers
             - flake8 kuma docs tests
             - black --check --diff kuma docs tests
-        - name: "Python testing"
+
+        - name: "JavaScript Lints"
+          language: node_js
+          node_js: 10
+          cache: npm
+          script:
+            - scripts/ci-jslint
+            - scripts/ci-flow
+
+        - stage: "Test"
+          name: "Documentation Build"
           language: python
           python: 3.8
+          cache: pip
+          install:
+            - pip install -r docs/requirements.txt
+          script:
+            - sphinx-build -b html -d doctrees docs html
+
+        - name: "Dockerized Tests"
           services: docker
           git: { submodules: true }
           env:
@@ -42,10 +55,3 @@ jobs:
             - scripts/ci-jest
             - scripts/ci-localerefresh
             - bash <(curl -s https://codecov.io/bash)
-        - name: "Javascript linting"
-          language: node_js
-          node_js: 10
-          cache: npm
-          script:
-            - scripts/ci-jslint
-            - scripts/ci-flow

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ jobs:
           language: python
           python: 3.8
           cache: pip
+          install:
+            - >-
+              pip install --disable-pip-version-check
+              black flake8 flake8-import-order
           script:
-            - set -x
             # Make sure there are no left-over git patch markers in
             - git --no-pager grep '>>>>>>>'
-            - pip install poetry~=1.0.0b9
-            - poetry --version
-            - poetry install -vv
-            - poetry run flake8 kuma docs tests
-            - poetry run black --check --diff kuma docs tests
+            - flake8 kuma docs tests
+            - black --check --diff kuma docs tests
         - name: "Python testing"
           language: python
           python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 branches:
     only:
         - master
-language: python
-python:
-    - "3.8"
+language: minimal
 services:
     - docker
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
     only:
         - master
 language: minimal
+git: { submodules: false }
 matrix:
     include:
         - language: python
@@ -29,6 +30,7 @@ matrix:
           name: "Python testing"
           python: 3.8
           services: docker
+          git: { submodules: true }
           env:
             UID=0
             DOCKER_COMPOSE_VERSION=1.23.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-branches:
-    only:
-        - master
+branches: master
 language: minimal
 git: { submodules: false }
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
         - master
 language: minimal
 git: { submodules: false }
-matrix:
+jobs:
     include:
         - name: "Documentation"
           language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ language: minimal
 git: { submodules: false }
 matrix:
     include:
-        - language: python
-          name: "Documentation"
+        - name: "Documentation"
+          language: python
           python: 3.8
           cache: pip
           install:
             - pip install -r docs/requirements.txt
           script:
             - sphinx-build -b html -d doctrees docs html
-        - language: python
-          name: "Python linting"
+        - name: "Python linting"
+          language: python
           python: 3.8
           cache: pip
           script:
@@ -26,8 +26,8 @@ matrix:
             - poetry install -vv
             - poetry run flake8 kuma docs tests
             - poetry run black --check --diff kuma docs tests
-        - language: python
-          name: "Python testing"
+        - name: "Python testing"
+          language: python
           python: 3.8
           services: docker
           git: { submodules: true }
@@ -45,8 +45,8 @@ matrix:
             - scripts/ci-jest
             - scripts/ci-localerefresh
             - bash <(curl -s https://codecov.io/bash)
-        - language: node_js
-          name: "Javascript linting"
+        - name: "Javascript linting"
+          language: node_js
           node_js: 10
           cache: npm
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ jobs:
               pip install --disable-pip-version-check
               black flake8 flake8-import-order
           script:
-            # Make sure there are no left-over git patch markers in
-            - git --no-pager grep '>>>>>>>'
+            - "! git grep -n '^<<<<<<< '"  # Check for Git conflict markers
             - flake8 kuma docs tests
             - black --check --diff kuma docs tests
         - name: "Python testing"

--- a/scripts/ci-docs
+++ b/scripts/ci-docs
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e  # Exit on non-zero status
-set -u  # Treat unset variables as an error
-
-pip install -r docs/requirements.txt
-sphinx-build -b html -d doctrees docs html

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -44,6 +44,6 @@ docker-compose exec -T web make clean
 docker-compose exec -T web make localecompile
 docker-compose exec -T web make build-static
 docker-compose exec -T web ./manage.py migrate
-docker-compose exec -T web make coveragetest
 # This checks that running `./manage.py makemigrations` wasn't forgotten
 docker-compose exec -T web ./manage.py makemigrations --check --dry-run
+docker-compose exec -T web make coveragetest

--- a/test.txt
+++ b/test.txt
@@ -1,5 +1,0 @@
-<<<<<<< HEAD
-Hello World
-=======
-test
->>>>>>> initial commit

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,5 @@
+<<<<<<< HEAD
+Hello World
+=======
+test
+>>>>>>> initial commit


### PR DESCRIPTION
Small tweaks to our Travis config.

Notable changes:

1. Python linting is 75% faster (3:10 -> 1:20)
2. Two stages: lint then test.
3. Checks for missing migrations before starting the test suite, so you get earlier feedback there.
4. Fixes a broken lint for git conflict markers
5. Uses Node 12 for JS lints, just like our Docker images

There's still lots to do (our docker tests can still take 18 minutes to run and we're not doing anything to parallelize them), but this at least gets us in a better position to start addressing that.

Plus, having a separate linting stage lets us fail fast and freeing up Travis capacity for other in-flight pull requests, instead of always blocking everything for a further 15 minutes while the test suite runs.

I've also migrated us from using Travis via Webhooks to using the GitHub Checks API. This makes the Travis output more accessible (see the "Checks" tab above this pull request!)