### PR TITLE
Re-enable stripe subscription form when modal is closed

### DIFF
--- a/kuma/static/js/stripe-subscription.js
+++ b/kuma/static/js/stripe-subscription.js
@@ -36,11 +36,17 @@
         token: function(response) {
             stripeTokenInput.value = response.id;
             stripeForm.submit();
+        },
+        closed: function() {
+            if (!stripeTokenInput.value) {
+                stripeForm.classList.remove('disabled');
+            }
         }
     });
 
     stripeForm.addEventListener('submit', function(e) {
         if (!stripeTokenInput.value) {
+            this.classList.add('disabled');
             handler.open();
             e.preventDefault();
         }


### PR DESCRIPTION
Fixes #6472 

I also had to add code to re-disable the form when the form is submitted again, after the modal has been closed once. The original jQuery code sets some semi-hidden data, that I could only access if I made the code jQuery dependent:
https://github.com/mdn/kuma/blob/master/kuma/static/js/main.js#L69

I decided adding a line for explicitly disabling the form is the lesser evil.

## How to test it
1. Enable Stripe in Kuma: https://kuma.readthedocs.io/en/latest/installation.html#enable-stripe-payments-optional
2. Sign-in/up as a staff user (or make a user staff through Django Admin)
3. Go to user edit and scroll to the bottom
4. (optional) if you want to go through the flow again there's multiple options
   1. delete your user (can also be found in user edit)
   1. run `docker-compose exec web python manage.py shell -c "from kuma.users.models import User; User.objects.filter(username='<YOUR_USERNAME>').update(stripe_customer_id='')"`
   1. go into the database and unset the stripe_customer_id