### PR TITLE
delete user with AttachmentRevisions

### DIFF
--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1611,9 +1611,6 @@ def test_delete_user_no_revisions_but_attachment_revisions_donate(
     The user didn't have any revisions to confront the legacy of, but there might be
     other things attached to the user.
     """
-    other_user = django_user_model.objects.create(
-        username="other", email="other@example.com"
-    )
     assert not Revision.objects.filter(creator=wiki_user).exists()
 
     attachment_revision = AttachmentRevision(

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1601,6 +1601,48 @@ def test_delete_user_keep_attributions(
     assert not Key.objects.all().exists()
 
 
+def test_delete_user_no_revisions_but_attachment_revisions_donate(
+    db, user_client, wiki_user, django_user_model
+):
+    """
+    This test is based on the bug report
+    https://github.com/mdn/kuma/issues/6479
+
+    The user didn't have any revisions to confront the legacy of, but there might be
+    other things attached to the user.
+    """
+    other_user = django_user_model.objects.create(
+        username="other", email="other@example.com"
+    )
+    assert not Revision.objects.filter(creator=wiki_user).update(creator=other_user)
+
+    attachment_revision = AttachmentRevision(
+        attachment=Attachment.objects.create(title="test attachment"),
+        file="some/path.ext",
+        mime_type="application/kuma",
+        creator=wiki_user,
+        title="test attachment",
+    )
+    attachment_revision.save()
+    url = reverse("users.user_delete", kwargs={"username": wiki_user.username})
+    response = user_client.post(url, HTTP_HOST=settings.WIKI_HOST)
+    # This means it didn't work! The form rejects.
+    assert response.status_code == 200
+
+    # Ok, let's donate the attachment revisions to "Anonymous"
+    response = user_client.post(
+        url, {"attributions": "donate"}, HTTP_HOST=settings.WIKI_HOST
+    )
+    # This means it didn't work! The form rejects.
+    assert response.status_code == 302
+
+    with pytest.raises(User.DoesNotExist):
+        wiki_user.refresh_from_db()
+
+    attachment_revision.refresh_from_db()
+    assert attachment_revision.creator.username == "Anonymous"
+
+
 @pytest.mark.parametrize(
     "email, expected_status",
     [("test@example.com", 302), ("not an email", 400)],

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1614,7 +1614,7 @@ def test_delete_user_no_revisions_but_attachment_revisions_donate(
     other_user = django_user_model.objects.create(
         username="other", email="other@example.com"
     )
-    assert not Revision.objects.filter(creator=wiki_user).update(creator=other_user)
+    assert not Revision.objects.filter(creator=wiki_user).exists()
 
     attachment_revision = AttachmentRevision(
         attachment=Attachment.objects.create(title="test attachment"),
@@ -1633,7 +1633,7 @@ def test_delete_user_no_revisions_but_attachment_revisions_donate(
     response = user_client.post(
         url, {"attributions": "donate"}, HTTP_HOST=settings.WIKI_HOST
     )
-    # This means it didn't work! The form rejects.
+    # This means it worked! The user's attributions have been donated to the Anonymous user.
     assert response.status_code == 302
 
     with pytest.raises(User.DoesNotExist):


### PR DESCRIPTION
Part of #6479

And CC @escattone 

This PR is only half the solution to #6479. Basically, our strategy is to confront the user, if they had revisions, so that they have to make a decision about them. Great. However, a user might not have done any DOCUMENT revisions. They might just have ATTACHMENT revisions. As in the case with [Gregor on Stage](https://sentry.prod.mozaws.net/operations/mdn-stage/issues/7271436/).

This PR just protects the Django side of things so the error can't happen. If you have EITHER document OR attachment revisions you now need to have a POST variable `attributions`. 

Once this is merge (or, can I perhaps start on it already??) I'll make it so that the two UIs (I hate that we have to maintain this in two different places!) doesn't decide whether or not to show the "What do do with you contributions" form piece only on the *document* revisions. 