### PR TITLE
Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,5 @@ indent_size = 4
 indent_size = 2
 
 # git and Makefile use the superior tabs
-[.git*,Makefile,make.bat]
+[{.git*,Makefile,make.bat}]
 indent_style = tab


### PR DESCRIPTION
Sections headers act like shell globs.

To match multiple patterns, you must wrap them in curly braces.