### PR TITLE
Add noindex for the whole wiki but allow it in robots.txt

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -11,13 +11,7 @@
   <title>{% block title %}{{ _('MDN Web Docs') }}{% endblock %}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content=
-    {%- if request.get_host() in settings.ALLOW_ROBOTS_WEB_DOMAINS -%}
-        "{% block robots_value%}index, follow{% endblock %}"
-    {%- else -%}
-        "noindex, nofollow"
-    {%- endif -%}
-  >
+  <meta name="robots" content="noindex, nofollow">
 
   {% include "includes/preload.html" %}
 

--- a/kuma/attachments/jinja2/attachments/edit_attachment.html
+++ b/kuma/attachments/jinja2/attachments/edit_attachment.html
@@ -2,7 +2,6 @@
 {# L10n: 'title' is the title of the document. #}
 {% set title = _('Attachments | %(title)s', title=document.title) %}
 {% block title %}{{ page_title(document.title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 {% from 'includes/common_macros.html' import li_field %}
 {% from "includes/error_list.html" import errorlist %}

--- a/kuma/dashboards/jinja2/dashboards/macros.html
+++ b/kuma/dashboards/jinja2/dashboards/macros.html
@@ -4,7 +4,6 @@
 {% set github_macro_list = "https://github.com/mdn/kumascript/tree/master/macros/" %}
 {% set github_macro_view_prefix = "https://github.com/mdn/kumascript/blob/master/macros/" %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}
 <h1>{{ title }}</h1>

--- a/kuma/dashboards/jinja2/dashboards/revisions.html
+++ b/kuma/dashboards/jinja2/dashboards/revisions.html
@@ -4,7 +4,6 @@
 {% set classes = 'compare' %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block document_head %}
   <!-- heading -->

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -3,7 +3,6 @@
 {% set title = _('Spam Dashboard') %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% set stat_ids=(('spam_viewers_change', '% Change', 'rate'),
                  ('spam_viewers', 'Spam Viewers', 'data'),

--- a/kuma/landing/jinja2/landing/maintenance-mode.html
+++ b/kuma/landing/jinja2/landing/maintenance-mode.html
@@ -3,7 +3,6 @@
 {% set styles = ('maintenance-mode',) %}
 
 {% block title %}{{ page_title(_('Maintenance Mode')) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}
 

--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -17,8 +17,6 @@
   {% endif %}
 {% endblock %}
 
-{% block robots_value %}noindex, nofollow{% endblock %}
-
 {% block bodyclass %}search-results search-results-no-demo search-navigator-flush{% endblock %}
 
 {% macro doc_block(doc, index) -%}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1140,7 +1140,11 @@ ENABLE_RESTRICTIONS_BY_HOST = config(
 # Allow robots, but restrict some paths
 # If the domain is a CDN, the CDN origin should be included.
 ALLOW_ROBOTS_WEB_DOMAINS = set(
-    config("ALLOW_ROBOTS_WEB_DOMAINS", default="developer.mozilla.org", cast=Csv())
+    config(
+        "ALLOW_ROBOTS_WEB_DOMAINS",
+        default="developer.mozilla.org,wiki.developer.mozilla.org",
+        cast=Csv(),
+    )
 )
 
 # Allow robots, no path restrictions

--- a/kuma/users/jinja2/users/ban_user_and_cleanup.html
+++ b/kuma/users/jinja2/users/ban_user_and_cleanup.html
@@ -5,7 +5,6 @@
 {% block bodyclass %}user ban-user{% endblock %}
 
 {% block title %}{{ _('Ban %(user)s', user=detail_user) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set styles = ('dashboards', 'jquery-ui') %}
 {% set classes = 'compare' %}
 

--- a/kuma/users/jinja2/users/ban_user_and_cleanup_summary.html
+++ b/kuma/users/jinja2/users/ban_user_and_cleanup_summary.html
@@ -5,7 +5,6 @@
 {% block bodyclass %}user ban-user{% endblock %}
 
 {% block title %}{{ _('Ban %(user)s', user=detail_user) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set styles = ('dashboards', 'jquery-ui') %}
 {% set classes = 'compare' %}
 

--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -8,7 +8,6 @@
 {% block bodyclass %}user user-display{% endblock %}
 
 {% block title %}{{ page_title(detail_user) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}
   {{ super() }}

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -9,7 +9,6 @@
 {% block bodyclass %}user user-edit{% endblock %}
 
 {% block title %}{{ page_title(_('Edit Your Profile')) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}
   {{ super() }}

--- a/kuma/wiki/jinja2/wiki/compare_revisions.html
+++ b/kuma/wiki/jinja2/wiki/compare_revisions.html
@@ -3,7 +3,6 @@
 
 {% set title = _('Compare Revisions | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'compare' %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/confirm_document_delete.html
+++ b/kuma/wiki/jinja2/wiki/confirm_document_delete.html
@@ -1,7 +1,6 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/document_macros.html" import build_document_crumbs with context %}
 {% block title %}{{ page_title(_('Delete Document | %(document)s', document=document.title)) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% block content %}
 
   <article class="delete-document">

--- a/kuma/wiki/jinja2/wiki/confirm_purge.html
+++ b/kuma/wiki/jinja2/wiki/confirm_purge.html
@@ -1,6 +1,5 @@
 {% extends "wiki/base.html" %}
 {% block title %}{{ page_title(_('Purge Document | %(document)s', document=document.title)) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% block content %}
 
   <article>

--- a/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
@@ -1,7 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revert Revision | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass %}revert-document{% endblock %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/create.html
+++ b/kuma/wiki/jinja2/wiki/create.html
@@ -4,7 +4,6 @@
 {% from "includes/common_macros.html" import content_editor %}
 {% set title = _('Create a New Article') %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'new' %}
 {% block bodyclass %}new{% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -38,14 +38,6 @@
   {% set content_class = 'column-main' %}
 {% endif %}
 
-{% block robots_value %}
-  {%- if document.is_experiment or document.has_legacy_namespace or fallback_reason or not document_html -%}
-    noindex, nofollow
-  {%- else -%}
-    {{ super() }}
-  {%- endif -%}
-{% endblock %}
-
 {% block bodyclass %}document{% endblock %}
 {% block body_attributes %}data-slug="{{ document.slug }}" contextmenu="edit-history-menu" data-search-url="{{ search_url }}"{% endblock body_attributes %}
 

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -3,7 +3,6 @@
 {% from 'wiki/includes/page_buttons.html' import page_buttons %}
 
 {% block title %}{{ page_title(_('%(title)s | Edit Article', title=document.title)) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% set classes = 'edit' %}
 {% block bodyclass %}edit{% endblock %}

--- a/kuma/wiki/jinja2/wiki/list/documents.html
+++ b/kuma/wiki/jinja2/wiki/list/documents.html
@@ -12,7 +12,6 @@
   {% set title = _('All documents') %}
 {% endif %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set crumbs = [(None, title)] %}
 
 {% block extrahead %}

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -1,7 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revision History | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}
     {{ super() }}

--- a/kuma/wiki/jinja2/wiki/move.html
+++ b/kuma/wiki/jinja2/wiki/move.html
@@ -1,7 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Move Article | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass %}move-page{% endblock %}
 
 {% block site_css %}

--- a/kuma/wiki/jinja2/wiki/preview.html
+++ b/kuma/wiki/jinja2/wiki/preview.html
@@ -1,6 +1,5 @@
 {% extends "wiki/base.html" %}
 {% block title %}{{ title }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 {% block bodyclass %}document{% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -1,7 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revision %(id)s | %(title)s', id=revision.id, title=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -6,7 +6,6 @@
 
 {% set title = _('Translate Article | %(document)s', document=parent.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass%}translate{% endblock %}
 
 {% block extrahead %}


### PR DESCRIPTION
Fixes #6340

Sets `noindex, nofollow` for all wiki pages, hence also removes the block from all those jinja files. That also contained a check for `has_legacy_namespace` so I removed all related code. But I'm not super sure about that change, maybe there's future use for it?