### PR TITLE
--slugsearch was wrong

### DIFF
--- a/kuma/wiki/management/commands/render_document.py
+++ b/kuma/wiki/management/commands/render_document.py
@@ -103,13 +103,13 @@ class Command(BaseCommand):
                 docs = docs.exclude(locale=options["not_locale"])
             if options["slugsearch"]:
                 if options["slugsearch"].endswith("*"):
-                    docs = docs.exclude(
+                    docs = docs.filter(
                         slug__startswith=options["slugsearch"].rstrip("*")
                     )
                 elif "*" in options["slugsearch"]:
                     raise NotImplementedError("* can only be on the end")
                 else:
-                    docs = docs.exclude(slug__contains=options["slugsearch"])
+                    docs = docs.filter(slug__contains=options["slugsearch"])
             docs = docs.order_by("-modified")
             docs = docs.values_list("id", flat=True)
 


### PR DESCRIPTION
I know it was my PR that introduced the `--slugsearch` and I said you didn't need to scrutinize it because it's not super important. 
Honestly, I don't know how it happened. I used to copy and paste this into `render_document.py` so I could re-render a subset. Don't know how I managed to mix up the `exclude` and `filter`. 
Because of my mistake I accidentally triggered `docker-compose exec web ./manage.py render_document --all --slugsearch=MDN/Jobs` and that caused re-render of 99% of the documents in my local db. Not the 1% I was interested in. 