### PR TITLE
take it easy npm update in ci

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -112,6 +112,8 @@ RUN mkdir /tools \
     && chmod 775 /tools
 WORKDIR /tools
 USER kuma
+# So that npm doesn't try to suggest we upgrade itself.
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 RUN ln -s /app/package.json /tools \
     && ln -s /app/package-lock.json /tools \
     && npm ci


### PR DESCRIPTION
Part of #6505

This takes away npm trying to announce that it can be upgraded. No more `npm update check failed` mentions in the CI logs. 

No idea if it has any impact on the build speed. 