### PR TITLE
Show username for keep attribution option

### DIFF
--- a/kuma/users/jinja2/users/includes/delete-user-content.html
+++ b/kuma/users/jinja2/users/includes/delete-user-content.html
@@ -7,7 +7,20 @@
             <p>{{ _('Deleting your account loses any preferences you have set.') }}</p>
             <p>{{ _('Although we can delete your account, any revisions you have made to pages on MDN will remain. Please select how would like us to handle the attribution for your changes.') }}</p>
             {{ form.attributions.errors }}
-            {{ form.attributions }}
+            <ul>
+                {% for field in form.attributions %}
+                    <li>
+                        <label for="{{ field.id_for_label }}">
+                            {{ field.tag() }}
+                            {% if "Anonymous" not in field.choice_label %}
+                                {{ field.choice_label }} ({{ username }})
+                            {% else %}
+                                {{ field.choice_label }}
+                            {% endif %}
+                        </label>
+                    </li>
+                {% endfor %}
+            </ul>
         {% else %}
             <p>{{ _('Deleting your account loses any preferences you have set, as well as makes your username available for others to use.') }}</p>
         {% endif %}


### PR DESCRIPTION
This shows the current user's username in parentheses next to the "Keep my attribution for my page changes" string

![Screenshot 2020-02-17 at 21 19 36](https://user-images.githubusercontent.com/10350960/74681342-d3b09f00-51cb-11ea-93a2-9088e82b1811.png)

Fix #6418 