### PR TITLE
Removes dynamic addition of checked class on user avatar

### DIFF
--- a/kuma/static/js/components/user-signup/signup.js
+++ b/kuma/static/js/components/user-signup/signup.js
@@ -36,9 +36,6 @@
             editContainer = document.getElementById('change-email-container');
             focusElement = editContainer.querySelector('label');
             showEditFields(staticContainer, editContainer, focusElement);
-        } else if (event.target.id === 'create-mdn-account') {
-            var mdnProfileImgContainer = document.querySelector('.mdn-profile');
-            mdnProfileImgContainer.classList.add('checked');
         }
     });
 


### PR DESCRIPTION
As decided in #6511 we no longer show the second checkmark on the user avatar during the sign up process. This PR simply removed the piece of JavaScript that was responsible for adding it.

Fix #6511 