### PR TITLE
Record which test functions cover each line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,9 +105,13 @@ target-version = ["py38"]
 [tool.coverage.run]
 source = ["kuma"]
 branch = true
+dynamic_context = "test_function"
 
 [tool.coverage.report]
 omit = ["*migrations*", "*/management/commands/*"]
+
+[tool.coverage.html]
+show_contexts = true
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Prior to this patch, our coverage reports only indicated whether a line
was covered or not. Now, they include additional metadata showing which
tests cover each line. Ned Batchelder calls this "Who Tests What:"
https://nedbatchelder.com/blog/201810/who_tests_what_is_here.html