### PR TITLE
Show username when deleting an account with edits

### DIFF
--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -204,17 +204,17 @@ class UserRecoveryEmailForm(forms.Form):
 
 
 class UserDeleteForm(forms.Form):
+    def __init__(self, *args, username, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    ATTRIBUTIONS_KEEP = "keep"
-    ATTRIBUTIONS_DONATE = "donate"
-    ATTRIBUTIONS_CHOICES = (
-        (ATTRIBUTIONS_KEEP, _("Keep my attribution for my page changes")),
-        (
-            ATTRIBUTIONS_DONATE,
-            _('Switch my attribution for my page changes to "Anonymous"'),
-        ),
-    )
+        choices = {
+            "keep": (
+                _("Keep my attribution for my page changes (%(username)s)")
+                % {"username": username}
+            ),
+            "donate": _('Switch my attribution for my page changes to "Anonymous"'),
+        }
 
-    attributions = forms.ChoiceField(
-        required=True, choices=ATTRIBUTIONS_CHOICES, widget=forms.widgets.RadioSelect()
-    )
+        self.fields["attributions"].choices = choices.items()
+
+    attributions = forms.ChoiceField(required=True, widget=forms.widgets.RadioSelect())

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -470,7 +470,7 @@ def user_edit(request, username):
         "edit_user": edit_user,
         "user_form": user_form,
         "username": user_form["username"].value(),
-        "form": UserDeleteForm(),
+        "form": UserDeleteForm(username=username),
         "revisions": revisions,
         "attachment_revisions": attachment_revisions,
         "subscription_info": retrieve_stripe_subscription_info(edit_user,),
@@ -548,7 +548,7 @@ def user_delete(request, username):
     if request.method == "POST":
         # If the user has no revisions there's not choices on the form.
         if revisions.exists() or attachment_revisions.exists():
-            form = UserDeleteForm(request.POST)
+            form = UserDeleteForm(request.POST, username=username)
             if form.is_valid():
                 if form.cleaned_data["attributions"] == "donate":
                     donate_attributions()
@@ -564,7 +564,7 @@ def user_delete(request, username):
             delete_user()
             return HttpResponseRedirect("/")
     else:
-        form = UserDeleteForm()
+        form = UserDeleteForm(username=username)
 
     context["form"] = form
     context["username"] = username


### PR DESCRIPTION
When a user deletes their account, we ask if we should retain or
anonymize their prior contributions to the Wiki. This change displays
their current username as part of the deletion / anonymization prompt.

Fixes #6418

Alternative approach to #6517