### PR TITLE
Update issue URL to link to templates

### DIFF
--- a/jinja2/500.html
+++ b/jinja2/500.html
@@ -32,7 +32,7 @@
       {%- endif %}
     {% endif %}
     <p>If you have additional information how to reproduce this problem, please
-    <a href="https://github.com/mdn/kuma/issues/new" rel="nofollow">file an issue.</a>
+    <a href="https://github.com/mdn/kuma/issues/new/choose" rel="nofollow">file an issue.</a>
     Thanks!</p>
 
     <p class="attrib"><small><a href="https://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>


### PR DESCRIPTION
fixes #6525 

Updates the URL https://github.com/mdn/kuma/issues/new/choose where users can choose an issue template.