### PR TITLE
Old payment management with new Stripe subscriptions

### DIFF
--- a/kuma/payments/jinja2/payments/management.html
+++ b/kuma/payments/jinja2/payments/management.html
@@ -22,7 +22,7 @@
     <div class="manage-payments">
         <article class="column-container">
             <header class="manage-payments-header">
-                <h1>{{_('Your MDN profile')}}</h1>
+                <h1>{{_('MDN subscription management')}}</h1>
             </header>
             <div>
                 <a href="{{ url('users.user_edit', username=user.username) }}" class="button neutral back">{% include 'includes/icons/arrows/arrow-left.svg' %} {{_('Back to profile')}}</a>

--- a/kuma/payments/jinja2/payments/management.html
+++ b/kuma/payments/jinja2/payments/management.html
@@ -92,7 +92,7 @@
                 <h3>{{_('Monthly Subscription')}}</h3>
                 <div class="bordered-info">
                     <span>
-                        {% trans url=url('recurring_payment_initial') %}
+                        {% trans url=url('users.user_edit', username=user.username) + '?has_stripe_error=False' %}
                             You have no active subscriptions.
                             Why not <a href="{{ url }}">set one up</a>?
                         {% endtrans %}
@@ -121,7 +121,5 @@
 {% endblock %}
 
 {% block js %}
-  {%- if contribution_enabled %}
     {% javascript 'payments' %}
-  {%- endif %}
 {% endblock %}

--- a/kuma/payments/jinja2/payments/management.html
+++ b/kuma/payments/jinja2/payments/management.html
@@ -92,7 +92,7 @@
                 <h3>{{_('Monthly Subscription')}}</h3>
                 <div class="bordered-info">
                     <span>
-                        {% trans url=url('users.user_edit', username=user.username) + '?has_stripe_error=False' %}
+                        {% trans url=url('users.user_edit', username=user.username)|urlparams(has_stripe_error=False) %}
                             You have no active subscriptions.
                             Why not <a href="{{ url }}">set one up</a>?
                         {% endtrans %}

--- a/kuma/payments/jinja2/payments/management.html
+++ b/kuma/payments/jinja2/payments/management.html
@@ -92,7 +92,7 @@
                 <h3>{{_('Monthly Subscription')}}</h3>
                 <div class="bordered-info">
                     <span>
-                        {% trans url=url('users.user_edit', username=user.username)|urlparams(has_stripe_error=False) %}
+                        {% trans url=url('users.user_edit', username=user.username)|urlparams('subscription') %}
                             You have no active subscriptions.
                             Why not <a href="{{ url }}">set one up</a>?
                         {% endtrans %}

--- a/kuma/payments/tests/test_utils.py
+++ b/kuma/payments/tests/test_utils.py
@@ -9,7 +9,7 @@ from kuma.payments.utils import (
 # Subset of data returned for customer
 # https://stripe.com/docs/api/customers/retrieve
 simple_customer_data = {
-    "sources": {"data": [{"card": {"last4": "0019"}}]},
+    "sources": {"data": [{"card": {"last4": "0019"}, "object": "source"}]},
     "subscriptions": {"data": [{"id": "sub_id", "plan": {"amount": 6400}}]},
 }
 

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -200,9 +200,8 @@ def test_recurring_payment_management_not_logged_in(enabled_, get, cancel_, clie
         "recurring_payment_management",
     ],
 )
-def test_redirect(db, client, endpoint, settings):
+def test_redirect(db, client, endpoint):
     """Redirect to the wiki domain if not already."""
-    settings.MDN_CONTRIBUTION = True
     url = reverse(endpoint)
     response = client.get(url)
     assert_redirect_to_wiki(response, url)

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -44,9 +44,16 @@ def get_stripe_customer_data(stripe_customer_id):
             customer["subscriptions"]["data"][0]["plan"]["amount"] / 100
         )
     if customer["sources"]["data"]:
-        stripe_data["stripe_card_last4"] = customer["sources"]["data"][0]["card"][
-            "last4"
-        ]
+        source = customer["sources"]["data"][0]
+        if source["object"] == "card":
+            card = source
+        elif source["object"] == "source":
+            card = source["card"]
+        else:
+            raise ValueError(
+                f"unexpected stripe customer source of type {source['object']!r}"
+            )
+        stripe_data["stripe_card_last4"] = card["last4"]
     return stripe_data
 
 

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -7,18 +7,9 @@ from .constants import CONTRIBUTION_BETA_FLAG, RECURRING_PAYMENT_BETA_FLAG
 stripe.api_key = settings.STRIPE_SECRET_KEY
 
 
-def enabled(request):
-    """Return True if contributions are enabled."""
-    return bool(settings.MDN_CONTRIBUTION)
-
-
 def popup_enabled(request):
     """Returns True if the popup is enabled for the user."""
-    return (
-        enabled(request)
-        and hasattr(request, "user")
-        and flag_is_active(request, CONTRIBUTION_BETA_FLAG)
-    )
+    return hasattr(request, "user") and flag_is_active(request, CONTRIBUTION_BETA_FLAG)
 
 
 def recurring_payment_enabled(request):

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -6,6 +6,7 @@ from django.http import Http404
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from stripe.error import StripeError
+from waffle.decorators import waffle_flag
 
 from kuma.core.decorators import ensure_wiki_domain, login_required
 
@@ -44,7 +45,7 @@ def payment_terms(request):
     return render(request, "payments/terms.html")
 
 
-@skip_if_disabled
+@waffle_flag("subscription")
 @ensure_wiki_domain
 @login_required
 @never_cache

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -1,8 +1,6 @@
 import logging
-from functools import wraps
 
 from django.conf import settings
-from django.http import Http404
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from stripe.error import StripeError

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -12,33 +12,20 @@ from kuma.core.decorators import ensure_wiki_domain, login_required
 
 from .utils import (
     cancel_stripe_customer_subscription,
-    enabled,
     get_stripe_customer_data,
 )
 
 log = logging.getLogger("kuma.payments.views")
 
 
-def skip_if_disabled(func):
-    """If contributions are not enabled, then 404."""
-
-    @wraps(func)
-    def wrapped(request, *args, **kwargs):
-        if enabled(request):
-            return func(request, *args, **kwargs)
-        raise Http404
-
-    return wrapped
-
-
-@skip_if_disabled
+@waffle_flag("subscription")
 @ensure_wiki_domain
 @never_cache
 def contribute(request):
     return render(request, "payments/payments.html")
 
 
-@skip_if_disabled
+@waffle_flag("subscription")
 @ensure_wiki_domain
 @never_cache
 def payment_terms(request):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1728,15 +1728,13 @@ STRIPE_PLAN_ID = config("STRIPE_PLAN_ID", default="")
 # Misc Stripe settings
 STRIPE_MAX_NETWORK_RETRIES = config("STRIPE_MAX_NETWORK_RETRIES", default=5, cast=int)
 
-MDN_CONTRIBUTION = config("MDN_CONTRIBUTION", False, cast=bool)
 CONTRIBUTION_SUPPORT_EMAIL = config(
     "CONTRIBUTION_SUPPORT_EMAIL", default="mdn-support@mozilla.com"
 )
-if MDN_CONTRIBUTION:
-    CSP_CONNECT_SRC.append("https://checkout.stripe.com")
-    CSP_FRAME_SRC.append("https://checkout.stripe.com")
-    CSP_IMG_SRC.append("https://*.stripe.com")
-    CSP_SCRIPT_SRC.append("https://checkout.stripe.com")
+CSP_CONNECT_SRC.append("https://checkout.stripe.com")
+CSP_FRAME_SRC.append("https://checkout.stripe.com")
+CSP_IMG_SRC.append("https://*.stripe.com")
+CSP_SCRIPT_SRC.append("https://checkout.stripe.com")
 
 # Settings used for communication with the React server side rendering server
 SSR_URL = config("SSR_URL", default="http://localhost:8002/ssr")

--- a/kuma/static/js/stripe-subscription.js
+++ b/kuma/static/js/stripe-subscription.js
@@ -3,15 +3,6 @@
     var stripeSection = document.querySelector('.stripe-subscription');
     var stripeForm = document.getElementById('stripe-form');
 
-    // The query parameter is added when the user submits the form
-    if (
-        stripeSection.scrollIntoView &&
-        location.search.indexOf('has_stripe_error') !== -1
-    ) {
-        history.replaceState(null, '', location.pathname);
-        stripeSection.scrollIntoView({behavior: 'smooth'});
-    }
-
     // This script is loaded for both before and after form submission.
     // In the latter case no form is rendered anymore
     if (!stripeForm) {

--- a/kuma/static/js/stripe-subscription.js
+++ b/kuma/static/js/stripe-subscription.js
@@ -1,6 +1,5 @@
 (function() {
     var stripeConfigElement = document.getElementById('stripe-config');
-    var stripeSection = document.querySelector('.stripe-subscription');
     var stripeForm = document.getElementById('stripe-form');
 
     // This script is loaded for both before and after form submission.

--- a/kuma/users/jinja2/users/includes/stripe_subscription.html
+++ b/kuma/users/jinja2/users/includes/stripe_subscription.html
@@ -64,7 +64,7 @@
     </div>
     <hr>
     <p>
-      {{ _('To cancel your subscription, please <a href="%(support_email)s">contact support</a>. <br>If you have questions, please read the <a href="%(terms_url)s">FAQ</a> or you can also contact support.', support_email='mailto:mdn-support@mozilla.com', terms_url=url('recurring_payment_initial')) }}
+      {{ _('To cancel your subscription <a href="%(manage_url)s">click here</a>. <br>If you have questions, please read the <a href="%(terms_url)s">FAQ</a> or you can also contact support.', manage_url=url('recurring_payment_management'), terms_url=url('recurring_payment_initial')) }}
     </p>
   {% endif %}
   {% javascript "stripe-subscription" %}

--- a/kuma/users/jinja2/users/includes/stripe_subscription.html
+++ b/kuma/users/jinja2/users/includes/stripe_subscription.html
@@ -64,7 +64,10 @@
     </div>
     <hr>
     <p>
-      {{ _('To cancel your subscription <a href="%(manage_url)s">click here</a>. <br>If you have questions, please read the <a href="%(terms_url)s">FAQ</a> or you can also contact support.', manage_url=url('recurring_payment_management'), terms_url=url('recurring_payment_initial')) }}
+      {% trans manage_url=url('recurring_payment_management'), terms_url=url('recurring_payment_initial'), support_email='mailto:' + settings.CONTRIBUTION_SUPPORT_EMAIL -%}
+        To cancel your subscription <a href="{{ manage_url }}">click here</a>. <br>If you have questions, please read
+        the <a href="{{ terms_url }}">FAQ</a> or you can also <a href="{{ support_email }}">contact support</a>.
+      {% endtrans -%}
     </p>
   {% endif %}
   {% javascript "stripe-subscription" %}

--- a/kuma/users/jinja2/users/includes/stripe_subscription.html
+++ b/kuma/users/jinja2/users/includes/stripe_subscription.html
@@ -6,7 +6,7 @@
   </style>
 </noscript>
 
-<section class="stripe-subscription">
+<section class="stripe-subscription" id="subscription">
   {% stylesheet 'stripe-subscription' %}
 
   {% if not subscription_info %}

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -50,6 +50,7 @@ from kuma.core.ga_tracking import (
     CATEGORY_SIGNUP_FLOW,
     track_event,
 )
+from kuma.core.utils import urlparams
 from kuma.wiki.forms import RevisionAkismetSubmissionSpamForm
 from kuma.wiki.models import (
     Document,
@@ -820,8 +821,13 @@ def create_stripe_subscription(request):
         raven_client.captureException()
         has_stripe_error = True
 
-    query_params = "?" + urlencode({"has_stripe_error": has_stripe_error})
-    return redirect(reverse("users.user_edit", args=[user.username]) + query_params)
+    return redirect(
+        urlparams(
+            reverse("users.user_edit", args=[user.username]),
+            has_stripe_error=has_stripe_error,
+        )
+        + "#subscription"
+    )
 
 
 recovery_email_sent = TemplateView.as_view(

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -28,7 +28,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_text
-from django.utils.http import urlencode, urlsafe_base64_decode
+from django.utils.http import urlsafe_base64_decode
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST


### PR DESCRIPTION
Fixes #6473, Fixes #6471 

## What it does:
- reuse old payment management view
  - enable it based on a waffle flag instead of the env var
  - handle multiple stripe source types when retrieving them. This is the yin to [this PR](https://github.com/mdn/kuma/pull/6528)'s yang
- link to the payment management view

## How to test it:
1. go to the user edit view
1. create a subscription (at the bottom) if you don't already have one
1. click on the cancel subscription link
1. verify that you can see your subscription on the next page
1. cancel it
1. use the link on the page to go back to user edit
1. check if you can create a new subscription