### PR TITLE
Add CSS fallback for MathML

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -882,6 +882,7 @@ PIPELINE_JS = {
             "js/libs/prism/prism-wasm.js",
             "js/libs/prism/prism-line-highlight.js",
             "js/libs/prism/prism-line-numbers.js",
+            "js/components/mathml.js",
             # The react.js file is created by webpack and
             # placed in the kuma/javascript/dist/ directory.
             "react.js",

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -882,7 +882,6 @@ PIPELINE_JS = {
             "js/libs/prism/prism-wasm.js",
             "js/libs/prism/prism-line-highlight.js",
             "js/libs/prism/prism-line-numbers.js",
-            "js/components/mathml.js",
             # The react.js file is created by webpack and
             # placed in the kuma/javascript/dist/ directory.
             "react.js",
@@ -903,6 +902,13 @@ PIPELINE_JS = {
         ),
         "output_filename": "build/js/banners.js",
         "extra_context": {"async": True},
+    },
+    "mathml": {
+        "source_filenames": (
+            "js/components/mathml.js",
+        ),
+        "output_filename": "build/js/mathml.js",
+        "extra_context": {"defer": True},
     },
     "users": {
         "source_filenames": ("js/users.js",),

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -904,9 +904,7 @@ PIPELINE_JS = {
         "extra_context": {"async": True},
     },
     "mathml": {
-        "source_filenames": (
-            "js/components/mathml.js",
-        ),
+        "source_filenames": ("js/components/mathml.js",),
         "output_filename": "build/js/mathml.js",
         "extra_context": {"defer": True},
     },

--- a/kuma/static/js/components/mathml.js
+++ b/kuma/static/js/components/mathml.js
@@ -1,0 +1,73 @@
+/**
+ * vanilla version of the function at:
+ * https://github.com/mdn/kuma/blob/master/kuma/static/js/wiki.js#L252
+ */
+(function() {
+    'use strict';
+
+    /*
+     * Bug 981409 - Add some CSS fallback for browsers without MathML support.
+     *
+     * This is based on:
+     * https://developer.mozilla.org/en-US/docs/Web/MathML/Authoring#Fallback_for_Browsers_without_MathML_support
+     * and https://github.com/fred-wang/mathml.css
+     */
+    var mathElements = document.querySelectorAll('math');
+    // if no `math` elements on the page, bail
+    if (!mathElements.length) {
+        return;
+    }
+
+    /**
+     * Returns a `math` element wrapped in a `div` that is positioned offscreen
+     * @returns `div` element
+     */
+    function getMathElement() {
+        var offscreenContainer = document.createElement('div');
+        var mathMLNamespace = 'http://www.w3.org/1998/Math/MathML';
+        var mathElement = document.createElementNS(mathMLNamespace, 'math');
+        var mspaceElement = document.createElementNS(mathMLNamespace, 'mspace');
+
+        mspaceElement.setAttribute('height', '23px');
+        mspaceElement.setAttribute('width', '77px');
+
+        mathElement.append(mspaceElement);
+        offscreenContainer.append(mathElement);
+        offscreenContainer.classList.add('offscreen');
+
+        return offscreenContainer;
+    }
+
+    // Test for MathML support
+    var mathMLTestElement = document.body.appendChild(getMathElement());
+    var box = mathMLTestElement.querySelector('mspace').getBoundingClientRect();
+    document.body.removeChild(mathMLTestElement);
+
+    var supportsMathML =
+        Math.abs(box.height - 23) <= 1 && Math.abs(box.width - 77) <= 1;
+    if (!supportsMathML) {
+        // Add CSS fallback
+        var polyfill = document.createElement('link');
+        polyfill.href = mdn.staticPath + 'styles/libs/mathml.css';
+        polyfill.rel = 'stylesheet';
+        polyfill.type = 'text/css';
+
+        document.head.append(polyfill);
+
+        // if we do not do this, React hydrate is unhappy and removes the element
+        // Warning: Did not expect server HTML to contain a <div> in <div>.
+        setTimeout(function() {
+            // Add notification
+            var wikiArticleContainer = document.getElementById('wikiArticle');
+            var notice = document.createElement('div');
+            var messageContainer = document.createElement('p');
+
+            messageContainer.textContent =
+                'Your browser does not support MathML. A CSS fallback has been used instead.';
+            notice.append(messageContainer);
+            notice.classList.add('notice');
+
+            wikiArticleContainer.insertAdjacentElement('beforebegin', notice);
+        }, 500);
+    }
+})();

--- a/kuma/static/js/components/mathml.js
+++ b/kuma/static/js/components/mathml.js
@@ -1,7 +1,3 @@
-/**
- * vanilla version of the function at:
- * https://github.com/mdn/kuma/blob/master/kuma/static/js/wiki.js#L252
- */
 (function() {
     'use strict';
 
@@ -19,10 +15,13 @@
     }
 
     /**
-     * Returns a `math` element wrapped in a `div` that is positioned offscreen
-     * @returns `div` element
+     * Tests whether MathML is supported(at least in terms of mspace),
+     * and returns true or false.
+     * @returns {Boolean} isMathMLSupported
      */
-    function getMathElement() {
+    function isMathMLSupported() {
+        var box = null;
+        var mathMLTestElement = null;
         var offscreenContainer = document.createElement('div');
         var mathMLNamespace = 'http://www.w3.org/1998/Math/MathML';
         var mathElement = document.createElementNS(mathMLNamespace, 'math');
@@ -35,17 +34,14 @@
         offscreenContainer.append(mathElement);
         offscreenContainer.classList.add('offscreen');
 
-        return offscreenContainer;
+        mathMLTestElement = document.body.appendChild(offscreenContainer);
+        box = mathMLTestElement.querySelector('mspace').getBoundingClientRect();
+        document.body.removeChild(mathMLTestElement);
+
+        return Math.abs(box.height - 23) <= 1 && Math.abs(box.width - 77) <= 1;
     }
 
-    // Test for MathML support
-    var mathMLTestElement = document.body.appendChild(getMathElement());
-    var box = mathMLTestElement.querySelector('mspace').getBoundingClientRect();
-    document.body.removeChild(mathMLTestElement);
-
-    var supportsMathML =
-        Math.abs(box.height - 23) <= 1 && Math.abs(box.width - 77) <= 1;
-    if (!supportsMathML) {
+    if (!isMathMLSupported()) {
         // Add CSS fallback
         var polyfill = document.createElement('link');
         polyfill.href = mdn.staticPath + 'styles/libs/mathml.css';

--- a/kuma/static/js/components/mathml.js
+++ b/kuma/static/js/components/mathml.js
@@ -49,21 +49,5 @@
         polyfill.type = 'text/css';
 
         document.head.append(polyfill);
-
-        // if we do not do this, React hydrate is unhappy and removes the element
-        // Warning: Did not expect server HTML to contain a <div> in <div>.
-        setTimeout(function() {
-            // Add notification
-            var wikiArticleContainer = document.getElementById('wikiArticle');
-            var notice = document.createElement('div');
-            var messageContainer = document.createElement('p');
-
-            messageContainer.textContent =
-                'Your browser does not support MathML. A CSS fallback has been used instead.';
-            notice.append(messageContainer);
-            notice.classList.add('notice');
-
-            wikiArticleContainer.insertAdjacentElement('beforebegin', notice);
-        }, 500);
     }
 })();

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -102,6 +102,7 @@
 
   <!-- site js -->
   {% javascript 'react-main' %}
+  {% javascript 'mathml' %}
   {% if settings.MULTI_AUTH_ENABLED %}
     {% javascript 'auth-modal' %}
   {% endif %}


### PR DESCRIPTION
This loads a CSS polyfill if MathML is not supported in the browser.

Tested with the following URLs:

- https://developer.mozilla.org/en-US/docs/Web/API/XRRigidTransform/matrix
- https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getTransform

Firefox supports this natively, Chrome does not.

fix #6391 