### PR TITLE
Minor corrections to docs and Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ and give feedback, or to tell you when we plan to review it.
 
 [gh-flow]: https://guides.github.com/introduction/flow/
 [install]: https://kuma.readthedocs.io/en/latest/installation.html
-[travisci]: https://travis-ci.org/mdn/kuma/pull_requests
+[travisci]: https://travis-ci.com/mdn/kuma/pull_requests
 
 Conventions
 ===========
@@ -197,7 +197,7 @@ We **prefer** test functions, a small number of global
 that customize the global fixtures, and using [assert][assert] for test
 assertions.
 
-[travisci]: https://travis-ci.org/mdn/kuma/pull_requests
+[travisci]: https://travis-ci.com/mdn/kuma/pull_requests
 [testing]: https://kuma.readthedocs.io/en/latest/tests.html#running-the-test-suite
 [testcase]: https://docs.djangoproject.com/en/1.8/topics/testing/tools/#testcase
 [fixture_files]: https://docs.djangoproject.com/en/1.8/topics/testing/tools/#fixture-loading

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,6 @@ collectstatic:
 
 build-static: webpack compilejsi18n compile-react-i18n collectstatic
 
-install:
-	@ echo "## Installing $(requirements) ##"
-	@ pip install $(requirements)
-
 clean:
 	rm -rf .coverage build/ tmp/emails/*.log
 	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -delete
@@ -171,4 +167,4 @@ npmrefresh:
 	npm install
 
 # Those tasks don't have file targets
-.PHONY: test coveragetest clean locale install compilejsi18n collectstatic localetest localeextract localecompile localerefresh npmrefresh webpack compile-react-i18n
+.PHONY: test coveragetest clean locale compilejsi18n collectstatic localetest localeextract localecompile localerefresh npmrefresh webpack compile-react-i18n

--- a/README.rst
+++ b/README.rst
@@ -2,17 +2,13 @@
 Kuma
 ====
 
-.. image:: https://travis-ci.org/mdn/kuma.svg?branch=master
-   :target: https://travis-ci.org/mdn/kuma
+.. image:: https://travis-ci.com/mdn/kuma.svg?branch=master
+   :target: https://travis-ci.com/mdn/kuma
    :alt: Build Status
 
 .. image:: https://codecov.io/github/mdn/kuma/coverage.svg?branch=master
    :target: https://codecov.io/github/mdn/kuma?branch=master
    :alt: Code Coverage Status
-
-.. image:: https://requires.io/github/mdn/kuma/requirements.svg?branch=master
-   :target: https://requires.io/github/mdn/kuma/requirements/?branch=master
-   :alt: Requirements Status
 
 .. image:: http://img.shields.io/badge/license-MPL2-blue.svg
    :target: https://raw.githubusercontent.com/mdn/kuma/master/LICENSE
@@ -39,7 +35,7 @@ Development
 
                 `Pull Request Queues`_
 :Dev Docs:      https://kuma.readthedocs.io/en/latest/installation.html
-:CI Server:     https://travis-ci.org/mdn/kuma
+:CI Server:     https://travis-ci.com/mdn/kuma
 :Forum:         https://discourse.mozilla.org/c/mdn
 :IRC:           irc://irc.mozilla.org/mdndev
 :Servers:       `What's Deployed on MDN?`_

--- a/contribute.json
+++ b/contribute.json
@@ -4,7 +4,7 @@
     "repository": {
         "url": "https://github.com/mdn/kuma",
         "license": "MPL2",
-        "tests": "https://travis-ci.org/mdn/kuma"
+        "tests": "https://travis-ci.com/mdn/kuma"
     },
     "participate": {
         "home": "https://wiki.mozilla.org/MDN",

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -141,14 +141,14 @@ Before deploying, a staff member should:
 
 .. _Dennis: https://github.com/willkg/dennis
 .. _Jenkins: https://ci.us-west-2.mdn.mozit.cloud
-.. _Kuma: https://travis-ci.org/mdn/kuma/
+.. _Kuma: https://travis-ci.com/mdn/kuma/
 .. _KumaScript: https://travis-ci.org/mdn/kumascript
 .. _Pontoon: https://pontoon.mozilla.org/projects/mdn/
 .. _`Kuma images`: https://hub.docker.com/r/mdnwebdocs/kuma/tags/
 .. _`Kuma master build`: https://ci.us-west-2.mdn.mozit.cloud/blue/organizations/jenkins/kuma/activity/?branch=master
 .. _`KumaScript images`: https://hub.docker.com/r/mdnwebdocs/kumascript/tags/
 .. _`KumaScript master build`: https://ci.us-west-2.mdn.mozit.cloud/blue/organizations/jenkins/kumascript/activity?branch=master
-.. _`master build`: https://travis-ci.org/mdn/kuma
+.. _`master build`: https://travis-ci.com/mdn/kuma
 .. _`mdn-browser-compat-data`: https://www.npmjs.com/package/mdn-browser-compat-data
 .. _`open a pull request`: https://github.com/mdn/kuma
 .. _mdn-l10n: https://github.com/mozilla-l10n/mdn-l10n

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,7 @@ transitioning to Docker containers for deployment as well.
 .. _`Docker for Mac`: https://docs.docker.com/docker-for-mac/
 .. _`Docker's Ubuntu packages`: https://docs.docker.com/engine/installation/linux/ubuntulinux/
 .. _`DockerHub`: https://hub.docker.com/r/mdnwebdocs/kuma_base/tags/
-.. _TravisCI: https://travis-ci.org/mdn/kuma/
+.. _TravisCI: https://travis-ci.com/mdn/kuma/
 .. _Jenkins: https://ci.us-west-2.mdn.mozit.cloud/blue/organizations/jenkins/kuma/activity
 .. _discourse: https://discourse.mozilla.org/c/mdn
 

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -104,7 +104,7 @@ It is possible to break deployments by adding a bad translation. The TravisCI_
 job ``TOXENV=locales`` will test that the deployment should pass, and should
 pass before merging the PR.
 
-.. _`TravisCI`: https://travis-ci.org/mdn/kuma
+.. _`TravisCI`: https://travis-ci.com/mdn/kuma
 
 .. _Updating the localizable strings in Pontoon:
 


### PR DESCRIPTION
- travis-ci.com, not .org, for mdn/kuma
- remove requires.io badge; we'll be using Dependabot or Renovate
- remove unused `make install` target which referenced an old
  requirements.txt that no longer exists

Fixes #6552