### PR TITLE
Remove legacy view_document permission

### DIFF
--- a/kuma/wiki/migrations/0007_view_document_permission.py
+++ b/kuma/wiki/migrations/0007_view_document_permission.py
@@ -1,0 +1,44 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import migrations
+
+
+def remove_view_document_permission(apps, schema_editor):
+    """
+    Delete our legacy view_document permission, which conflicts with the default
+    permissions added by Django 2.1.
+    """
+    Permission = apps.get_model("auth.Permission")
+    ContentType = apps.get_model("contenttypes.ContentType")
+
+    try:
+        content_type = ContentType.objects.get(app_label="wiki", model="document")
+        Permission.objects.get(
+            content_type=content_type, codename=("view_document")
+        ).delete()
+    except ObjectDoesNotExist:
+        # The ContentType and Permission may not exist on a new, empty database,
+        # like in our CI environment. And that's OK.
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wiki", "0006_auto_20191023_0741"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="document",
+            options={
+                "permissions": (
+                    ("move_tree", "Can move a tree of documents"),
+                    ("purge_document", "Can permanently delete document"),
+                    ("restore_document", "Can restore deleted document"),
+                )
+            },
+        ),
+        migrations.RunPython(
+            remove_view_document_permission, migrations.RunPython.noop
+        ),
+    ]

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -324,7 +324,6 @@ class Document(NotificationsMixin, models.Model):
             ("slug", "locale"),
         )
         permissions = (
-            ("view_document", "Can view document"),
             ("move_tree", "Can move a tree of documents"),
             ("purge_document", "Can permanently delete document"),
             ("restore_document", "Can restore deleted document"),


### PR DESCRIPTION
Django 2.1 introduces a new `view` permission on models, which conflicts with our legacy `view_document` permission. This is reported by `manage.py check` in Django 2 as:

> wiki.Document: (auth.E005) The permission codenamed 'view_document' clashes with a builtin permission for model 'wiki.Document'.

See: https://docs.djangoproject.com/en/2.2/releases/2.1/#model-view-permission

I took the step of manually deleting the legacy permission from the database to avoid unintentionally granting view-only access to the Django admin:
https://docs.djangoproject.com/en/2.2/releases/2.1/#new-default-view-permission-could-allow-unwanted-access-to-admin-views) to users with the former `view_document` permission.

The `view_document` permission was added to Kuma seven years ago in commit 6a8ea905b86c83232770940a8fc52c038053e677, and is not used in our current code. Its last use was removed five years ago in 2e32120cfbd1cd1b2251a1e3af261f7cffc97c1d.

Fixes #6564