### PR TITLE
translateURL should be based on parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ kuma/static/js/libs/ckeditor/source/ckbuilder/
 
 # Emacs backup files
 *~
+junit.xml

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -89,7 +89,10 @@ def test_doc_api(client, trans_doc):
     assert doc_data["wikiURL"] == absolutify(
         trans_doc.get_absolute_url(), for_wiki_site=True
     )
-    assert doc_data["translateURL"] is None
+    assert doc_data["translateURL"] == absolutify(
+        reverse("wiki.edit", args=(trans_doc.slug,), locale=trans_doc.locale),
+        for_wiki_site=True,
+    )
     assert doc_data["bodyHTML"] == trans_doc.get_body_html()
     assert doc_data["quickLinksHTML"] == trans_doc.get_quick_links_html()
     assert doc_data["tocHTML"] == trans_doc.get_toc_html()
@@ -130,10 +133,8 @@ def test_doc_api_for_redirect_to_doc(client, root_doc, redirect_doc):
     assert doc_data["wikiURL"] == absolutify(
         root_doc.get_absolute_url(), for_wiki_site=True
     )
-    assert doc_data["translateURL"] == absolutify(
-        reverse("wiki.select_locale", args=(root_doc.slug,), locale=root_doc.locale,),
-        for_wiki_site=True,
-    )
+    # Because 'root_doc' doesn't have a parent
+    assert doc_data["translateURL"] is None
     assert doc_data["bodyHTML"] == root_doc.get_body_html()
     assert doc_data["quickLinksHTML"] == root_doc.get_quick_links_html()
     assert doc_data["tocHTML"] == root_doc.get_toc_html()

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -89,8 +89,12 @@ def test_doc_api(client, trans_doc):
     assert doc_data["wikiURL"] == absolutify(
         trans_doc.get_absolute_url(), for_wiki_site=True
     )
+    assert doc_data["editURL"] == absolutify(
+        reverse("wiki.edit", args=(trans_doc.slug,), locale=trans_doc.locale),
+        for_wiki_site=True,
+    )
     assert doc_data["translateURL"] == absolutify(
-        reverse("wiki.translate", args=(trans_doc.slug,), locale=trans_doc.locale)
+        reverse("wiki.select_locale", args=(trans_doc.slug,), locale=trans_doc.locale)
         + "?tolocale=fr",
         for_wiki_site=True,
     )

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -93,15 +93,7 @@ def test_doc_api(client, trans_doc):
         reverse("wiki.edit", args=(trans_doc.slug,), locale=trans_doc.locale),
         for_wiki_site=True,
     )
-    assert doc_data["translateURL"] == absolutify(
-        reverse(
-            "wiki.select_locale",
-            args=(trans_doc.parent.slug,),
-            locale=trans_doc.parent.locale,
-        )
-        + "?tolocale=fr",
-        for_wiki_site=True,
-    )
+    assert doc_data["translateURL"] is None
     assert doc_data["bodyHTML"] == trans_doc.get_body_html()
     assert doc_data["quickLinksHTML"] == trans_doc.get_quick_links_html()
     assert doc_data["tocHTML"] == trans_doc.get_toc_html()
@@ -142,8 +134,10 @@ def test_doc_api_for_redirect_to_doc(client, root_doc, redirect_doc):
     assert doc_data["wikiURL"] == absolutify(
         root_doc.get_absolute_url(), for_wiki_site=True
     )
-    # Because 'root_doc' doesn't have a parent
-    assert doc_data["translateURL"] is None
+    assert doc_data["translateURL"] == absolutify(
+        reverse("wiki.select_locale", args=(root_doc.slug,), locale=root_doc.locale,),
+        for_wiki_site=True,
+    )
     assert doc_data["bodyHTML"] == root_doc.get_body_html()
     assert doc_data["quickLinksHTML"] == root_doc.get_quick_links_html()
     assert doc_data["tocHTML"] == root_doc.get_toc_html()

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -94,7 +94,11 @@ def test_doc_api(client, trans_doc):
         for_wiki_site=True,
     )
     assert doc_data["translateURL"] == absolutify(
-        reverse("wiki.select_locale", args=(trans_doc.slug,), locale=trans_doc.locale)
+        reverse(
+            "wiki.select_locale",
+            args=(trans_doc.parent.slug,),
+            locale=trans_doc.parent.locale,
+        )
         + "?tolocale=fr",
         for_wiki_site=True,
     )

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -90,7 +90,8 @@ def test_doc_api(client, trans_doc):
         trans_doc.get_absolute_url(), for_wiki_site=True
     )
     assert doc_data["translateURL"] == absolutify(
-        reverse("wiki.edit", args=(trans_doc.slug,), locale=trans_doc.locale),
+        reverse("wiki.translate", args=(trans_doc.slug,), locale=trans_doc.locale)
+        + "?tolocale=fr",
         for_wiki_site=True,
     )
     assert doc_data["bodyHTML"] == trans_doc.get_body_html()

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -165,10 +165,10 @@ def document_api_data(doc=None, redirect_url=None):
             "wikiURL": absolutify(doc_absolute_url, for_wiki_site=True),
             "translateURL": (
                 absolutify(
-                    reverse("wiki.select_locale", args=(doc.slug,), locale=doc.locale,),
+                    reverse("wiki.edit", args=(doc.slug,), locale=doc.locale,),
                     for_wiki_site=True,
                 )
-                if doc.is_localizable
+                if doc.parent and doc.parent.is_localizable
                 else None
             ),
             "translationStatus": translation_status,

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -171,15 +171,10 @@ def document_api_data(doc=None, redirect_url=None):
             ),
             "translateURL": (
                 absolutify(
-                    reverse(
-                        "wiki.select_locale",
-                        args=(doc.parent.slug,),
-                        locale=doc.parent.locale,
-                    ),
+                    reverse("wiki.select_locale", args=(doc.slug,), locale=doc.locale),
                     for_wiki_site=True,
                 )
-                + f"?{urlencode(dict(tolocale=doc.locale))}"
-                if doc.parent and doc.parent.is_localizable
+                if doc.is_localizable
                 else None
             ),
             "translationStatus": translation_status,

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -171,7 +171,11 @@ def document_api_data(doc=None, redirect_url=None):
             ),
             "translateURL": (
                 absolutify(
-                    reverse("wiki.select_locale", args=(doc.slug,), locale=doc.locale),
+                    reverse(
+                        "wiki.select_locale",
+                        args=(doc.parent.slug,),
+                        locale=doc.parent.locale,
+                    ),
                     for_wiki_site=True,
                 )
                 + f"?{urlencode(dict(tolocale=doc.locale))}"

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -165,9 +165,13 @@ def document_api_data(doc=None, redirect_url=None):
             "hrefLang": doc.get_hreflang(available_locales),
             "absoluteURL": doc_absolute_url,
             "wikiURL": absolutify(doc_absolute_url, for_wiki_site=True),
+            "editURL": absolutify(
+                reverse("wiki.edit", args=(doc.slug,), locale=doc.locale),
+                for_wiki_site=True,
+            ),
             "translateURL": (
                 absolutify(
-                    reverse("wiki.translate", args=(doc.slug,), locale=doc.locale),
+                    reverse("wiki.select_locale", args=(doc.slug,), locale=doc.locale),
                     for_wiki_site=True,
                 )
                 + f"?{urlencode(dict(tolocale=doc.locale))}"

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.conf import settings
 from django.http import Http404, HttpResponsePermanentRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
@@ -165,9 +167,10 @@ def document_api_data(doc=None, redirect_url=None):
             "wikiURL": absolutify(doc_absolute_url, for_wiki_site=True),
             "translateURL": (
                 absolutify(
-                    reverse("wiki.edit", args=(doc.slug,), locale=doc.locale,),
+                    reverse("wiki.translate", args=(doc.slug,), locale=doc.locale),
                     for_wiki_site=True,
                 )
+                + f"?{urlencode(dict(tolocale=doc.locale))}"
                 if doc.parent and doc.parent.is_localizable
                 else None
             ),

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlencode
-
 from django.conf import settings
 from django.http import Http404, HttpResponsePermanentRedirect, JsonResponse
 from django.shortcuts import get_object_or_404

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -20,6 +20,9 @@ type DocumentProps = {
 function TranslationStatus({
     document: { translationStatus, translateURL }
 }: DocumentProps) {
+    if (!translateURL) {
+        return null;
+    }
     let content;
 
     if (translationStatus === 'in-progress') {

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -18,11 +18,8 @@ type DocumentProps = {
 };
 
 function TranslationStatus({
-    document: { translationStatus, translateURL }
+    document: { translationStatus, editURL }
 }: DocumentProps) {
-    if (!translateURL) {
-        return null;
-    }
     let content;
 
     if (translationStatus === 'in-progress') {
@@ -32,7 +29,7 @@ function TranslationStatus({
             <>
                 {gettext('This translation is incomplete.')}
                 &nbsp;
-                <a href={translateURL} rel="nofollow">
+                <a href={editURL} rel="nofollow">
                     {gettext('Please help translate this article from English')}
                 </a>
             </>

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -29,7 +29,7 @@ export type DocumentData = {
     hrefLang: string,
     absoluteURL: string,
     wikiURL: string,
-    translateURL: string,
+    translateURL: string | null,
     translationStatus: null | 'in-progress' | 'outdated',
     bodyHTML: string,
     quickLinksHTML: string,

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -29,6 +29,7 @@ export type DocumentData = {
     hrefLang: string,
     absoluteURL: string,
     wikiURL: string,
+    editURL: string,
     translateURL: string | null,
     translationStatus: null | 'in-progress' | 'outdated',
     bodyHTML: string,

--- a/kuma/javascript/src/document.test.js
+++ b/kuma/javascript/src/document.test.js
@@ -25,6 +25,8 @@ export const fakeDocumentData = {
     translateURL: '[fake translate url]',
     wikiURL:
         'https://wiki.mdn.developer.mozilla.org/en-US/docs/Web/CSS/box-shadow',
+    editURL:
+        'https://wiki.mdn.developer.mozilla.org/en-US/docs/Web/CSS/box-shadow$edit',
     bodyHTML: '[fake body HTML]',
     quickLinksHTML: '[fake quicklinks HTML]',
     tocHTML: '[fake TOC HTML]',


### PR DESCRIPTION
Fixes #6536

If you're on a non-en-US page that is not fully translated, it now links to the wiki `$edit` URL, not the URL for choosing locale. Because, surely, if you're reading a non-en-US page (e.g. `sv-SE` in the current URL) then you shouldn't need to choose locale :)
This fix makes it so that that link works the same as the Wiki except in the read-only the link hops over to the Wiki. 