### PR TITLE
don't use async scripts

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -901,7 +901,6 @@ PIPELINE_JS = {
             "js/components/banners/banners.js",
         ),
         "output_filename": "build/js/banners.js",
-        "extra_context": {"async": True},
     },
     "mathml": {
         "source_filenames": ("js/components/mathml.js",),
@@ -911,12 +910,10 @@ PIPELINE_JS = {
     "users": {
         "source_filenames": ("js/users.js",),
         "output_filename": "build/js/users.js",
-        "extra_context": {"async": True},
     },
     "user-signup": {
         "source_filenames": ("js/components/user-signup/signup.js",),
         "output_filename": "build/js/signup.js",
-        "extra_context": {"async": True},
     },
     "delete-user-page": {
         "source_filenames": (
@@ -945,7 +942,6 @@ PIPELINE_JS = {
     "dashboard": {
         "source_filenames": ("js/dashboard.js",),
         "output_filename": "build/js/dashboard.js",
-        "extra_context": {"async": True},
     },
     "jquery-ui": {
         "source_filenames": (
@@ -958,7 +954,6 @@ PIPELINE_JS = {
     "search": {
         "source_filenames": ("js/search.js",),
         "output_filename": "build/js/search.js",
-        "extra_context": {"async": True},
     },
     "payments": {
         "source_filenames": ("js/components/payments/payments-manage.js",),
@@ -1005,7 +1000,6 @@ PIPELINE_JS = {
             "js/components/page-load-actions.js",
         ),
         "output_filename": "build/js/wiki.js",
-        "extra_context": {"async": True},
     },
     "wiki-edit": {
         "source_filenames": (
@@ -1019,7 +1013,6 @@ PIPELINE_JS = {
     "wiki-move": {
         "source_filenames": ("js/wiki-move.js",),
         "output_filename": "build/js/wiki-move.js",
-        "extra_context": {"async": True},
     },
     "wiki-compat-tables": {
         "source_filenames": ("js/wiki-compat-tables.js",),
@@ -1029,7 +1022,6 @@ PIPELINE_JS = {
     "task-completion": {
         "source_filenames": ("js/task-completion.js",),
         "output_filename": "build/js/task-completion.js",
-        "extra_context": {"async": True},
     },
     "newsletter": {
         "source_filenames": ("js/newsletter.js",),


### PR DESCRIPTION
Fixes #6550

It's a miracle this hasn't caused more bugs. Perhaps it has caused hundreds of thousands of bugs  due to the progressive-enhancement nature of non-reactive JS, people have simply not noticed and they just refresh and get luckier the next time. 

You should almost never use `async` on a script tag. The only time you should is when you're 101% comfortable with it potentially executing before other .js file has NOT been executed. 

For example:
```html
<script src="/jquery.js"></script>
<script src="/mdn.js"></script>
<script async src="/main.js"></script>
```
is dangerous, **if** the contents of `main.js` is something like this:
```javascript
$(function() { // hi! 
});
```
or...
```javascript
if (window.mdn.utils.getCookie('foo')) {
  ...
}
```

The only time you should use `async` is if...

1) You're sure it doesn't depend any JS inline, or script tags. Doesn't matter if the `<script>` tag appears before or after the `<script async>` one. 
2) You're ok with it blocking the rendering process of the page. 
3) You're ok with the page not being fully rendered and/or `DOMContentLoaded` event signals have fired. 

It's a rare optimization trick that has deep implications. For the Wiki I can't imagine any reason any `<script>` tag should be `async` (other than `perf.js` or `analytics_debug.js`) . 