### PR TITLE
Allow for missing zip when retrieving stripe card info

### DIFF
--- a/kuma/users/utils.py
+++ b/kuma/users/utils.py
@@ -62,7 +62,8 @@ def retrieve_stripe_subscription_info(user):
             "brand": card.brand,
             "expires_at": f"{card.exp_month}/{card.exp_year}",
             "last4": card.last4,
-            "zip": card.address_zip,
+            # Cards that are part of a "source" don't have a zip
+            "zip": card.get("address_zip", None),
         }
 
     return None


### PR DESCRIPTION
Fix #6583 

I don't have a great test plan, because I don't know how the old subscriptions were created. What I did was to grab the prod keys, Kadir's email and stripe customer ID and put it into my logged-in user's DB row.

But I also think this can be greenlit without testing it as it only makes the code more defensive.

Here's the docs for the [source object](https://stripe.com/docs/api/sources/object) and the [card object](https://stripe.com/docs/api/cards/object), where only the latter has an `address_zip`. 