### PR TITLE
Revert "Switch to async GA tag (#6463)"

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -5,7 +5,11 @@
     {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
+
         ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
 
@@ -63,4 +67,3 @@
     }
     {%- endif %}
 </script>
-<script async src='https://www.google-analytics.com/{{ GA_FILE }}.js'></script>

--- a/jinja2/includes/react_google_analytics.html
+++ b/jinja2/includes/react_google_analytics.html
@@ -7,10 +7,12 @@
     {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
         ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
     }
     {%- endif %}
 </script>
-<script async src='https://www.google-analytics.com/{{ GA_FILE }}.js'></script>


### PR DESCRIPTION
We suspect that this change is causing a drop in performance, from 3.4s to 3.7s for the 90th percentile. [Slack convo for reference.](https://mozilla.slack.com/archives/CLTBV3W9X/p1582711416043200)

This reverts commit 669ec0a87ddc44045d4593c986b4d102b6717668.