### PR TITLE
Rename ugettext to gettext

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.http import Http404, HttpResponsePermanentRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
-from django.utils.translation import activate, ugettext as _
+from django.utils.translation import activate, gettext as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_GET, require_safe
 from ratelimit.decorators import ratelimit

--- a/kuma/attachments/admin.py
+++ b/kuma/attachments/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin, messages
 from django.utils.encoding import force_text
 from django.utils.html import format_html
 from django.utils.text import get_text_list
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.core.admin import DisabledDeleteActionMixin
 from kuma.core.urlresolvers import reverse

--- a/kuma/attachments/apps.py
+++ b/kuma/attachments/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AttachmentsConfig(AppConfig):

--- a/kuma/attachments/feeds.py
+++ b/kuma/attachments/feeds.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.wiki.feeds import DocumentsFeed
 

--- a/kuma/attachments/forms.py
+++ b/kuma/attachments/forms.py
@@ -2,7 +2,7 @@ import magic
 from constance import config
 from django import forms
 from django.core.validators import EMPTY_VALUES
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import AttachmentRevision
 

--- a/kuma/attachments/models.py
+++ b/kuma/attachments/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.db.utils import IntegrityError
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_mysql.models import Model as MySQLModel
 from storages.backends.s3boto3 import S3Boto3Storage
 

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.crypto import constant_time_compare
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def generate_key():

--- a/kuma/core/apps.py
+++ b/kuma/core/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.conf import settings
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.celery import app
 

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -10,7 +10,7 @@ from django.template import defaultfilters
 from django.template.loader import get_template
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_jinja import library
 from pytz import timezone, utc
 from soapbox.models import Message

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -15,7 +15,7 @@ from django.shortcuts import _get_queryset, redirect
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_text, smart_bytes
 from django.utils.http import urlencode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from polib import pofile
 from pyquery import PyQuery as pq
 from pytz import timezone

--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.forms.fields import CharField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 LANG_CHOICES = [("", _("All Locales"))] + settings.SORTED_LANGUAGES

--- a/kuma/feeder/apps.py
+++ b/kuma/feeder/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.celery import app
 

--- a/kuma/feeder/sections.py
+++ b/kuma/feeder/sections.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class SECTION_HACKS:

--- a/kuma/search/admin.py
+++ b/kuma/search/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin, messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .forms import IndexModelForm
 from .models import Filter, FilterGroup, Index

--- a/kuma/search/apps.py
+++ b/kuma/search/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from elasticsearch_dsl.connections import connections as es_connections
 
 

--- a/kuma/search/forms.py
+++ b/kuma/search/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Index
 

--- a/kuma/search/management/commands/generate_search_names.py
+++ b/kuma/search/management/commands/generate_search_names.py
@@ -11,7 +11,7 @@ This is generated from the production database using the management command:
 
 ./manage.py generate_search_names.py
 '''
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 FILTER_NAMES = {
   {%- for group_name, filter_names in names %}

--- a/kuma/search/names.py
+++ b/kuma/search/names.py
@@ -5,7 +5,7 @@ This is generated from the production database using the management command:
 
 ./manage.py generate_search_names.py
 """
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 FILTER_NAMES = {
     _("Document type"): [_("Code Samples"), _("How-To & Tutorial"), _("Tools")],

--- a/kuma/search/search.py
+++ b/kuma/search/search.py
@@ -1,6 +1,6 @@
 from operator import attrgetter
 
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from rest_framework.generics import ListAPIView
 from rest_framework.renderers import JSONRenderer
 
@@ -95,8 +95,8 @@ class SearchView(ListAPIView):
                 group_slug = None
             else:
                 # Let's check if we can get the name from the gettext catalog
-                filter_name = ugettext(filter_["name"])
-                group_name = ugettext(filter_["group"]["name"])
+                filter_name = gettext(filter_["name"])
+                group_name = gettext(filter_["group"]["name"])
                 group_slug = filter_["group"]["slug"]
 
             filter_groups.setdefault(

--- a/kuma/search/serializers.py
+++ b/kuma/search/serializers.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from rest_framework import serializers
 
 from . import models
@@ -79,7 +79,7 @@ class FilterSerializer(serializers.ModelSerializer):
         fields = ("name", "slug", "shortcut")
 
     def get_localized_name(self, obj):
-        return ugettext(obj.name)
+        return gettext(obj.name)
 
 
 class GroupSerializer(serializers.Serializer):

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -37,7 +37,7 @@ class SerializerTests(ElasticTestCase):
         assert 1 == len(data["tags"])
         assert "tag" == data["tags"][0]
 
-    @mock.patch("kuma.search.serializers.ugettext")
+    @mock.patch("kuma.search.serializers.gettext")
     def test_filter_serializer_with_translations(self, _mock):
         _mock.return_value = "Juegos"
         translation.activate("es")

--- a/kuma/search/utils.py
+++ b/kuma/search/utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from urlobject import URLObject
 
 

--- a/kuma/spam/forms.py
+++ b/kuma/spam/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from waffle import flag_is_active
 
 from . import akismet, constants

--- a/kuma/spam/models.py
+++ b/kuma/spam/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_extensions.db.fields import CreationDateTimeField
 
 

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.shortcuts import redirect, render
 from django.utils.cache import add_never_cache_headers
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from waffle import switch_is_active
 
 from kuma.core.ga_tracking import (

--- a/kuma/users/apps.py
+++ b/kuma/users/apps.py
@@ -1,7 +1,7 @@
 import stripe
 from django.conf import settings
 from django.contrib.auth.apps import AuthConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # the checks self-register so we don't need to use anything from the import
 import kuma.users.checks  # noqa: F401

--- a/kuma/users/constants.py
+++ b/kuma/users/constants.py
@@ -1,6 +1,6 @@
 import re
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 USERNAME_CHARACTERS = _(

--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from sundial.forms import TimezoneChoiceField
 from sundial.zones import COMMON_GROUPED_CHOICES
 

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -9,7 +9,7 @@ from django.db import models
 from django.utils.encoding import force_bytes
 from django.utils.functional import cached_property
 from django.utils.http import urlsafe_base64_encode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.core.urlresolvers import reverse
 

--- a/kuma/users/signup.py
+++ b/kuma/users/signup.py
@@ -1,7 +1,7 @@
 from allauth.socialaccount.forms import SignupForm as BaseSignupForm
 from django import forms
 from django.core import validators
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 USERNAME_REQUIRED = _("Username is required.")

--- a/kuma/users/tasks.py
+++ b/kuma/users/tasks.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives, send_mail
 from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.core.decorators import skip_in_maintenance_mode
 from kuma.core.email_utils import render_email

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -6,7 +6,7 @@ from allauth.socialaccount.templatetags.socialaccount import get_providers
 from allauth.utils import get_request_param
 from django.conf import settings
 from django.contrib import admin
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from django_jinja import library
 from honeypot.templatetags.honeypot import render_honeypot_field
 from jinja2 import contextfunction, escape, Markup
@@ -46,7 +46,7 @@ def ban_links(context, ban_user, banner_user):
         )
         if active_ban:
             url = reverse("admin:users_userban_change", args=(active_ban.id,))
-            title = ugettext("Banned on %(ban_date)s by %(ban_admin)s.") % {
+            title = gettext("Banned on %(ban_date)s by %(ban_admin)s.") % {
                 "ban_date": datetimeformat(
                     context, active_ban.date, format="date", output="json"
                 ),
@@ -55,24 +55,24 @@ def ban_links(context, ban_user, banner_user):
             link = (
                 '<a id="ban_link" href="%s" class="button ban-link" title="%s">%s'
                 '<i aria-hidden="true" class="icon-ban"></i></a>'
-                % (url, title, ugettext("Banned"))
+                % (url, title, gettext("Banned"))
             )
             link_cleanup = (
                 '<a id="cleanup_link" href="%s" class="button negative ban-link">%s'
                 '<i aria-hidden="true" class="icon-ban"></i></a>'
-                % (url_ban_cleanup, ugettext("Clean Up Revisions"))
+                % (url_ban_cleanup, gettext("Clean Up Revisions"))
             )
         else:
             url = reverse("users.ban_user", kwargs={"username": ban_user.username})
             link = (
                 '<a id="ban_link" href="%s" class="button negative ban-link">%s'
                 '<i aria-hidden="true" class="icon-ban"></i></a>'
-                % (url, ugettext("Ban User"))
+                % (url, gettext("Ban User"))
             )
             link_cleanup = (
                 '<a id="cleanup_link" href="%s" class="button negative ban-link">%s'
                 '<i aria-hidden="true" class="icon-ban"></i></a>'
-                % (url_ban_cleanup, ugettext("Ban User & Clean Up"))
+                % (url_ban_cleanup, gettext("Ban User & Clean Up"))
             )
         links = link_cleanup + " " + link
     return Markup(links)
@@ -86,7 +86,7 @@ def admin_link(user):
     )
     link = (
         '<a href="%s" class="button neutral">%s'
-        '<i aria-hidden="true" class="icon-wrench"></i></a>' % (url, ugettext("Admin"))
+        '<i aria-hidden="true" class="icon-wrench"></i></a>' % (url, gettext("Admin"))
     )
     return Markup(link)
 

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -29,7 +29,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.http import urlencode, urlsafe_base64_decode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView

--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -1,6 +1,6 @@
 from celery.schedules import crontab
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from kuma.celery import app
 

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse, urlunparse
 
 import bleach
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 ALLOWED_TAGS = bleach.ALLOWED_TAGS + [

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -7,7 +7,7 @@ import bleach
 import html5lib
 import newrelic.agent
 from django.conf import settings
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from html5lib.filters.base import Filter as html5lib_Filter
 from lxml import etree
 
@@ -733,7 +733,7 @@ class SectionEditLinkFilter(html5lib_Filter):
                                 "type": "StartTag",
                                 "name": "a",
                                 "data": {
-                                    (None, "title"): ugettext("Edit section"),
+                                    (None, "title"): gettext("Edit section"),
                                     (None, "class"): "edit-section",
                                     (None, "data-section-id"): value,
                                     (None, "data-section-src-url"): order_params(
@@ -772,7 +772,7 @@ class SectionEditLinkFilter(html5lib_Filter):
                                     ),
                                 },
                             },
-                            {"type": "Characters", "data": ugettext("Edit")},
+                            {"type": "Characters", "data": gettext("Edit")},
                             {"type": "EndTag", "name": "a"},
                         )
                         for t in ts:

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -7,7 +7,7 @@ from constance import config
 from django.conf import settings
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from tidings.events import EventUnion, InstanceEvent
 
 from kuma.core.email_utils import emails_with_users_and_watches

--- a/kuma/wiki/feeds.py
+++ b/kuma/wiki/feeds.py
@@ -10,7 +10,7 @@ from django.db.models import F
 from django.utils.feedgenerator import Atom1Feed, Rss201rev2Feed, SyndicationFeed
 from django.utils.html import escape
 from django.utils.timezone import get_current_timezone, is_naive
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.urlresolvers import reverse

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -13,8 +13,8 @@ from django.forms.widgets import CheckboxSelectMultiple
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 from taggit.utils import parse_tags
 
 import kuma.wiki.content
@@ -524,14 +524,14 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
     comment = CharField(required=False, label=_("Comment:"))
 
     review_tags = forms.MultipleChoiceField(
-        label=ugettext("Tag this revision for review?"),
+        label=gettext("Tag this revision for review?"),
         widget=CheckboxSelectMultiple,
         required=False,
         choices=REVIEW_FLAG_TAGS,
     )
 
     localization_tags = forms.MultipleChoiceField(
-        label=ugettext("Tag this revision for localization?"),
+        label=gettext("Tag this revision for localization?"),
         widget=CheckboxSelectMultiple,
         required=False,
         choices=LOCALIZATION_FLAG_TAGS,

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -15,7 +15,7 @@ from django.db import models, transaction
 from django.db.models import signals
 from django.utils.decorators import available_attrs
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 from taggit.managers import TaggableManager
 from taggit.models import ItemBase, TagBase
 from taggit.utils import edit_string_for_tags, parse_tags
@@ -108,9 +108,7 @@ def valid_slug_parent(slug, locale):
             parent = Document.objects.get(locale=locale, slug=parent_slug)
         except Document.DoesNotExist:
             raise Exception(
-                ugettext(
-                    "Parent %s does not exist." % ("%s/%s" % (locale, parent_slug))
-                )
+                gettext("Parent %s does not exist." % ("%s/%s" % (locale, parent_slug)))
             )
 
     return parent
@@ -1788,7 +1786,7 @@ class Revision(models.Model):
                     old = self.based_on
                     self.based_on = based_on  # Guess a correct value.
                     locale = settings.LOCALES[settings.WIKI_DEFAULT_LANGUAGE].native
-                    error = ugettext(
+                    error = gettext(
                         "A revision must be based on a revision of the "
                         "%(locale)s document. Revision ID %(id)s does "
                         "not fit those criteria."

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -5,7 +5,7 @@ from celery import chain
 from django.conf import settings
 from django.db.models import Q
 from django.utils.html import strip_tags
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import document, field
 from elasticsearch_dsl.connections import connections

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.template import loader
 from django.utils.html import conditional_escape
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from django_jinja import library
 
 from kuma.core.urlresolvers import reverse
@@ -113,14 +113,14 @@ def diff_table(content_from, content_to, prev_id, curr_id, tidy=False):
         diff = html_diff.make_table(
             content_from.splitlines(),
             content_to.splitlines(),
-            ugettext("Revision %s") % prev_id,
-            ugettext("Revision %s") % curr_id,
+            gettext("Revision %s") % prev_id,
+            gettext("Revision %s") % curr_id,
             context=True,
             numlines=config.DIFF_CONTEXT_LINES,
         )
     except RuntimeError:
         # some diffs hit a max recursion error
-        message = ugettext("There was an error generating the content.")
+        message = gettext("There was an error generating the content.")
         diff = '<div class="warning"><p>%s</p></div>' % message
     return jinja2.Markup(diff)
 
@@ -132,8 +132,8 @@ def tag_diff_table(prev_tags, curr_tags, prev_id, curr_id):
     diff = html_diff.make_table(
         [prev_tags],
         [curr_tags],
-        ugettext("Revision %s") % prev_id,
-        ugettext("Revision %s") % curr_id,
+        gettext("Revision %s") % prev_id,
+        gettext("Revision %s") % curr_id,
     )
 
     # Simple formatting update: 784877

--- a/kuma/wiki/views/delete.py
+++ b/kuma/wiki/views/delete.py
@@ -1,6 +1,6 @@
 from django.db import IntegrityError
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from django.views.decorators.cache import never_cache
 
 from kuma.core.decorators import (
@@ -59,7 +59,7 @@ def revert_document(request, document_path, revision_id):
                 {
                     "revision": revision,
                     "document": revision.document,
-                    "error": ugettext(
+                    "error": gettext(
                         "Document already exists. Note: You cannot "
                         "revert a document that has been moved until you "
                         "delete its redirect."

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -17,7 +17,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.cache import add_never_cache_headers, patch_vary_headers
 from django.utils.http import parse_etags, quote_etag
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
@@ -744,7 +744,7 @@ def wiki_document(request, document_slug, document_locale):
             request,
             messages.WARNING,
             mark_safe(
-                ugettext("Redirected from %(url)s")
+                gettext("Redirected from %(url)s")
                 % {"url": request.build_absolute_uri(doc.get_absolute_url())}
             ),
             extra_tags="wiki_redirect",
@@ -801,9 +801,7 @@ def wiki_document(request, document_slug, document_locale):
         else:
             en_slug = ""
 
-        share_text = ugettext("I learned about %(title)s on MDN.") % {
-            "title": doc.title
-        }
+        share_text = gettext("I learned about %(title)s on MDN.") % {"title": doc.title}
 
         contributors = doc.contributors
         contributors_count = len(contributors)
@@ -910,7 +908,7 @@ def react_document(request, document_slug, document_locale):
             request,
             messages.WARNING,
             mark_safe(
-                ugettext("Redirected from %(url)s")
+                gettext("Redirected from %(url)s")
                 % {"url": request.build_absolute_uri(doc.get_absolute_url())}
             ),
             extra_tags="wiki_redirect",
@@ -1033,13 +1031,13 @@ def _document_api_PUT(request, document_slug, document_locale):
         else:
             resp = HttpResponse()
             resp.status_code = 400
-            resp.content = ugettext("Unsupported content-type: %s") % content_type
+            resp.content = gettext("Unsupported content-type: %s") % content_type
             return resp
 
     except Exception as e:
         resp = HttpResponse()
         resp.status_code = 400
-        resp.content = ugettext("Request parsing error: %s") % e
+        resp.content = gettext("Request parsing error: %s") % e
         return resp
 
     try:
@@ -1062,7 +1060,7 @@ def _document_api_PUT(request, document_slug, document_locale):
             if current_etag not in expected_etags:
                 resp = HttpResponse()
                 resp.status_code = 412
-                resp.content = ugettext("ETag precondition failed")
+                resp.content = gettext("ETag precondition failed")
                 return resp
 
     except Document.DoesNotExist:

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_http_methods
@@ -122,7 +122,7 @@ def edit(request, document_slug, document_locale):
 
     section_id = request.GET.get("section", None)
     if section_id and not request.is_ajax():
-        return HttpResponse(ugettext("Sections may only be edited inline."))
+        return HttpResponse(gettext("Sections may only be edited inline."))
     disclose_description = bool(request.GET.get("opendescription"))
 
     doc_form = rev_form = None

--- a/kuma/wiki/views/misc.py
+++ b/kuma/wiki/views/misc.py
@@ -1,7 +1,7 @@
 import newrelic.agent
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import render
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_GET
 
 from kuma.core.decorators import (

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -10,7 +10,7 @@ from django.http import (
     HttpResponseForbidden,
 )
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 
 import kuma.wiki.content


### PR DESCRIPTION
The `ugettext` functions are now aliases to their `gettext` equivalents,
and have been since Django 2.0. The `u` versions are deprecated in 3.0.

https://docs.djangoproject.com/en/3.0/releases/3.0/#id3