### PR TITLE
Use django.urls.re_path() instead of url()

### DIFF
--- a/kuma/api/urls.py
+++ b/kuma/api/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 
 urlpatterns = [
-    url("^v1/", include("kuma.api.v1.urls")),
+    re_path("^v1/", include("kuma.api.v1.urls")),
 ]

--- a/kuma/api/v1/urls.py
+++ b/kuma/api/v1/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = [
-    url(r"^doc/(?P<locale>[^/]+)/(?P<slug>.*)$", views.doc, name="api.v1.doc"),
-    url(r"^whoami/?$", views.whoami, name="api.v1.whoami"),
-    url(r"^search/(?P<locale>[^/]+)/?$", views.search, name="api.v1.search"),
-    url(r"^bc-signal/?$", views.bc_signal, name="api.v1.bc_signal"),
-    url(r"^users/(?P<username>[^/]+)/?$", views.get_user, name="api.v1.get_user"),
+    re_path(r"^doc/(?P<locale>[^/]+)/(?P<slug>.*)$", views.doc, name="api.v1.doc"),
+    re_path(r"^whoami/?$", views.whoami, name="api.v1.whoami"),
+    re_path(r"^search/(?P<locale>[^/]+)/?$", views.search, name="api.v1.search"),
+    re_path(r"^bc-signal/?$", views.bc_signal, name="api.v1.bc_signal"),
+    re_path(r"^users/(?P<username>[^/]+)/?$", views.get_user, name="api.v1.get_user"),
 ]

--- a/kuma/attachments/urls.py
+++ b/kuma/attachments/urls.py
@@ -1,15 +1,15 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = [
-    url(
+    re_path(
         r"^files/(?P<attachment_id>\d+)/(?P<filename>.+)$",
         views.raw_file,
         name="attachments.raw_file",
     ),
-    url(
+    re_path(
         r"^@api/deki/files/(?P<file_id>\d+)/=(?P<filename>.+)$",
         views.mindtouch_file_redirect,
         name="attachments.mindtouch_file_redirect",

--- a/kuma/authkeys/urls.py
+++ b/kuma/authkeys/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r"^new$", views.new, name="authkeys.new"),
-    url(r"^(?P<pk>\d+)/history$", views.history, name="authkeys.history"),
-    url(r"^(?P<pk>\d+)/delete$", views.delete, name="authkeys.delete"),
+    re_path(r"^new$", views.new, name="authkeys.new"),
+    re_path(r"^(?P<pk>\d+)/history$", views.history, name="authkeys.history"),
+    re_path(r"^(?P<pk>\d+)/delete$", views.delete, name="authkeys.delete"),
 ]

--- a/kuma/core/tests/logging_urls.py
+++ b/kuma/core/tests/logging_urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
 from django.core.exceptions import SuspiciousOperation
+from django.urls import re_path
 
 from kuma.core.urlresolvers import i18n_patterns
 
@@ -8,4 +8,4 @@ def suspicious(request):
     raise SuspiciousOperation("Raising exception to test logging.")
 
 
-urlpatterns = i18n_patterns(url(r"^suspicious/$", suspicious, name="suspicious"))
+urlpatterns = i18n_patterns(re_path(r"^suspicious/$", suspicious, name="suspicious"))

--- a/kuma/dashboards/urls.py
+++ b/kuma/dashboards/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.generic.base import RedirectView
 
 from kuma.core.decorators import shared_cache_control
@@ -10,10 +10,10 @@ WEEK = 60 * 60 * 24 * 7
 
 
 lang_urlpatterns = [
-    url(r"^revisions$", views.revisions, name="dashboards.revisions"),
-    url(r"^user_lookup$", views.user_lookup, name="dashboards.user_lookup"),
-    url(r"^topic_lookup$", views.topic_lookup, name="dashboards.topic_lookup"),
-    url(
+    re_path(r"^revisions$", views.revisions, name="dashboards.revisions"),
+    re_path(r"^user_lookup$", views.user_lookup, name="dashboards.user_lookup"),
+    re_path(r"^topic_lookup$", views.topic_lookup, name="dashboards.topic_lookup"),
+    re_path(
         r"^localization$",
         # Here the "shared_cache_control" decorator is an optimization. It
         # informs the CDN to cache the redirect for a week, so once this URL
@@ -23,6 +23,6 @@ lang_urlpatterns = [
             RedirectView.as_view(url="/docs/MDN/Doc_status/Overview", permanent=True,)
         ),
     ),
-    url(r"^spam$", views.spam, name="dashboards.spam"),
-    url(r"^macros$", views.macros, name="dashboards.macros"),
+    re_path(r"^spam$", views.spam, name="dashboards.spam"),
+    re_path(r"^macros$", views.macros, name="dashboards.macros"),
 ]

--- a/kuma/health/urls.py
+++ b/kuma/health/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = [
-    url(r"^healthz/?$", views.liveness, name="health.liveness"),
-    url(r"^readiness/?$", views.readiness, name="health.readiness"),
-    url(r"^_kuma_status.json$", views.status, name="health.status"),
-    url(
+    re_path(r"^healthz/?$", views.liveness, name="health.liveness"),
+    re_path(r"^readiness/?$", views.readiness, name="health.readiness"),
+    re_path(r"^_kuma_status.json$", views.status, name="health.status"),
+    re_path(
         r"^csp-violation-capture$",
         views.csp_violation_capture,
         name="health.csp_violation_capture",

--- a/kuma/landing/urls.py
+++ b/kuma/landing/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from kuma.core.decorators import shared_cache_control
 
@@ -9,16 +9,16 @@ MONTH = 60 * 60 * 24 * 30
 
 
 lang_urlpatterns = [
-    url(r"^$", views.home, name="home"),
-    url(r"^maintenance-mode/?$", views.maintenance_mode, name="maintenance_mode"),
-    url(r"^promote/?$", views.promote_buttons, name="promote"),
-    url(r"^promote/buttons/?$", views.promote_buttons, name="promote_buttons"),
+    re_path(r"^$", views.home, name="home"),
+    re_path(r"^maintenance-mode/?$", views.maintenance_mode, name="maintenance_mode"),
+    re_path(r"^promote/?$", views.promote_buttons, name="promote"),
+    re_path(r"^promote/buttons/?$", views.promote_buttons, name="promote_buttons"),
 ]
 
 urlpatterns = [
-    url(r"^contribute\.json$", views.contribute_json, name="contribute_json"),
-    url(r"^robots.txt$", views.robots_txt, name="robots_txt"),
-    url(
+    re_path(r"^contribute\.json$", views.contribute_json, name="contribute_json"),
+    re_path(r"^robots.txt$", views.robots_txt, name="robots_txt"),
+    re_path(
         r"^favicon.ico$",
         shared_cache_control(views.FaviconRedirect.as_view(), s_maxage=MONTH),
         name="favicon_ico",

--- a/kuma/payments/urls.py
+++ b/kuma/payments/urls.py
@@ -1,16 +1,16 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 lang_urlpatterns = [
-    url(r"^recurring/?$", views.contribute, name="recurring_payment_initial"),
-    url(
+    re_path(r"^recurring/?$", views.contribute, name="recurring_payment_initial"),
+    re_path(
         r"^recurring/subscription/?$",
         views.contribute,
         name="recurring_payment_subscription",
     ),
-    url(r"^terms/?$", views.payment_terms, name="payment_terms"),
-    url(
+    re_path(r"^terms/?$", views.payment_terms, name="payment_terms"),
+    re_path(
         r"^recurring/management/?$",
         views.recurring_payment_management,
         name="recurring_payment_management",

--- a/kuma/search/urls.py
+++ b/kuma/search/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 lang_base_urlpatterns = [
-    url(r"^$", views.search, name="search"),
-    url(r"^.(?P<format>json)$", views.SearchRedirectView.as_view()),
+    re_path(r"^$", views.search, name="search"),
+    re_path(r"^.(?P<format>json)$", views.SearchRedirectView.as_view()),
 ]
 
 
 lang_urlpatterns = [
-    url(r"^xml$", views.plugin, name="search.plugin"),
+    re_path(r"^xml$", views.plugin, name="search.plugin"),
 ]

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -1,9 +1,8 @@
 from decorator_include import decorator_include
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
 from django.shortcuts import render
-from django.urls import reverse_lazy
+from django.urls import include, re_path, reverse_lazy
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 from django.views.static import serve
@@ -39,13 +38,13 @@ handler403 = core_views.handler403
 handler404 = core_views.handler404
 handler500 = core_views.handler500
 
-urlpatterns = [url("", include("kuma.health.urls"))]
+urlpatterns = [re_path("", include("kuma.health.urls"))]
 # The non-locale-based landing URL's
-urlpatterns += [url("", include("kuma.landing.urls"))]
+urlpatterns += [re_path("", include("kuma.landing.urls"))]
 # The locale-based landing URL's
-urlpatterns += i18n_patterns(url("", include(landing_lang_urlpatterns)))
+urlpatterns += i18n_patterns(re_path("", include(landing_lang_urlpatterns)))
 urlpatterns += i18n_patterns(
-    url(
+    re_path(
         r"^events",
         # Here the "shared_cache_control" decorator is an optimization. It
         # informs the CDN to cache the redirect for a month, so once this URL
@@ -62,7 +61,7 @@ urlpatterns += i18n_patterns(
 
 if settings.MAINTENANCE_MODE:
     urlpatterns.append(
-        url(
+        re_path(
             r"^admin/.*",
             never_cache(
                 RedirectView.as_view(pattern_name="maintenance_mode", permanent=False)
@@ -72,42 +71,48 @@ if settings.MAINTENANCE_MODE:
 else:
     # Django admin:
     urlpatterns += [
-        url(r"^admin/wiki/document/purge/", purge_view, name="wiki.admin_bulk_purge"),
+        re_path(
+            r"^admin/wiki/document/purge/", purge_view, name="wiki.admin_bulk_purge"
+        ),
         # We don't worry about decorating the views within django.contrib.admin
         # with "never_cache", since most have already been decorated, and the
         # remaining can be safely cached.
-        url(r"^admin/", admin.site.urls),
+        re_path(r"^admin/", admin.site.urls),
     ]
 
-urlpatterns += i18n_patterns(url(r"^search/", include(search_lang_urlpatterns)))
-urlpatterns += i18n_patterns(url(r"^search", include(search_lang_base_urlpatterns)))
-urlpatterns += i18n_patterns(url(r"^docs.json$", document_as_json, name="wiki.json"))
-urlpatterns += i18n_patterns(url(r"^docs/", include(wiki_lang_urlpatterns)))
-urlpatterns += [url("", include("kuma.attachments.urls"))]
+urlpatterns += i18n_patterns(re_path(r"^search/", include(search_lang_urlpatterns)))
+urlpatterns += i18n_patterns(re_path(r"^search", include(search_lang_base_urlpatterns)))
 urlpatterns += i18n_patterns(
-    url(r"dashboards/?$", dashboards_index, name="dashboards.index"),
+    re_path(r"^docs.json$", document_as_json, name="wiki.json")
 )
-urlpatterns += i18n_patterns(url(r"^dashboards/", include(dashboards_lang_urlpatterns)))
-urlpatterns += [url("users/", include("kuma.users.urls"))]
+urlpatterns += i18n_patterns(re_path(r"^docs/", include(wiki_lang_urlpatterns)))
+urlpatterns += [re_path("", include("kuma.attachments.urls"))]
 urlpatterns += i18n_patterns(
-    url(r"^payments/$", payment_views.contribute, name="payments"),
+    re_path(r"dashboards/?$", dashboards_index, name="dashboards.index"),
 )
 urlpatterns += i18n_patterns(
-    url(
+    re_path(r"^dashboards/", include(dashboards_lang_urlpatterns))
+)
+urlpatterns += [re_path("users/", include("kuma.users.urls"))]
+urlpatterns += i18n_patterns(
+    re_path(r"^payments/$", payment_views.contribute, name="payments"),
+)
+urlpatterns += i18n_patterns(
+    re_path(
         r"^contribute/$",
         ensure_wiki_domain(RedirectView.as_view(url=reverse_lazy("payments"))),
         name="redirect-to-payments",
     ),
 )
-urlpatterns += i18n_patterns(url(r"^payments/", include(payments_lang_urlpatterns)))
+urlpatterns += i18n_patterns(re_path(r"^payments/", include(payments_lang_urlpatterns)))
 urlpatterns += i18n_patterns(
-    url("", decorator_include(never_cache, users_lang_urlpatterns))
+    re_path("", decorator_include(never_cache, users_lang_urlpatterns))
 )
 
 if settings.MAINTENANCE_MODE:
     urlpatterns += i18n_patterns(
         # Redirect if we try to use the "tidings" unsubscribe.
-        url(
+        re_path(
             r"^unsubscribe/.*",
             ensure_wiki_domain(
                 never_cache(
@@ -122,33 +127,35 @@ else:
     urlpatterns += i18n_patterns(
         # The first argument to "decorator_include" can be an iterable
         # of view decorators, which are applied in reverse order.
-        url(r"^", decorator_include((ensure_wiki_domain, never_cache), "tidings.urls")),
+        re_path(
+            r"^", decorator_include((ensure_wiki_domain, never_cache), "tidings.urls")
+        ),
     )
 
 
 urlpatterns += [
     # Services and sundry.
-    url("^api/", include("kuma.api.urls")),
-    url("", include("kuma.version.urls")),
+    re_path("^api/", include("kuma.api.urls")),
+    re_path("", include("kuma.version.urls")),
     # Serve sitemap files.
-    url(
+    re_path(
         r"^sitemap.xml$", serve_from_media_root, {"path": "sitemap.xml"}, name="sitemap"
     ),
-    url(r"^(?P<path>sitemaps/.+)$", serve_from_media_root, name="sitemaps"),
-    url(r"^humans.txt$", core_views.humans_txt, name="humans_txt"),
-    url(
+    re_path(r"^(?P<path>sitemaps/.+)$", serve_from_media_root, name="sitemaps"),
+    re_path(r"^humans.txt$", core_views.humans_txt, name="humans_txt"),
+    re_path(
         r"^miel$",
         shared_cache_control(s_maxage=WEEK)(render),
         {"template_name": "500.html", "status": 500},
         name="users.honeypot",
     ),
     # We use our own views for setting language in cookies. But to just align with django, set it like this.
-    url(r"^i18n/setlang/", core_views.set_language, name="set-language-cookie"),
+    re_path(r"^i18n/setlang/", core_views.set_language, name="set-language-cookie"),
 ]
 
 if settings.SERVE_LEGACY and settings.LEGACY_ROOT:
     urlpatterns.append(
-        url(
+        re_path(
             r"^(?P<path>(diagrams|presentations|samples)/.+)$",
             shared_cache_control(s_maxage=MONTH)(serve),
             {"document_root": settings.LEGACY_ROOT},
@@ -159,16 +166,16 @@ if getattr(settings, "DEBUG_TOOLBAR_INSTALLED", False):
     import debug_toolbar
 
     urlpatterns.append(
-        url(r"^__debug__/", decorator_include(never_cache, debug_toolbar.urls)),
+        re_path(r"^__debug__/", decorator_include(never_cache, debug_toolbar.urls)),
     )
 
 # Legacy MindTouch redirects. These go last so that they don't mess
 # with local instances' ability to serve media.
 urlpatterns += [
-    url(
+    re_path(
         r"^@api/deki/files/(?P<file_id>\d+)/=(?P<filename>.+)$",
         attachment_views.mindtouch_file_redirect,
         name="attachments.mindtouch_file_redirect",
     ),
-    url(r"^(?P<path>.*)$", mindtouch_to_kuma_redirect),
+    re_path(r"^(?P<path>.*)$", mindtouch_to_kuma_redirect),
 ]

--- a/kuma/urls_untrusted.py
+++ b/kuma/urls_untrusted.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from kuma.core import views as core_views
 from kuma.core.urlresolvers import i18n_patterns
@@ -11,13 +11,13 @@ handler404 = core_views.handler404
 handler500 = core_views.handler500
 
 urlpatterns = [
-    url("", include("kuma.attachments.urls")),
-    url(r"^robots.txt", robots_txt, name="robots_txt"),
+    re_path("", include("kuma.attachments.urls")),
+    re_path(r"^robots.txt", robots_txt, name="robots_txt"),
 ]
 
 if getattr(settings, "DEBUG_TOOLBAR_INSTALLED", False):
     import debug_toolbar
 
-    urlpatterns.append(url(r"^__debug__/", include(debug_toolbar.urls)),)
+    urlpatterns.append(re_path(r"^__debug__/", include(debug_toolbar.urls)),)
 
-urlpatterns += i18n_patterns(url(r"^docs/", include(wiki_lang_urlpatterns)))
+urlpatterns += i18n_patterns(re_path(r"^docs/", include(wiki_lang_urlpatterns)))

--- a/kuma/users/urls.py
+++ b/kuma/users/urls.py
@@ -2,7 +2,7 @@ import importlib
 
 from allauth.account import views as account_views
 from allauth.socialaccount import providers, views as socialaccount_views
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from kuma.authkeys.views import list as list_keys
@@ -12,76 +12,76 @@ from . import views
 
 
 account_patterns = [
-    url(
+    re_path(
         r"^signin/cancelled/?$",
         socialaccount_views.login_cancelled,
         name="socialaccount_login_cancelled",
     ),
-    url(
+    re_path(
         r"^signin/error/?$",
         socialaccount_views.login_error,
         name="socialaccount_login_error",
     ),
-    url(r"^signup/?$", views.signup, name="socialaccount_signup"),
-    url(r"^signup-landing/?$", views.signin_landing, name="socialaccount_signin"),
-    url(r"^inactive/?$", account_views.account_inactive, name="account_inactive"),
-    url(r"^email/?$", account_views.email, name="account_email"),
-    url(
+    re_path(r"^signup/?$", views.signup, name="socialaccount_signup"),
+    re_path(r"^signup-landing/?$", views.signin_landing, name="socialaccount_signin"),
+    re_path(r"^inactive/?$", account_views.account_inactive, name="account_inactive"),
+    re_path(r"^email/?$", account_views.email, name="account_email"),
+    re_path(
         r"^email/confirm/?$",
         account_views.email_verification_sent,
         name="account_email_verification_sent",
     ),
-    url(
+    re_path(
         r"^email/confirm/(?P<key>[-:\w]+)/?$",
         redirect_in_maintenance_mode(account_views.confirm_email),
         name="account_confirm_email",
     ),
     # Auth keys
-    url(r"^keys$", list_keys, name="authkeys.list"),
-    url(r"^keys/", include("kuma.authkeys.urls")),
+    re_path(r"^keys$", list_keys, name="authkeys.list"),
+    re_path(r"^keys/", include("kuma.authkeys.urls")),
 ]
 
 
 users_patterns = [
-    url(
+    re_path(
         r"^signup/?$",
         redirect_in_maintenance_mode(account_views.signup),
         name="account_signup",
     ),
-    url(
+    re_path(
         r"^signin/?$",
         redirect_in_maintenance_mode(account_views.login),
         name="account_login",
     ),
-    url(
+    re_path(
         r"^signout/?$",
         redirect_in_maintenance_mode(csrf_exempt(account_views.logout)),
         name="account_logout",
     ),
-    url(r"^account/", include(account_patterns)),
-    url(r"^ban/(?P<username>[^/]+)$", views.ban_user, name="users.ban_user"),
-    url(
+    re_path(r"^account/", include(account_patterns)),
+    re_path(r"^ban/(?P<username>[^/]+)$", views.ban_user, name="users.ban_user"),
+    re_path(
         r"^ban_user_and_cleanup/(?P<username>[^/]+)$",
         views.ban_user_and_cleanup,
         name="users.ban_user_and_cleanup",
     ),
-    url(
+    re_path(
         r"^ban_user_and_cleanup_summary/(?P<username>[^/]+)$",
         views.ban_user_and_cleanup_summary,
         name="users.ban_user_and_cleanup_summary",
     ),
-    url(
+    re_path(
         r"^account/recover/send",
         views.send_recovery_email,
         name="users.send_recovery_email",
     ),
-    url(
+    re_path(
         r"^account/recover/sent",
         views.recovery_email_sent,
         name="users.recovery_email_sent",
     ),
-    url(r"^account/recover/done", views.recover_done, name="users.recover_done"),
-    url(
+    re_path(r"^account/recover/done", views.recover_done, name="users.recover_done"),
+    re_path(
         r"^account/recover/(?P<uidb64>[0-9A-Za-z_\-]+)/"
         r"(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})$",
         views.recover,
@@ -101,23 +101,23 @@ for provider in providers.registry.get_list():
         urlpatterns += prov_urlpatterns
 
 lang_urlpatterns = [
-    url(
+    re_path(
         r"^profiles/(?P<username>[^/]+)/?$", views.user_detail, name="users.user_detail"
     ),
-    url(
+    re_path(
         r"^profiles/(?P<username>[^/]+)/edit$", views.user_edit, name="users.user_edit"
     ),
-    url(
+    re_path(
         r"^profiles/(?P<username>[^/]+)/delete$",
         views.user_delete,
         name="users.user_delete",
     ),
-    url(
+    re_path(
         r"^profile/stripe_subscription$",
         views.create_stripe_subscription,
         name="users.create_stripe_subscription",
     ),
-    url(r"^profile/?$", views.my_detail_page, name="users.my_detail_page"),
-    url(r"^profile/edit/?$", views.my_edit_page, name="users.my_edit_page"),
-    url(r"^users/", include(users_patterns)),
+    re_path(r"^profile/?$", views.my_detail_page, name="users.my_detail_page"),
+    re_path(r"^profile/edit/?$", views.my_edit_page, name="users.my_edit_page"),
+    re_path(r"^users/", include(users_patterns)),
 ]

--- a/kuma/version/urls.py
+++ b/kuma/version/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = [
     # Serve the revision hashes.
-    url(r"^media/revision.txt$", views.revision_hash, name="version.kuma"),
-    url(
+    re_path(r"^media/revision.txt$", views.revision_hash, name="version.kuma"),
+    re_path(
         r"^media/kumascript-revision.txt$",
         views.kumascript_revision_hash,
         name="version.kumascript",

--- a/kuma/wiki/urls.py
+++ b/kuma/wiki/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.views.generic import RedirectView
 
 from kuma.attachments.feeds import AttachmentsFeed
@@ -11,52 +11,54 @@ from .constants import DOCUMENT_PATH_RE
 
 # These patterns inherit (?P<document_path>[^\$]+).
 document_patterns = [
-    url(r"^$", views.document.document, name="wiki.document"),
-    url(r"^\$api$", views.document.document_api, name="wiki.document_api"),
-    url(r"^\$revision$", views.revision.revision_api, name="wiki.revision_api"),
-    url(
+    re_path(r"^$", views.document.document, name="wiki.document"),
+    re_path(r"^\$api$", views.document.document_api, name="wiki.document_api"),
+    re_path(r"^\$revision$", views.revision.revision_api, name="wiki.revision_api"),
+    re_path(
         r"^\$revision/(?P<revision_id>\d+)$",
         views.revision.revision,
         name="wiki.revision",
     ),
-    url(r"^\$history$", views.list.revisions, name="wiki.document_revisions"),
-    url(r"^\$edit$", views.edit.edit, name="wiki.edit"),
-    url(r"^\$files$", edit_attachment, name="attachments.edit_attachment"),
-    url(r"^\$compare$", views.revision.compare, name="wiki.compare_revisions"),
-    url(r"^\$children$", views.document.children, name="wiki.children"),
-    url(r"^\$translate$", views.translate.translate, name="wiki.translate"),
-    url(r"^\$locales$", views.translate.select_locale, name="wiki.select_locale"),
-    url(r"^\$json$", views.document.as_json, name="wiki.json_slug"),
-    url(r"^\$toc$", views.document.toc, name="wiki.toc"),
-    url(r"^\$move$", views.document.move, name="wiki.move"),
-    url(r"^\$quick-review$", views.revision.quick_review, name="wiki.quick_review"),
-    url(
+    re_path(r"^\$history$", views.list.revisions, name="wiki.document_revisions"),
+    re_path(r"^\$edit$", views.edit.edit, name="wiki.edit"),
+    re_path(r"^\$files$", edit_attachment, name="attachments.edit_attachment"),
+    re_path(r"^\$compare$", views.revision.compare, name="wiki.compare_revisions"),
+    re_path(r"^\$children$", views.document.children, name="wiki.children"),
+    re_path(r"^\$translate$", views.translate.translate, name="wiki.translate"),
+    re_path(r"^\$locales$", views.translate.select_locale, name="wiki.select_locale"),
+    re_path(r"^\$json$", views.document.as_json, name="wiki.json_slug"),
+    re_path(r"^\$toc$", views.document.toc, name="wiki.toc"),
+    re_path(r"^\$move$", views.document.move, name="wiki.move"),
+    re_path(r"^\$quick-review$", views.revision.quick_review, name="wiki.quick_review"),
+    re_path(
         r"^\$samples/(?P<sample_name>.+)/files/(?P<attachment_id>\d+)/(?P<filename>.+)$",
         views.code.raw_code_sample_file,
         name="wiki.raw_code_sample_file",
     ),
-    url(
+    re_path(
         r"^\$samples/(?P<sample_name>.+)$",
         views.code.code_sample,
         name="wiki.code_sample",
     ),
-    url(
+    re_path(
         r"^\$revert/(?P<revision_id>\d+)$",
         views.delete.revert_document,
         name="wiki.revert_document",
     ),
-    url(
+    re_path(
         r"^\$repair_breadcrumbs$",
         views.document.repair_breadcrumbs,
         name="wiki.repair_breadcrumbs",
     ),
-    url(r"^\$delete$", views.delete.delete_document, name="wiki.delete_document"),
-    url(r"^\$restore$", views.delete.restore_document, name="wiki.restore_document"),
-    url(r"^\$purge$", views.delete.purge_document, name="wiki.purge_document"),
+    re_path(r"^\$delete$", views.delete.delete_document, name="wiki.delete_document"),
+    re_path(
+        r"^\$restore$", views.delete.restore_document, name="wiki.restore_document"
+    ),
+    re_path(r"^\$purge$", views.delete.purge_document, name="wiki.purge_document"),
     # Un/Subscribe to document edit notifications.
-    url(r"^\$subscribe$", views.document.subscribe, name="wiki.subscribe"),
+    re_path(r"^\$subscribe$", views.document.subscribe, name="wiki.subscribe"),
     # Un/Subscribe to document tree edit notifications.
-    url(
+    re_path(
         r"^\$subscribe_to_tree$",
         views.document.subscribe_to_tree,
         name="wiki.subscribe_to_tree",
@@ -64,42 +66,42 @@ document_patterns = [
 ]
 
 non_document_patterns = [
-    url(
+    re_path(
         r"^ckeditor_config.js$", views.misc.ckeditor_config, name="wiki.ckeditor_config"
     ),
     # internals
-    url(r"^preview-wiki-content$", views.revision.preview, name="wiki.preview"),
-    url(
+    re_path(r"^preview-wiki-content$", views.revision.preview, name="wiki.preview"),
+    re_path(
         r"^get-documents$",
         views.misc.autosuggest_documents,
         name="wiki.autosuggest_documents",
     ),
     # Special pages
-    url(r"^tags$", views.list.tags, name="wiki.list_tags"),
-    url(r"^tag/(?P<tag>.+)$", views.list.documents, name="wiki.tag"),
-    url(r"^new$", views.create.create, name="wiki.create"),
-    url(r"^all$", views.list.documents, name="wiki.all_documents"),
-    url(r"^with-errors$", views.list.with_errors, name="wiki.errors"),
-    url(r"^without-parent$", views.list.without_parent, name="wiki.without_parent"),
-    url(r"^top-level$", views.list.top_level, name="wiki.top_level"),
-    url(
+    re_path(r"^tags$", views.list.tags, name="wiki.list_tags"),
+    re_path(r"^tag/(?P<tag>.+)$", views.list.documents, name="wiki.tag"),
+    re_path(r"^new$", views.create.create, name="wiki.create"),
+    re_path(r"^all$", views.list.documents, name="wiki.all_documents"),
+    re_path(r"^with-errors$", views.list.with_errors, name="wiki.errors"),
+    re_path(r"^without-parent$", views.list.without_parent, name="wiki.without_parent"),
+    re_path(r"^top-level$", views.list.top_level, name="wiki.top_level"),
+    re_path(
         r"^needs-review/(?P<tag>[^/]+)$",
         views.list.needs_review,
         name="wiki.list_review_tag",
     ),
-    url(r"^needs-review/?", views.list.needs_review, name="wiki.list_review"),
-    url(
+    re_path(r"^needs-review/?", views.list.needs_review, name="wiki.list_review"),
+    re_path(
         r"^localization-tag/(?P<tag>[^/]+)$",
         views.list.with_localization_tag,
         name="wiki.list_with_localization_tag",
     ),
-    url(
+    re_path(
         r"^localization-tag/?",
         views.list.with_localization_tag,
         name="wiki.list_with_localization_tags",
     ),
     # Legacy KumaScript macro list, when they were stored in Kuma database
-    url(
+    re_path(
         r"^templates$",
         ensure_wiki_domain(
             shared_cache_control(s_maxage=60 * 60 * 24 * 30)(
@@ -108,43 +110,43 @@ non_document_patterns = [
         ),
     ),
     # Akismet Revision
-    url(
+    re_path(
         r"^submit_akismet_spam$",
         views.akismet_revision.submit_akismet_spam,
         name="wiki.submit_akismet_spam",
     ),
     # Feeds
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/all/?",
         shared_cache_control(feeds.DocumentsRecentFeed()),
         name="wiki.feeds.recent_documents",
     ),
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/l10n-updates/?",
         shared_cache_control(feeds.DocumentsUpdatedTranslationParentFeed()),
         name="wiki.feeds.l10n_updates",
     ),
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/tag/(?P<tag>[^/]+)",
         shared_cache_control(feeds.DocumentsRecentFeed()),
         name="wiki.feeds.recent_documents",
     ),
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/needs-review/(?P<tag>[^/]+)",
         shared_cache_control(feeds.DocumentsReviewFeed()),
         name="wiki.feeds.list_review_tag",
     ),
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/needs-review/?",
         shared_cache_control(feeds.DocumentsReviewFeed()),
         name="wiki.feeds.list_review",
     ),
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/revisions/?",
         shared_cache_control(feeds.RevisionsFeed()),
         name="wiki.feeds.recent_revisions",
     ),
-    url(
+    re_path(
         r"^feeds/(?P<format>[^/]+)/files/?",
         shared_cache_control(AttachmentsFeed()),
         name="attachments.feeds.recent_files",
@@ -152,7 +154,7 @@ non_document_patterns = [
 ]
 
 lang_urlpatterns = non_document_patterns + [
-    url(
+    re_path(
         r"^(?P<document_path>%s)" % DOCUMENT_PATH_RE.pattern, include(document_patterns)
     ),
 ]

--- a/kuma/wiki/urls_untrusted.py
+++ b/kuma/wiki/urls_untrusted.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from . import views
 from .constants import DOCUMENT_PATH_RE
@@ -6,12 +6,12 @@ from .constants import DOCUMENT_PATH_RE
 
 # These patterns inherit (?P<document_path>[^\$]+).
 document_patterns = [
-    url(
+    re_path(
         r"^\$samples/(?P<sample_name>.+)/files/(?P<attachment_id>\d+)/(?P<filename>.+)$",
         views.code.raw_code_sample_file,
         name="wiki.raw_code_sample_file",
     ),
-    url(
+    re_path(
         r"^\$samples/(?P<sample_name>.+)$",
         views.code.code_sample,
         name="wiki.code_sample",
@@ -19,7 +19,7 @@ document_patterns = [
 ]
 
 lang_urlpatterns = [
-    url(
+    re_path(
         r"^(?P<document_path>%s)" % DOCUMENT_PATH_RE.pattern, include(document_patterns)
     ),
 ]


### PR DESCRIPTION
Django 2.0 introduced a simplified URL routing syntax.

The previous, regex-based syntax is still supported, but under a new
name: `django.urls.re_path()`. The old name, `django.conf.urls.url()`, is
still available as an alias to help with backwards compatibility.

We might as well adopt the new name to match current documentation.

https://docs.djangoproject.com/en/2.2/releases/2.0/#simplified-url-routing-syntax