### PR TITLE
Remove django.utils.decorators.available_attrs

### DIFF
--- a/kuma/core/decorators.py
+++ b/kuma/core/decorators.py
@@ -8,7 +8,6 @@ from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect, render
-from django.utils.decorators import available_attrs
 
 from .jobs import BannedIPsJob
 from .urlresolvers import reverse
@@ -31,7 +30,7 @@ def shared_cache_control(func=None, **kwargs):
     """
 
     def _shared_cache_controller(viewfunc):
-        @wraps(viewfunc, assigned=available_attrs(viewfunc))
+        @wraps(viewfunc)
         def _cache_controlled(request, *args, **kw):
             response = viewfunc(request, *args, **kw)
             add_shared_cache_control(response, **kwargs)
@@ -78,7 +77,7 @@ def user_access_decorator(
 
             return view_fn(request, *args, **kwargs)
 
-        return wraps(view_fn, assigned=available_attrs(view_fn))(_wrapped_view)
+        return wraps(view_fn)(_wrapped_view)
 
     return decorator
 
@@ -158,7 +157,7 @@ def block_user_agents(view_func):
                     return HttpResponseForbidden()
         return view_func(request, *args, **kwargs)
 
-    return wraps(view_func, assigned=available_attrs(view_func))(agent_blocked_view)
+    return wraps(view_func)(agent_blocked_view)
 
 
 def block_banned_ips(view_func):

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import signals
-from django.utils.decorators import available_attrs
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext, ugettext_lazy as _
 from taggit.managers import TaggableManager
@@ -79,7 +78,7 @@ def cache_with_field(field_name):
     """
 
     def decorator(fn):
-        @wraps(fn, assigned=available_attrs(fn))
+        @wraps(fn)
         def wrapper(self, *args, **kwargs):
             force_fresh = kwargs.pop("force_fresh", False)
 


### PR DESCRIPTION
The `available_attrs` function was originally added to Django 1 to work
around a bug in Python 2. When using Python 3, it returns a static
value: `functools.WRAPPER_ASSIGNMENTS`

The `available_attrs` function is removed in Django 3.0:
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis

We only ever use `available_attrs` with `functools.wraps`, like this:

    @wraps(viewfunc, assigned=available_attrs(viewfunc))

Which, under Python 3, is equivalent to `functools.WRAPPER_ASSIGNMENTS`:

    @wraps(viewfunc, assigned=WRAPPER_ASSIGNMENTS)

And that's the default value for that kwarg, so we just need:

    @wraps(viewfunc)

Hooray!