### PR TITLE
Fix a ResourceWarning: unclosed file in our tests

### DIFF
--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -178,6 +178,8 @@ def test_sitemap(client, settings, sitemaps, db, method):
             "".join([chunk.decode() for chunk in response.streaming_content])
             == sitemaps["index"]
         )
+    else:
+        response.close()  # Discard response body; prevents an unclosed file warning
 
 
 @pytest.mark.parametrize("method", ["post", "put", "delete", "options", "patch"])
@@ -201,6 +203,8 @@ def test_sitemaps(client, settings, sitemaps, db, method):
             "".join([chunk.decode() for chunk in response.streaming_content])
             == sitemaps["locales"]["en-US"]
         )
+    else:
+        response.close()  # Discard response body; prevents an unclosed file warning
 
 
 @pytest.mark.parametrize("method", ["post", "put", "delete", "options", "patch"])

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -22,6 +22,7 @@ def cleared_cache():
 
 def test_contribute_json(client, db):
     response = client.get(reverse("contribute_json"))
+    response.close()  # Discard response body; prevents an unclosed file warning
     assert response.status_code == 200
     assert_shared_cache_header(response)
     assert response["Content-Type"].startswith("application/json")


### PR DESCRIPTION
Failing to consume or close a StreamingHttpResponse raises a
ResourceWarning: unclosed file.

This fixes that.