### PR TITLE
Replace case default with default in index.jsx

### DIFF
--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -57,7 +57,7 @@ if (container) {
             // to handle it as a special case here.
             app = <SignupFlow />;
             break;
-        case 'default':
+        default:
             throw new Error(
                 `Cannot render or hydrate unknown component: ${componentName}`
             );


### PR DESCRIPTION
Change the behaviour of index.jsx from throwing an error when the component name is `default` to throwing an error if the component  name is not `SPA`, `landing` or `signupflow`, mirroring the logic in
ssr.jsx.

- this PR basically updates one of two duplicated switch statements, so they handle the same cases, and the todo comment can be address with a refactor.