### PR TITLE
In 'revise diff', pass '--no-index' to 'git diff'

### DIFF
--- a/scripts/revise/revise.py
+++ b/scripts/revise/revise.py
@@ -111,7 +111,7 @@ def diff(dir, no_pager):
     if not dir.exists():
         raise ReviseException(f"{dir} does not exist")
     pager = "--no-pager" if no_pager else "--paginate"
-    cmd = f"git {pager} diff {{ref}} {{rev}}"
+    cmd = f"git {pager} diff --no-index {{ref}} {{rev}}"
     for rev in dir.rglob(f"rev.html"):
         ref = rev.with_name("ref.html")
         run(cmd.format(rev=rev, ref=ref).split())


### PR DESCRIPTION
Fixes https://github.com/mdn/kuma/issues/6625.

This adds the `--no-index` argument to `git diff`, which as far as I can tell [makes `git diff` compare two files or directories on disk rather than comparing the working tree with the index](https://git-scm.com/docs/git-diff).
