### PR TITLE
Add `isLoading` prop to React Router state 

### DIFF
--- a/kuma/javascript/src/router.jsx
+++ b/kuma/javascript/src/router.jsx
@@ -73,7 +73,6 @@ export default function Router({
     };
 
     // Router state: this is the data we'll use below to render the page
-    //
     let [pageState: PageState, setPageState] = useState({
         url: null,
         route: null,


### PR DESCRIPTION
Currently, the visibility of the loading animation is tied to the component's data. It shows by default, and then is hidden when either of these cases occur: 1) a Promise resolves with a non-null value, or 2) initial data is passed to the component. 

In some cases, such as the Subscriptions landing page (https://github.com/mdn/kuma/issues/6582), neither case will be true, so the loading animation always shows. 

The suggestion in the comments from David was:
> // TODO: update Router to handle the null return case

But I think that data and the loading state should be de-coupled, and therefore added an additional `isLoading` prop to `PageState`.  It is set to `true` and changes to `false` when the Promise resolves or if we have the initial data we need to render the component. 

To test:
- Check out the landing page branch (https://github.com/mindy/kuma/tree/landing-6582) and go to /payments. Without these routing changes, the animation persists, but with the changes, the animation is removed, as expected. I thought it would be easier to review if the routing changes were separate from Subscriptions, so that's why it's in a separate diff. 
- For this branch, I checked to make sure Search and Documents still loads correctly, since those are the only two sections that use this. 

Parent issue:
https://github.com/mdn/kuma/issues/6581

Context (thanks to @schalkneethling for all of this info!):
https://github.com/mdn/kuma/issues/6581#issuecomment-591378120 
