### PR TITLE
avoid AttributeError inside build_json_data()

### DIFF
--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -652,6 +652,8 @@ class Document(NotificationsMixin, models.Model):
         if self.pk:
             for translation in self.other_translations:
                 revision = translation.current_revision
+                if not revision:
+                    continue
                 if revision.summary:
                     summary = revision.summary
                 else:


### PR DESCRIPTION
Fixes #6630

No tests because it's such a rare thing anyway and I speculate the worst that can happen is that for some documents there's no link to the other translation if that other translation lacks a `current_revision`. (All 3 of them)