### PR TITLE
fix username keyerror (github kuma issue #6623)

### DIFF
--- a/kuma/users/jinja2/account/signup.html
+++ b/kuma/users/jinja2/account/signup.html
@@ -9,7 +9,7 @@
 
   <p>{% trans login_url=login_url %}Already have an profile? Then please <a href="{{ login_url }}">sign in</a>.{% endtrans %}</p>
 
-  <form class="signup" id="signup_form" method="post" action="{{ url('account_signup') }}" {% if matching_accounts.exists() %}data-account-match-for="{{ provider.name }}{% endif %}>
+  <form class="signup" id="signup_form" method="post" action="{{ url('account_signup') }}">
     {% csrf_token %}
     {{ form.as_p() }}
     {% if redirect_field_value %}

--- a/kuma/users/jinja2/socialaccount/signup.html
+++ b/kuma/users/jinja2/socialaccount/signup.html
@@ -55,8 +55,6 @@
             {% if form.username.errors %}
               {{ form.username.errors }}
               {% include 'socialaccount/includes/change_username.html' %}
-            {% elif matching_user %}
-              {% include 'socialaccount/includes/change_username.html' %}
             {% else %}
               <div id="username-static-container" class="username-static">
                 {% set provider_username = form.username.value() %}

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1105,19 +1105,6 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         doc = pq(resp.content)
         assert "Account Sign In Failure" in doc.find("h1").text()
 
-    def test_matching_user(self):
-        self.github_login()
-        response = self.client.get(self.signup_url)
-        assert response.status_code == 200
-        assert_no_cache_header(response)
-        assert "matching_user" in response.context
-        assert response.context["matching_user"] is None
-        octocat = user(username="octocat", save=True)
-        response = self.client.get(self.signup_url)
-        assert response.status_code == 200
-        assert_no_cache_header(response)
-        assert response.context["matching_user"] == octocat
-
     def test_email_addresses(self):
         public_email = "octocat-public@example.com"
         private_email = "octocat-private@example.com"

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -600,7 +600,7 @@ class SignupView(BaseSignupView):
         # We should only see GitHub/Google users.
         assert self.sociallogin.account.provider in ("github", "google")
 
-        initial_username = form.initial.get("username")
+        initial_username = form.initial.get("username", "")
 
         # When no username is provided, try to derive one from the email address.
         if not initial_username:
@@ -618,8 +618,6 @@ class SignupView(BaseSignupView):
             while User.objects.filter(username__iexact=initial_username).exists():
                 increment += 1
                 initial_username = f"{initial_username_base}{increment}"
-        else:
-            initial_username = ""
 
         form.initial["username"] = initial_username
 


### PR DESCRIPTION
@peterbe This was a thought experiment for partly addressing #6623 (it doesn't address the failure to recover existing accounts, just the immediate server error) in a way that is more radical and cleans-up some code that has been bothering me for some time, but I'm not sure I like it. I'm submitting it as an example for discussion.