### PR TITLE
enable multi-auth

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1694,10 +1694,10 @@ ENABLE_BCD_SIGNAL = config("ENABLE_BCD_SIGNAL", default=True, cast=bool)
 
 # Enable or disable the multi auth(Google and Github) sign-in flow
 # When disabled, Github will be the default and only Auth provider
-MULTI_AUTH_ENABLED = config("MULTI_AUTH_ENABLED", default=False, cast=bool)
+MULTI_AUTH_ENABLED = True
 
 # Auth and permissions related constants
-LOGIN_URL = "socialaccount_signin" if MULTI_AUTH_ENABLED else "account_login"
+LOGIN_URL = "socialaccount_signin"
 LOGIN_REDIRECT_URL = "home"
 
 # Content Experiments


### PR DESCRIPTION
Enables multi-auth (the addition of Google login) for everything (stage, production, etc.).

@peterbe I went down the road of exploring doing the clean-up (resolving all code that depends-on `settings.MULTI_AUTH_ENABLED`) in this PR as well (just to get it over with), but decided it was best to do that in a later PR as [you originally suggested](https://github.com/mdn/infra/pull/378#issuecomment-595394057). 😄 