### PR TITLE
return missing ga proxy

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -5,6 +5,7 @@
     {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
+        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
         ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
 

--- a/jinja2/includes/react_google_analytics.html
+++ b/jinja2/includes/react_google_analytics.html
@@ -7,6 +7,7 @@
     {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
+        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
         ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
     }


### PR DESCRIPTION
Add back `ga` proxies that were missed in #6621. Fixes current production issue.