### PR TITLE
Use two spaces for yaml, reindent .travis.yml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,8 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-# Jenkinsfile uses two spaces
-[Jenkinsfile]
+# YAML and Jenkins use two spaces
+[{*.yml,Jenkinsfile}]
 indent_size = 2
 
 # git and Makefile use the superior tabs

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,56 +2,56 @@ branches: master
 language: minimal
 git: { submodules: false }
 jobs:
-    include:
-        - stage: "Lint"
-          name: "General Lints"
-          script:
-            - "! git grep -n '^<<<<<<< '"  # Check for Git conflict markers
+  include:
+    - stage: "Lint"
+      name: "General Lints"
+      script:
+        - "! git grep -n '^<<<<<<< '"  # Check for Git conflict markers
 
-        - name: "Python Lints"
-          language: python
-          python: 3.8
-          cache: pip
-          install:
-            - >-
-              pip install --disable-pip-version-check
-              black flake8 flake8-import-order
-          script:
-            - flake8 kuma docs tests
-            - black --check --diff kuma docs tests
+    - name: "Python Lints"
+      language: python
+      python: 3.8
+      cache: pip
+      install:
+        - >-
+          pip install --disable-pip-version-check
+          black flake8 flake8-import-order
+      script:
+        - flake8 kuma docs tests
+        - black --check --diff kuma docs tests
 
-        - name: "JavaScript Lints"
-          language: node_js
-          node_js: 12
-          cache: npm
-          script:
-            - scripts/ci-jslint
-            - scripts/ci-flow
+    - name: "JavaScript Lints"
+      language: node_js
+      node_js: 12
+      cache: npm
+      script:
+        - scripts/ci-jslint
+        - scripts/ci-flow
 
-        - stage: "Test"
-          name: "Documentation Build"
-          language: python
-          python: 3.8
-          cache: pip
-          install:
-            - pip install -r docs/requirements.txt
-          script:
-            - sphinx-build -b html -d doctrees docs html
+    - stage: "Test"
+      name: "Documentation Build"
+      language: python
+      python: 3.8
+      cache: pip
+      install:
+        - pip install -r docs/requirements.txt
+      script:
+        - sphinx-build -b html -d doctrees docs html
 
-        - name: "Dockerized Tests"
-          services: docker
-          git: { submodules: true }
-          env:
-            UID=0
-            DOCKER_COMPOSE_VERSION=1.23.2
-          cache:
-            directories:
-              - downloads
-              - build
-              - static
-          script:
-            - set -e
-            - scripts/ci-python
-            - scripts/ci-jest
-            - scripts/ci-localerefresh
-            - bash <(curl -s https://codecov.io/bash)
+    - name: "Dockerized Tests"
+      services: docker
+      git: { submodules: true }
+      env:
+        UID=0
+        DOCKER_COMPOSE_VERSION=1.23.2
+      cache:
+        directories:
+          - downloads
+          - build
+          - static
+      script:
+        - set -e
+        - scripts/ci-python
+        - scripts/ci-jest
+        - scripts/ci-localerefresh
+        - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This matches the most common practice, including what we do in mdn/infra.