### PR TITLE
Extract duplicate switch statement into component

### DIFF
--- a/kuma/javascript/src/app.jsx
+++ b/kuma/javascript/src/app.jsx
@@ -1,0 +1,54 @@
+// @flow
+import React from 'react';
+
+import SinglePageApp from './single-page-app.jsx';
+import LandingPage from './landing-page.jsx';
+import SignupFlow from './signup-flow.jsx';
+import UserAccount from './user-account/user-account.jsx';
+
+export type AppProps = {
+    // The root component name of the page - SPA, landing or signupflow
+    componentName: string,
+
+    // Data needed to hydrate or render the UI
+    data: any
+};
+
+export default function App({ componentName, data }: AppProps) {
+    switch (componentName) {
+        case 'SPA':
+            // Ideally, we want as much as possible of MDN to be part
+            // of the single page app so that we can get client-side
+            // navigation between pages. Currently the single page app
+            // handles document pages and search results
+            return (
+                <SinglePageApp
+                    initialURL={data.url}
+                    initialData={data.documentData}
+                />
+            );
+        case 'landing':
+            // This is the React UI for the MDN homepage.
+            // The homepage has a React-based header, but most of the
+            // content is still based on Jinja templates, so we can't
+            // currently make it part of the single page app and have
+            // to handle it as a special case here.
+            return <LandingPage />;
+        case 'signupflow':
+            // This is the React UI for the MDN sign-up flow.
+            // The signup flow has a React-based header, but most of the
+            // content is still based on Jinja templates, so we can't
+            // currently make it part of the single page app and have
+            // to handle it as a special case here.
+            return <SignupFlow />;
+        case 'user-account':
+            // This is the React UI for the MDN user account page.
+            // The user account has a React-based header, but most of the
+            // content is still based on Jinja templates, so we can't
+            // currently make it part of the single page app and have
+            // to handle it as a special case here.
+            return <UserAccount />;
+        default:
+            return null;
+    }
+}

--- a/kuma/javascript/src/app.jsx
+++ b/kuma/javascript/src/app.jsx
@@ -49,6 +49,8 @@ export default function App({ componentName, data }: AppProps) {
             // to handle it as a special case here.
             return <UserAccount />;
         default:
-            return null;
+            throw new Error(
+                `Cannot render or hydrate unknown component: ${componentName}`
+            );
     }
 }

--- a/kuma/javascript/src/app.test.jsx
+++ b/kuma/javascript/src/app.test.jsx
@@ -1,0 +1,59 @@
+//@flow
+import React from 'react';
+import { create } from 'react-test-renderer';
+
+import App from './app.jsx';
+import SinglePageApp from './single-page-app.jsx';
+import LandingPage from './landing-page.jsx';
+import SignupFlow from './signup-flow.jsx';
+import UserAccount from './user-account/user-account.jsx';
+
+import { fakeDocumentData } from './document.test.js';
+
+let mockData = {
+    documentData: fakeDocumentData,
+    url: 'mock-url'
+};
+
+jest.mock('./single-page-app', () => '<single-page-app />');
+jest.mock('./landing-page', () => '<landing-page />');
+jest.mock('./signup-flow', () => '<signup-flow />');
+jest.mock('./user-account/user-account', () => '<user-account />');
+
+describe('App', () => {
+    test('returs null when the componentName is unknown', () => {
+        let app = create(
+            <App componentName="UNKNOWN_COMPONENT_NAME" data={mockData} />
+        );
+
+        expect(app.toJSON()).toBe(null);
+    });
+
+    test('renders SinglePageApp when the componentName is SPA', () => {
+        let app = create(<App componentName="SPA" data={mockData} />);
+
+        const { root } = app;
+        expect(root.findAllByType(SinglePageApp).length).toBe(1);
+    });
+
+    test('renders LandingPage when the componentName is landing', () => {
+        let app = create(<App componentName="landing" data={mockData} />);
+
+        const { root } = app;
+        expect(root.findAllByType(LandingPage).length).toBe(1);
+    });
+
+    it('renders SignupFlow when componentName is signupflow', () => {
+        let app = create(<App componentName="signupflow" data={mockData} />);
+
+        const { root } = app;
+        expect(root.findAllByType(SignupFlow).length).toBe(1);
+    });
+
+    it('renders a UserAccount when componentName is user-account', () => {
+      let app = create(<App componentName="user-account" data={mockData} />);
+
+      const { root } = app;
+      expect(root.findAllByType(UserAccount).length).toBe(1);
+    });
+});

--- a/kuma/javascript/src/app.test.jsx
+++ b/kuma/javascript/src/app.test.jsx
@@ -1,4 +1,3 @@
-//@flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 
@@ -21,12 +20,19 @@ jest.mock('./signup-flow', () => '<signup-flow />');
 jest.mock('./user-account/user-account', () => '<user-account />');
 
 describe('App', () => {
-    test('returs null when the componentName is unknown', () => {
-        let app = create(
-            <App componentName="UNKNOWN_COMPONENT_NAME" data={mockData} />
+    test('throws an Error when the componentName is unknown', () => {
+        const originalError = console.error;
+        console.error = jest.fn();
+
+        expect(() => {
+            create(
+                <App componentName="UNKNOWN_COMPONENT_NAME" data={mockData} />
+            );
+        }).toThrowError(
+            /Cannot render or hydrate unknown component: UNKNOWN_COMPONENT_NAME/
         );
 
-        expect(app.toJSON()).toBe(null);
+        console.error = originalError;
     });
 
     test('renders SinglePageApp when the componentName is SPA', () => {
@@ -51,9 +57,9 @@ describe('App', () => {
     });
 
     it('renders a UserAccount when componentName is user-account', () => {
-      let app = create(<App componentName="user-account" data={mockData} />);
+        let app = create(<App componentName="user-account" data={mockData} />);
 
-      const { root } = app;
-      expect(root.findAllByType(UserAccount).length).toBe(1);
+        const { root } = app;
+        expect(root.findAllByType(UserAccount).length).toBe(1);
     });
 });

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -23,13 +23,8 @@ if (container) {
     // Store the string catalog so that l10n.gettext() can do translations
     localize(data.locale, data.stringCatalog, data.pluralFunction);
 
+    // Will throw an error for an unknown componentName.
     let app = <App componentName={componentName} data={data} />;
-
-    if (app === null) {
-        throw new Error(
-            `Cannot render or hydrate unknown component: ${componentName}`
-        );
-    }
 
     /* StrictMode is a tool for highlighting potential problems
        in an application. Like Fragment, StrictMode does not

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -2,11 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import SinglePageApp from './single-page-app.jsx';
-import LandingPage from './landing-page.jsx';
-import SignupFlow from './signup-flow.jsx';
-import UserAccount from './user-account/user-account.jsx';
-
+import App from './app.jsx';
 import { AppErrorBoundary } from './error-boundaries.jsx';
 import GAProvider from './ga-provider.jsx';
 import { localize } from './l10n.js';
@@ -27,50 +23,12 @@ if (container) {
     // Store the string catalog so that l10n.gettext() can do translations
     localize(data.locale, data.stringCatalog, data.pluralFunction);
 
-    let app = null;
-    // This switch statement is duplicated in ssr.jsx. Anything changed
-    // here should also be changed there. TODO: refactor this!
-    switch (componentName) {
-        case 'SPA':
-            // Ideally, we want as much as possible of MDN to be part
-            // of the single page app so that we can get client-side
-            // navigation between pages. Currently the single page app
-            // handles document pages and search results
-            app = (
-                <SinglePageApp
-                    initialURL={data.url}
-                    initialData={data.documentData}
-                />
-            );
-            break;
-        case 'landing':
-            // This is the React UI for the MDN homepage.
-            // The homepage has a React-based header, but most of the
-            // content is still based on Jinja templates, so we can't
-            // currently make it part of the single page app and have
-            // to handle it as a special case here.
-            app = <LandingPage />;
-            break;
-        case 'signupflow':
-            // This is the React UI for the MDN sign-up flow.
-            // The signup flow has a React-based header, but most of the
-            // content is still based on Jinja templates, so we can't
-            // currently make it part of the single page app and have
-            // to handle it as a special case here.
-            app = <SignupFlow />;
-            break;
-        case 'user-account':
-            // This is the React UI for the MDN user account page.
-            // The user account has a React-based header, but most of the
-            // content is still based on Jinja templates, so we can't
-            // currently make it part of the single page app and have
-            // to handle it as a special case here.
-            app = <UserAccount />;
-            break;
-        default:
-            throw new Error(
-                `Cannot render or hydrate unknown component: ${componentName}`
-            );
+    let app = <App componentName={componentName} data={data} />;
+
+    if (app === null) {
+        throw new Error(
+            `Cannot render or hydrate unknown component: ${componentName}`
+        );
     }
 
     /* StrictMode is a tool for highlighting potential problems
@@ -78,6 +36,7 @@ if (container) {
        render any visible UI. It activates additional checks and
        warnings for its descendants.
        @see https://reactjs.org/docs/strict-mode.html */
+
     app = (
         <GAProvider>
             <AppErrorBoundary>

--- a/kuma/javascript/src/ssr.jsx
+++ b/kuma/javascript/src/ssr.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import jsesc from 'jsesc';
-import SinglePageApp from './single-page-app.jsx';
-import LandingPage from './landing-page.jsx';
-import SignupFlow from './signup-flow.jsx';
-import UserAccount from './user-account/user-account.jsx';
+import App from './app.jsx';
 import { localize } from './l10n.js';
 
 /**
@@ -39,53 +36,11 @@ export default function ssr(componentName, data) {
 
     localize(data.locale, data.stringCatalog, pluralFunction);
 
-    // This switch statement is duplicated in index.jsx. Anything changed
-    // here should also be changed there. TODO: refactor this!
-    let html = '';
-    switch (componentName) {
-        case 'SPA':
-            // Ideally, we want as much as possible of MDN to be part
-            // of the single page app so that we can get client-side
-            // navigation between pages. Currently the single page app
-            // handles document pages and search results
-            html = renderToString(
-                <SinglePageApp
-                    initialURL={data.url}
-                    initialData={data.documentData}
-                />
-            );
-            break;
-        case 'landing':
-            // This is the React UI for the MDN homepage.
-            // The homepage has a React-based header, but most of the
-            // content is still based on Jinja templates, so we can't
-            // currently make it part of the single page app and have
-            // to handle it as a special case here.
-            html = renderToString(<LandingPage />);
-            break;
-        case 'signupflow':
-            // This is the React UI for the MDN sign-up flow.
-            // The signup flow has a React-based header, but most of the
-            // content is still based on Jinja templates, so we can't
-            // currently make it part of the single page app and have
-            // to handle it as a special case here.
-            html = renderToString(<SignupFlow />);
-            break;
-        case 'user-account':
-            // This is the React UI for the MDN user account page.
-            // The user account has a React-based header, but most of the
-            // content is still based on Jinja templates, so we can't
-            // currently make it part of the single page app and have
-            // to handle it as a special case here.
-            html = renderToString(<UserAccount />);
-            break;
-        default:
-            console.error(
-                'Can not render unknown component name:',
-                componentName
-            );
-            break;
+    let app = <App componentName={componentName} data={data} />;
+
+    if (app === null) {
+        console.error('Can not render unknown component name:', componentName);
     }
 
-    return { html, script: stringifySafely(data) };
+    return { html: renderToString(app), script: stringifySafely(data) };
 }

--- a/kuma/javascript/src/ssr.jsx
+++ b/kuma/javascript/src/ssr.jsx
@@ -36,11 +36,23 @@ export default function ssr(componentName, data) {
 
     localize(data.locale, data.stringCatalog, pluralFunction);
 
-    let app = <App componentName={componentName} data={data} />;
+    let html = '';
 
-    if (app === null) {
-        console.error('Can not render unknown component name:', componentName);
+    try {
+        html = renderToString(
+            <App componentName={componentName} data={data} />
+        );
+    } catch (error) {
+        if (
+            error.message.indexOf(
+                `Cannot render or hydrate unknown component: ${componentName}`
+            ) === -1
+        ) {
+            throw error;
+        }
+
+        console.error(error.message);
     }
 
-    return { html: renderToString(app), script: stringifySafely(data) };
+    return { html, script: stringifySafely(data) };
 }

--- a/kuma/javascript/src/ssr.test.js
+++ b/kuma/javascript/src/ssr.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import App from './app.jsx';
+import { fakeDocumentData } from './document.test.js';
+import ssr from './ssr.jsx';
+
+let mockData = {
+    documentData: fakeDocumentData,
+    url: 'mock-url'
+};
+
+describe('ssr', () => {
+    test('renders a HTML string for a valid componentName', () => {
+        const htmlString = renderToString(
+            <App componentName="SPA" data={mockData} />
+        );
+
+        const result = ssr('SPA', mockData);
+
+        expect(result.html).toEqual(htmlString);
+    });
+
+    test('writes to console.error with an unknown componentName', () => {
+        const originalError = console.error;
+        console.error = jest.fn();
+
+        const result = ssr('UNKNOWN_COMPONENT_NAME', mockData);
+
+        expect(console.error).toHaveBeenCalledWith(
+            'Cannot render or hydrate unknown component: UNKNOWN_COMPONENT_NAME'
+        );
+        expect(result.html).toEqual('');
+
+        console.error = originalError;
+    });
+});


### PR DESCRIPTION
This commit just extracts the duplicate switch statement in index.jsx and ssr.jsx into it’s own thing, an App component.

As the default handling for an unknown prop `componentName` is different in index.jsx (throws an error) than in ssr.jsx (writes to console), the App component just returns null to indicate this condition. 

App also takes an optional second prop `data`, in index.jsx it comes from `window._react_data`, I can’t find a type for it anywhere, so have left it as `any` for now.