### PR TITLE
Create subscription page (copy of #6647 but with a clean commit history)

### DIFF
--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -98,7 +98,6 @@
   <main id="content">
       {% block document_head %}{% endblock %}
       {% block content %}{% endblock %}
-      </div>
   </main>
 
   {%- block contrib_popup %}{# Inject contributions popup where needed #}{% endblock %}

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -104,33 +104,35 @@
 
   {%- block contrib_popup %}{# Inject contributions popup where needed #}{% endblock %}
 
-  <!-- Footer -->
-  <footer id="nav-footer" class="nav-footer">
-    <div class="center">
-        {% include "includes/footer/mdn-footer.html" %}
+  {% block footer %}
+    <!-- Footer -->
+    <footer id="nav-footer" class="nav-footer">
+      <div class="center">
+          {% include "includes/footer/mdn-footer.html" %}
 
-        {% include "includes/footer/moz-footer.html" %}
+          {% include "includes/footer/moz-footer.html" %}
 
-        {% block lang_switcher %}
-          {% include "includes/lang_switcher.html" %}
-        {% endblock %}
+          {% block lang_switcher %}
+            {% include "includes/lang_switcher.html" %}
+          {% endblock %}
 
-        {% block footer_copyright %}
-          <ul class="footer-tos">
-            <li><a href="https://www.mozilla.org/about/legal/terms/mozilla">{{ _('Terms') }}</a></li>
-            <li><a href="https://www.mozilla.org/privacy/websites/">{{ _('Privacy') }}</a></li>
-            <li><a href="https://www.mozilla.org/privacy/websites/#cookies">{{ _('Cookies') }}</a></li>
-          </ul>
+          {% block footer_copyright %}
+            <ul class="footer-tos">
+              <li><a href="https://www.mozilla.org/about/legal/terms/mozilla">{{ _('Terms') }}</a></li>
+              <li><a href="https://www.mozilla.org/privacy/websites/">{{ _('Privacy') }}</a></li>
+              <li><a href="https://www.mozilla.org/privacy/websites/#cookies">{{ _('Cookies') }}</a></li>
+            </ul>
 
-          <div id="license" class="contentinfo">
-            {% trans copyright_url='/en-US/docs/MDN/About#Copyrights_and_licenses', thisyear=thisyear() %}
-              <p>&copy; 2005-{{ thisyear }} Mozilla and individual contributors.</p>
-              <p>Content is available under <a href="{{ copyright_url }}">these licenses</a>.</p>
-            {% endtrans %}
-          </div>
-        {% endblock %}
-    </div>
-  </footer>
+            <div id="license" class="contentinfo">
+              {% trans copyright_url='/en-US/docs/MDN/About#Copyrights_and_licenses', thisyear=thisyear() %}
+                <p>&copy; 2005-{{ thisyear }} Mozilla and individual contributors.</p>
+                <p>Content is available under <a href="{{ copyright_url }}">these licenses</a>.</p>
+              {% endtrans %}
+            </div>
+          {% endblock %}
+      </div>
+    </footer>
+  {% endblock %}
 
   {% block auth_modal %}
     {% include "includes/auth-modal.html" %}

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -97,7 +97,6 @@
   <!-- Content will go here -->
   <main id="content">
       {% block document_head %}{% endblock %}
-      <div class="center clear">
       {% block content %}{% endblock %}
       </div>
   </main>

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { getLocale, gettext, Interpolated } from '../l10n.js';
 import A11yNav from '../a11y/a11y-nav.jsx';
 import Header from '../header/header.jsx';
+import Footer from '../footer.jsx';
 import Route from '../route.js';
 import SubHeader from './subheader.jsx';
 import ListItem from './list-item.jsx';
@@ -318,6 +319,7 @@ export default function PaymentsLandingPage() {
                     </ol>
                 </section>
             </main>
+            <Footer />
         </>
     );
 }

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -345,11 +345,10 @@ export class PaymentsRoute extends Route<PaymentsRouteParams, null> {
     }
 
     match(url: string): ?PaymentsRouteParams {
-        const path = new URL(url, BASEURL).pathname;
+        const currentPath = new URL(url, BASEURL).pathname;
         const paymentsPath = `/${this.locale}/payments`;
-        const regex = new RegExp(paymentsPath, 'g');
 
-        if (regex.test(path)) {
+        if (currentPath.startsWith(paymentsPath)) {
             return {
                 locale: this.locale
             };

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { getLocale, gettext, Interpolated } from '../l10n.js';
 import A11yNav from '../a11y/a11y-nav.jsx';
 import Header from '../header/header.jsx';
-import Footer from '../footer.jsx';
 import Route from '../route.js';
 import SubHeader from './subheader.jsx';
 import ListItem from './list-item.jsx';
@@ -319,7 +318,6 @@ export default function PaymentsLandingPage() {
                     </ol>
                 </section>
             </main>
-            <Footer />
         </>
     );
 }

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -1,0 +1,367 @@
+// @flow
+import * as React from 'react';
+
+import { getLocale, gettext, Interpolated } from '../l10n.js';
+import A11yNav from '../a11y/a11y-nav.jsx';
+import Header from '../header/header.jsx';
+import Footer from '../footer.jsx';
+import UserProvider from '../user-provider.jsx';
+import Route from '../route.js';
+import SubHeader from './subheader.jsx';
+import ListItem from './list-item.jsx';
+
+type PaymentsRouteParams = {
+    locale: string
+};
+
+export default function PaymentsLandingPage() {
+    const locale = getLocale();
+    const urls = {
+        annualReport:
+            'https://www.mozilla.org/en-US/foundation/annualreport/2019/',
+        email:
+            'mailto:mdn-support@mozilla.com?Subject=Manage%20monthly%20subscription',
+        moco: 'https://www.mozilla.org/foundation/moco/',
+        mozillaFoundation: 'https://www.mozilla.org/foundation/',
+        managePayments: `/${locale}/payments/recurring/management`,
+        stripe: 'https://stripe.com/',
+        taxDeductible: 'https://donate.mozilla.org/faq#item_tax_a',
+        terms: `/${locale}/payments/terms`
+    };
+
+    return (
+        <UserProvider>
+            <A11yNav />
+            <Header />
+            <SubHeader
+                title="Become a monthly supporter"
+                description="Support MDN with a $5 monthly subscription and get back more of the knowledge and tools you rely on for when your work has to work."
+                columnWidth="7"
+            />
+            <main
+                id="contributions-page"
+                className="contributions-page"
+                role="main"
+            >
+                <section className="section">
+                    <header>
+                        <h2>{gettext('FAQs')}</h2>
+                    </header>
+                    <ol id="contribute-faqs" className="faqs clear">
+                        <ListItem
+                            title={gettext('Why is MDN asking me for money?')}
+                            number="1"
+                        >
+                            <p>
+                                {gettext(
+                                    'MDN is seeking direct support from our users. We’d like to accelerate our growth and extend the maintenance of MDN’s content and platform, with assistance from those who use it.'
+                                )}
+                            </p>
+                            <p>
+                                {gettext(
+                                    'Our user base has grown exponentially in the last few years and we have a large list of improvements we’d like to make. While MDN is currently wholly funded by Mozilla, and has been from the beginning, we’d like to create a closer, more collaborative relationship between our audience (that’s you!), our content (written for you and sometimes by you), and our supporters (also, you, again)-- to accelerate those improvements.'
+                                )}
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="How is my payment handled? Is it secure?"
+                            number="2"
+                        >
+                            <p>
+                                <Interpolated
+                                    id={gettext(
+                                        'All payment information goes through payment processor <stripeLink />, and a record of your payment will be stored by Mozilla. Mozilla does not receive or store your credit card number.'
+                                    )}
+                                    stripeLink={
+                                        <a
+                                            href={urls.stripe}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            {gettext('Stripe')}
+                                        </a>
+                                    }
+                                />
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="What data is Mozilla collecting about me?"
+                            number="3"
+                        >
+                            <p>
+                                {gettext(
+                                    'Mozilla will collect and store your name and email, which will be used to send transactional emails (e.g. receipts and notifications). Mozilla will not have access to or store your credit card number.'
+                                )}
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="What does money go towards?"
+                            number="4"
+                        >
+                            <p>
+                                {gettext(
+                                    'The money collected through MDN (minus processing fees, taxes, etc.) will be reinvested back into MDN. We will publish a monthly report on MDN Web Docs showing what work was completed.'
+                                )}
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="Can I help MDN by donating to the Mozilla Foundation?"
+                            number="5"
+                        >
+                            <p>
+                                <Interpolated
+                                    id={gettext(
+                                        'The <mozillaLink /> and MDN are separate organizations and programs. Donations to the Mozilla Foundation are <taxLink /> to the fullest extent permitted by law, and go to support Mozilla public and charitable programs in one general fund. MDN is part of <mocoLink /> and payments to MDN are not used in Mozilla’s charitable programs but are reinvested into MDN’s content, tools, and platform.'
+                                    )}
+                                    mozillaLink={
+                                        <a
+                                            href={urls.mozillaFoundation}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            {gettext('Mozilla Foundation')}
+                                        </a>
+                                    }
+                                    taxLink={
+                                        <a href={urls.taxDeductible}>
+                                            {gettext(
+                                                'tax-deductible in the U.S.'
+                                            )}
+                                        </a>
+                                    }
+                                    mocoLink={
+                                        <a href={urls.moco}>
+                                            {gettext('Mozilla Corporation')}
+                                        </a>
+                                    }
+                                />
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="Is support of MDN tax-deductible?"
+                            number="6"
+                        >
+                            <p>
+                                {gettext(
+                                    'No. Payments to Mozilla Corporation in support of MDN are not tax deductible in the United States or other countries.'
+                                )}
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="What will MDN user funding pay for?"
+                            number="7"
+                        >
+                            <p>
+                                {gettext(
+                                    'Currently, Mozilla pays for site operations and overhead (including staff writers and web developers). MDN user payments will fund accelerating current projects or launching new ones, including:'
+                                )}
+                            </p>
+                            <ul>
+                                <li>
+                                    {gettext(
+                                        'Adding more content, and updating current content'
+                                    )}
+                                </li>
+                                <li>
+                                    {gettext(
+                                        'Improving performance of the site'
+                                    )}
+                                </li>
+                                <li>
+                                    {gettext('Modernizing the MDN platform')}
+                                </li>
+                                <li>
+                                    {gettext('Adding offline access to MDN')}
+                                </li>
+                                <li>
+                                    {gettext(
+                                        'Supporting integrations with popular developer tools'
+                                    )}
+                                </li>
+                                <li>{gettext('More tutorials and guides')}</li>
+                                <li>{gettext('Training and webinars')}</li>
+                            </ul>
+                        </ListItem>
+                        <ListItem
+                            title="Why can’t you just open a Crowdsourcing campaign?"
+                            number="8"
+                        >
+                            <p>
+                                {gettext(
+                                    'Because we aren’t looking for a lump sum. Our goal is to create a broad base of financial support from the people who benefit from the work of MDN.'
+                                )}
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="How has MDN been funded to date?"
+                            number="9"
+                        >
+                            <p>
+                                {gettext(
+                                    'MDN is funded out of the Mozilla Corporation general budget (and has been since it was founded in 2005). Mozilla Corporation intends to continue to financially support MDN into the future, even as we broaden and diversify the sources of MDN funding. We just want to do more things with you and for you!'
+                                )}
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="How does Mozilla make money?"
+                            number="10"
+                        >
+                            <p>
+                                {gettext(
+                                    'The Mozilla Corporation, which funds MDN, makes money primarily from royalties from search providers on Firefox (such as Google, Amazon, DuckDuckGo, and others).'
+                                )}
+                            </p>
+                            <p>
+                                <Interpolated
+                                    id={gettext(
+                                        'Separately, the Mozilla Foundation is a not-for-profit, making its money primarily from donations and royalties from Mozilla Corporation. As a not-for-profit, the Mozilla Foundation reports these revenues publicly every trailing year, as in our most recent <annualReportLink />.'
+                                    )}
+                                    annualReportLink={
+                                        <a href={urls.annualReport}>
+                                            {gettext(
+                                                '2019 Mozilla Annual Report'
+                                            )}
+                                        </a>
+                                    }
+                                />
+                            </p>
+                        </ListItem>
+                    </ol>
+                </section>
+                <section className="section">
+                    <header>
+                        <h2>{gettext('Monthly payments')}</h2>
+                    </header>
+                    <ol id="contribute-monthly-faqs" className="faqs clear">
+                        <ListItem
+                            title="How do I manage my monthly subscription?"
+                            number="11"
+                        >
+                            <p>
+                                <Interpolated
+                                    id={gettext(
+                                        'If you would like to manage your monthly subscription, such as changing your card account details, you will need to cancel your subscription and sign up again using the new card details. To cancel, go to <subscriptionsLink />, or if you have any questions please contact <emailLink />.'
+                                    )}
+                                    subscriptionsLink={
+                                        <a href={urls.managePayments}>
+                                            {gettext(
+                                                'manage monthly subscription page'
+                                            )}
+                                        </a>
+                                    }
+                                    emailLink={
+                                        <a
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            href={urls.email}
+                                        >
+                                            {gettext('mdn-support@mozilla.com')}
+                                        </a>
+                                    }
+                                />
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="How do I apply for a refund or cancel my subscription?"
+                            number="12"
+                        >
+                            <p>
+                                <Interpolated
+                                    id={gettext(
+                                        'You can cancel your monthly subscription any time. Please go to <subscriptionsLink /> to cancel your subscription. If you choose to cancel, we will not charge your payment card for subsequent months. For any other questions or inquiries please <emailLink />.'
+                                    )}
+                                    subscriptionsLink={
+                                        <a href={urls.managePayments}>
+                                            {gettext(
+                                                'manage monthly subscription page'
+                                            )}
+                                        </a>
+                                    }
+                                    emailLink={
+                                        <a
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            href={urls.email}
+                                        >
+                                            {gettext('contact support')}
+                                        </a>
+                                    }
+                                />
+                            </p>
+                        </ListItem>
+
+                        <ListItem
+                            title="What are the payment terms?"
+                            number="13"
+                        >
+                            <p>
+                                <Interpolated
+                                    id={gettext(
+                                        'Please read our <paymentLink /> for more information.'
+                                    )}
+                                    paymentLink={
+                                        <a href={urls.terms}>
+                                            {gettext('payment terms')}
+                                        </a>
+                                    }
+                                />
+                            </p>
+                        </ListItem>
+                        <ListItem
+                            title="Does deleting my MDN account cancel my monthly subscription?"
+                            number="14"
+                        >
+                            <p>
+                                {gettext(
+                                    'When you request to delete your account we will also cancel your monthly subscription and not charge you for subsequent months.'
+                                )}
+                            </p>
+                        </ListItem>
+                    </ol>
+                </section>
+            </main>
+            <Footer />
+        </UserProvider>
+    );
+}
+
+// In order to use new URL() with relative URLs, we need an absolute base
+// URL. If we're running in the browser we can use our current page URL.
+// But if we're doing SSR, we just have to make something up.
+const BASEURL =
+    typeof window !== 'undefined' && window.location
+        ? window.location.origin
+        : 'http://ssr.hack';
+
+export class PaymentsRoute extends Route<PaymentsRouteParams, null> {
+    locale: string;
+
+    constructor(locale: string) {
+        super();
+        this.locale = locale;
+    }
+
+    getComponent() {
+        return PaymentsLandingPage;
+    }
+
+    match(url: string): ?PaymentsRouteParams {
+        let path = new URL(url, BASEURL).pathname;
+
+        if (path !== `/${this.locale}/payments`) {
+            return null;
+        }
+
+        return {
+            locale: this.locale
+        };
+    }
+
+    fetch() {
+        return Promise.resolve(null);
+    }
+
+    getTitle() {
+        return `${gettext('Contribute')} | MDN`;
+    }
+}

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -94,7 +94,7 @@ export default function PaymentsLandingPage() {
                             </p>
                         </ListItem>
                         <ListItem
-                            title="What does money go towards?"
+                            title="What does the money go towards?"
                             number="4"
                         >
                             <p>

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -362,6 +362,6 @@ export class PaymentsRoute extends Route<PaymentsRouteParams, null> {
     }
 
     getTitle() {
-        return `${gettext('Contribute')} | MDN`;
+        return `${gettext('Become a monthly supporter')} | MDN`;
     }
 }

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -239,7 +239,7 @@ export default function PaymentsLandingPage() {
                             <p>
                                 <Interpolated
                                     id={gettext(
-                                        'If you would like to manage your monthly subscription, such as changing your card account details, you will need to cancel your subscription and sign up again using the new card details. To cancel, go to <subscriptionsLink />, or if you have any questions please contact <emailLink />.'
+                                        'If you would like to manage your monthly subscription, such as changing your card account details, you will need to cancel your subscription and sign up again using the new card details. To cancel, go to the <subscriptionsLink />, or if you have any questions please contact <emailLink />.'
                                     )}
                                     subscriptionsLink={
                                         <a href={urls.managePayments}>

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -358,6 +358,6 @@ export class PaymentsRoute extends Route<PaymentsRouteParams, null> {
     }
 
     fetch() {
-        return Promise.resolve(null);
+        throw new Error('Payments should never need to post-fetch more data');
     }
 }

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -343,15 +343,16 @@ export class PaymentsRoute extends Route<PaymentsRouteParams, null> {
     }
 
     match(url: string): ?PaymentsRouteParams {
-        let path = new URL(url, BASEURL).pathname;
+        const path = new URL(url, BASEURL).pathname;
+        const paymentsPath = `/${this.locale}/payments`;
+        const regex = new RegExp(paymentsPath, 'g');
 
-        if (path !== `/${this.locale}/payments`) {
-            return null;
+        if (regex.test(path)) {
+            return {
+                locale: this.locale
+            };
         }
-
-        return {
-            locale: this.locale
-        };
+        return null;
     }
 
     fetch() {

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -18,7 +18,7 @@ export default function PaymentsLandingPage() {
     const locale = getLocale();
     const urls = {
         annualReport:
-            'https://www.mozilla.org/en-US/foundation/annualreport/2019/',
+            'https://www.mozilla.org/en-US/foundation/annualreport/2018/',
         email:
             'mailto:mdn-support@mozilla.com?Subject=Manage%20monthly%20subscription',
         moco: 'https://www.mozilla.org/foundation/moco/',
@@ -219,7 +219,7 @@ export default function PaymentsLandingPage() {
                                     annualReportLink={
                                         <a href={urls.annualReport}>
                                             {gettext(
-                                                '2019 Mozilla Annual Report'
+                                                '2018 Mozilla Annual Report'
                                             )}
                                         </a>
                                     }

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -267,7 +267,7 @@ export default function PaymentsLandingPage() {
                             <p>
                                 <Interpolated
                                     id={gettext(
-                                        'You can cancel your monthly subscription any time. Please go to <subscriptionsLink /> to cancel your subscription. If you choose to cancel, we will not charge your payment card for subsequent months. For any other questions or inquiries please <emailLink />.'
+                                        'You can cancel your monthly subscription at any time. Please go to the <subscriptionsLink /> to cancel your subscription. If you choose to cancel, we will not charge your payment card for subsequent months. For any other questions or inquiries please <emailLink />.'
                                     )}
                                     subscriptionsLink={
                                         <a href={urls.managePayments}>

--- a/kuma/javascript/src/payments/index.jsx
+++ b/kuma/javascript/src/payments/index.jsx
@@ -5,7 +5,6 @@ import { getLocale, gettext, Interpolated } from '../l10n.js';
 import A11yNav from '../a11y/a11y-nav.jsx';
 import Header from '../header/header.jsx';
 import Footer from '../footer.jsx';
-import UserProvider from '../user-provider.jsx';
 import Route from '../route.js';
 import SubHeader from './subheader.jsx';
 import ListItem from './list-item.jsx';
@@ -30,7 +29,7 @@ export default function PaymentsLandingPage() {
     };
 
     return (
-        <UserProvider>
+        <>
             <A11yNav />
             <Header />
             <SubHeader
@@ -321,7 +320,7 @@ export default function PaymentsLandingPage() {
                 </section>
             </main>
             <Footer />
-        </UserProvider>
+        </>
     );
 }
 
@@ -359,9 +358,5 @@ export class PaymentsRoute extends Route<PaymentsRouteParams, null> {
 
     fetch() {
         return Promise.resolve(null);
-    }
-
-    getTitle() {
-        return `${gettext('Become a monthly supporter')} | MDN`;
     }
 }

--- a/kuma/javascript/src/payments/list-item.jsx
+++ b/kuma/javascript/src/payments/list-item.jsx
@@ -1,0 +1,20 @@
+//@flow
+import * as React from 'react';
+
+import { gettext } from '../l10n.js';
+
+type ListItemProps = {
+    title: string,
+    number: string,
+    children: React.Node
+};
+
+const ListItem = ({ title, number, children }: ListItemProps) => (
+    <li className="faq">
+        <h3>{gettext(title)}</h3>
+        <span className="faq-number">{number}</span>
+        {children}
+    </li>
+);
+
+export default ListItem;

--- a/kuma/javascript/src/payments/subheader.jsx
+++ b/kuma/javascript/src/payments/subheader.jsx
@@ -1,0 +1,35 @@
+//@flow
+import * as React from 'react';
+
+import { gettext } from '../l10n.js';
+
+type Props = {
+    title: string,
+    subtitle?: string,
+    description?: string,
+    children?: React.Node,
+    columnWidth?: string
+};
+
+const SubHeader = ({
+    title,
+    subtitle,
+    description,
+    columnWidth = 'all', // number of columns, based on grid system defined in _columns.scss
+    children
+}: Props): React.Node => (
+    <div className="contribution-page-header">
+        <div className="column-container">
+            <div className={`column-${columnWidth}`}>
+                <h1 className="highlight highlight-spanned">
+                    <span className="highlight-span">{gettext(title)}</span>
+                </h1>
+                {subtitle && <h2>{gettext(subtitle)}</h2>}
+                {description && <p>{gettext(description)}</p>}
+            </div>
+            {children}
+        </div>
+    </div>
+);
+
+export default SubHeader;

--- a/kuma/javascript/src/single-page-app.jsx
+++ b/kuma/javascript/src/single-page-app.jsx
@@ -6,6 +6,7 @@ import { getLocale } from './l10n.js';
 import Router from './router.jsx';
 import { SearchRoute } from './search-results-page.jsx';
 import UserProvider from './user-provider.jsx';
+import { PaymentsRoute } from './payments/index.jsx';
 
 type SinglePageAppProps = {
     initialURL: string,
@@ -17,7 +18,11 @@ export default function SinglePageApp({
     initialData
 }: SinglePageAppProps) {
     const locale = getLocale();
-    const routes = [new DocumentRoute(locale), new SearchRoute(locale)];
+    const routes = [
+        new DocumentRoute(locale),
+        new SearchRoute(locale),
+        new PaymentsRoute(locale)
+    ];
 
     return (
         <UserProvider>

--- a/kuma/landing/jinja2/landing/react_homepage.html
+++ b/kuma/landing/jinja2/landing/react_homepage.html
@@ -64,59 +64,60 @@
 
 
 {% block content %}
-
-<!-- callout area -->
-<div class="home-callouts">
-  <h2 class="offscreen">{{ _('Featured') }}</h2>
-  <div class="column-container center">
-    {%- if settings.FOUNDATION_CALLOUT %}
-      {% include "landing/includes/callouts/foundation.html" %}
-    {% else %}
-      {% include "landing/includes/callouts/featured.html" %}
-    {% endif %}
-    {% if settings.NEWSLETTER %}
-    <div class="column-callout callout-newsletter">
-      {% include "includes/newsletter.html" %}
+<div class="center clear">
+  <!-- callout area -->
+  <div class="home-callouts">
+    <h2 class="offscreen">{{ _('Featured') }}</h2>
+    <div class="column-container center">
+      {%- if settings.FOUNDATION_CALLOUT %}
+        {% include "landing/includes/callouts/foundation.html" %}
+      {% else %}
+        {% include "landing/includes/callouts/featured.html" %}
+      {% endif %}
+      {% if settings.NEWSLETTER %}
+      <div class="column-callout callout-newsletter">
+        {% include "includes/newsletter.html" %}
+      </div>
+      {% else %}
+        <div class="column-callout callout-learn">
+          <a href="{{ wiki_url('Learn') }}"><span>{{ _('Learn Web Development') }}</span></a>
+        </div>
+        <div class="column-callout callout-deved">
+          <a href="https://www.mozilla.org/firefox/developer/?utm_source=developer.mozilla.org&utm_medium=referral&utm_campaign=mdn-front-pg-promo"><span>{{ _('Get The Browser For Developers Like You') }}</span></a>
+        </div>
+      {% endif %}
     </div>
-    {% else %}
-      <div class="column-callout callout-learn">
-        <a href="{{ wiki_url('Learn') }}"><span>{{ _('Learn Web Development') }}</span></a>
-      </div>
-      <div class="column-callout callout-deved">
-        <a href="https://www.mozilla.org/firefox/developer/?utm_source=developer.mozilla.org&utm_medium=referral&utm_campaign=mdn-front-pg-promo"><span>{{ _('Get The Browser For Developers Like You') }}</span></a>
-      </div>
-    {% endif %}
   </div>
-</div>
 
-<!-- hacks area -->
-<div class="home-hacks">
-  <div class="column-container center">
-    <div class="column-hacks" dir="ltr">
-      <h2>
-          {% include 'includes/icons/general/star.svg' %} Hacks Blog
-          <span class="heading-link">
-              <a href="http://hacks.mozilla.org">
-                {{ _('read more at hacks.mozilla.org') }}
-                {% include 'includes/icons/arrows/arrow.svg' %}
-              </a>
-          </span>
-      </h2>
-      {{ newsfeed(updates) }}
-    </div>
-    <div class="column-involved">
-      <!-- contributions section -->
-      <h2>{% include 'includes/icons/emojis/smile.svg' %} {{ _('Help improve MDN') }}</h2>
-      <p>{{ _('All parts of MDN (docs and the site itself) are created by an open community of developers. Please join us! Pick one of these ways to help:') }}</p>
-      <ul>
-        <li><a href="{{ wiki_url('MDN/Getting_started') }}">{{ _('Getting started') }}</a></li>
-        <li><a href="{{ wiki_url('MDN/Contribute/Howto/Do_an_editorial_review') }}">{{ _('Editorial review') }}</a></li>
-        <li><a href="{{ wiki_url('MDN/Contribute/Howto/Do_a_technical_review') }}">{{ _('Technical review') }}</a></li>
-        <li><a href="{{ wiki_url('MDN/Contribute/Localize/Translating_pages') }}">{{ _('Translating') }}</a></li>
-        <li><a href="{{ wiki_url('MDN/Promote') }}">{{ _('Promoting MDN') }}</a></li>
-        <li><a href="https://github.com/mdn/kuma#readme">{{ _('Contributing to the MDN codebase') }}</a></li>
-        <li><a href="https://github.com/mdn/browser-compat-data">{{ _('Updating browser compatibility data') }}</a></li>
-      </ul>
+  <!-- hacks area -->
+  <div class="home-hacks">
+    <div class="column-container center">
+      <div class="column-hacks" dir="ltr">
+        <h2>
+            {% include 'includes/icons/general/star.svg' %} Hacks Blog
+            <span class="heading-link">
+                <a href="http://hacks.mozilla.org">
+                  {{ _('read more at hacks.mozilla.org') }}
+                  {% include 'includes/icons/arrows/arrow.svg' %}
+                </a>
+            </span>
+        </h2>
+        {{ newsfeed(updates) }}
+      </div>
+      <div class="column-involved">
+        <!-- contributions section -->
+        <h2>{% include 'includes/icons/emojis/smile.svg' %} {{ _('Help improve MDN') }}</h2>
+        <p>{{ _('All parts of MDN (docs and the site itself) are created by an open community of developers. Please join us! Pick one of these ways to help:') }}</p>
+        <ul>
+          <li><a href="{{ wiki_url('MDN/Getting_started') }}">{{ _('Getting started') }}</a></li>
+          <li><a href="{{ wiki_url('MDN/Contribute/Howto/Do_an_editorial_review') }}">{{ _('Editorial review') }}</a></li>
+          <li><a href="{{ wiki_url('MDN/Contribute/Howto/Do_a_technical_review') }}">{{ _('Technical review') }}</a></li>
+          <li><a href="{{ wiki_url('MDN/Contribute/Localize/Translating_pages') }}">{{ _('Translating') }}</a></li>
+          <li><a href="{{ wiki_url('MDN/Promote') }}">{{ _('Promoting MDN') }}</a></li>
+          <li><a href="https://github.com/mdn/kuma#readme">{{ _('Contributing to the MDN codebase') }}</a></li>
+          <li><a href="https://github.com/mdn/browser-compat-data">{{ _('Updating browser compatibility data') }}</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/kuma/payments/jinja2/payments/index.html
+++ b/kuma/payments/jinja2/payments/index.html
@@ -1,9 +1,14 @@
 {% extends "react_base.html" %}
 
-{% block title %}{{ _('Become a monthly supporter') }}{% endblock %}
+{% block title %}{{ page_title(_('Become a monthly supporter')) }}{% endblock %}
 
 {% block document_head %}
-    {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), None)|safe }}
+    <!--
+        This page doesn't need to fetch data, so we pass `True`
+        as an argument to indicate that we have the data we need, which
+        allows the component to load properly.
+    -->
+    {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), True)|safe }}
 {% endblock %}
 
 {% block content %}{% endblock %}

--- a/kuma/payments/jinja2/payments/index.html
+++ b/kuma/payments/jinja2/payments/index.html
@@ -12,3 +12,5 @@
 {% endblock %}
 
 {% block content %}{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/kuma/payments/jinja2/payments/index.html
+++ b/kuma/payments/jinja2/payments/index.html
@@ -12,5 +12,3 @@
 {% endblock %}
 
 {% block content %}{% endblock %}
-
-{% block footer %}{% endblock %}

--- a/kuma/payments/jinja2/payments/index.html
+++ b/kuma/payments/jinja2/payments/index.html
@@ -1,0 +1,11 @@
+{% extends "react_base.html" %}
+
+{% block pageheader %}
+    {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), None)|safe }}
+{% endblock %}
+
+{% block document_head %}{% endblock %}
+
+{% block content %}{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/kuma/payments/jinja2/payments/index.html
+++ b/kuma/payments/jinja2/payments/index.html
@@ -3,11 +3,11 @@
 {% block title %}{{ page_title(_('Become a monthly supporter')) }}{% endblock %}
 
 {% block document_head %}
-    <!--
+   {#
         This page doesn't need to fetch data, so we pass `True`
         as an argument to indicate that we have the data we need, which
-        allows the component render in the server. 
-    -->
+        allows the component to render in the server.
+    #}
     {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), True)|safe }}
 {% endblock %}
 

--- a/kuma/payments/jinja2/payments/index.html
+++ b/kuma/payments/jinja2/payments/index.html
@@ -1,10 +1,10 @@
 {% extends "react_base.html" %}
 
-{% block pageheader %}
+{% block title %}{{ _('Become a monthly supporter') }}{% endblock %}
+
+{% block document_head %}
     {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), None)|safe }}
 {% endblock %}
-
-{% block document_head %}{% endblock %}
 
 {% block content %}{% endblock %}
 

--- a/kuma/payments/jinja2/payments/payments.html
+++ b/kuma/payments/jinja2/payments/payments.html
@@ -1,3 +1,5 @@
+<!-- This page will be replaced in the next sprint by https://github.com/mdn/kuma/issues/6581 -->
+
 {% extends 'base.html' %}
 
 {% block body_attributes %}id="contribute"{% endblock %}

--- a/kuma/payments/jinja2/payments/payments.html
+++ b/kuma/payments/jinja2/payments/payments.html
@@ -42,10 +42,9 @@
 
     <main id="contributions-page" class="contributions-page" role="main">
         <section class="section">
-            <img src="{{ static('img/hero-dino-blank.png') }}" class="backdrop-image" alt="" role="presentation" />
-            <div class="index">
+            <header>
                 <h2>{{_('FAQs')}}</h2>
-            </div>
+            </header>
             <ol id="contribute-faqs" class="faqs clear">
                 {% call faq_entry(1, _("Why is MDN asking me for money?")) %}
                     <p>
@@ -191,9 +190,9 @@
             </ol>
         </section>
         <section class="section">
-            <div class="index">
+            <header>
                 <h2>{{_('Monthly payments')}}</h2>
-            </div>
+            </header>
             <ol id="contribute-monthly-faqs" class="faqs clear">
                 {%- call faq_entry(11, _("How do I manage my monthly payment?")) %}
                     <p>

--- a/kuma/payments/jinja2/payments/payments.html
+++ b/kuma/payments/jinja2/payments/payments.html
@@ -1,4 +1,4 @@
-<!-- This page will be replaced in the next sprint by https://github.com/mdn/kuma/issues/6581 -->
+{# This page will be replaced in the next sprint by https://github.com/mdn/kuma/issues/6581 #}
 
 {% extends 'base.html' %}
 

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -167,7 +167,6 @@ def test_recurring_payment_management_not_logged_in(get, cancel_, client):
 @pytest.mark.parametrize(
     "endpoint",
     [
-        "payments",
         "payment_terms",
         "recurring_payment_initial",
         "recurring_payment_subscription",

--- a/kuma/payments/urls.py
+++ b/kuma/payments/urls.py
@@ -15,4 +15,5 @@ lang_urlpatterns = [
         views.recurring_payment_management,
         name="recurring_payment_management",
     ),
+    re_path(r"", views.index, name="payments_index"),
 ]

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -17,6 +17,12 @@ log = logging.getLogger("kuma.payments.views")
 
 
 @waffle_flag("subscription")
+@never_cache
+def index(request):
+    return render(request, "payments/index.html")
+
+
+@waffle_flag("subscription")
 @ensure_wiki_domain
 @never_cache
 def contribute(request):

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -16,7 +16,6 @@ from .utils import (
 log = logging.getLogger("kuma.payments.views")
 
 
-@waffle_flag("subscription")
 @never_cache
 def index(request):
     return render(request, "payments/index.html")

--- a/kuma/static/styles/components/payments/_page.scss
+++ b/kuma/static/styles/components/payments/_page.scss
@@ -22,6 +22,16 @@
             }
         }
 
+        h1 {
+            @extend %highlight;
+            @include set-font-size($h2-font-size);
+            margin-bottom: 20px;
+        }
+
+        p {
+            margin-bottom: 0;
+        }
+
         @media #{$mq-mobile-and-down} {
             padding: $payment-header-padding-mobile;
         }
@@ -48,11 +58,16 @@
 }
 
 .contributions-page {
+
+    @media #{$mq-small-desktop-and-up} {
+        background: url('/static/img/hero-dino-blank.png') no-repeat 10% 1%;
+    }
+
     .section {
         display: flex;
         position: relative;
         margin: 0 auto;
-        padding: 56px 18px;
+        padding: 56px 25px;
         max-width: 1160px;
 
         .sub-section {
@@ -72,20 +87,7 @@
         }
     }
 
-    .backdrop-image {
-        display: none;
-
-        @media #{$mq-small-desktop-and-up} {
-            display: block;
-            position: absolute;
-            top: 30px;
-            left: 70px;
-            width: 410px;
-            height: auto;
-        }
-    }
-
-    .index {
+    header {
         flex: 30%;
         z-index: 99;
 
@@ -115,6 +117,10 @@
             ul {
                 list-style-type: initial;
                 padding-left: 1em;
+            }
+
+            p:last-of-type {
+                margin-bottom: 0;
             }
 
             .faq-number {

--- a/kuma/static/styles/components/payments/_page.scss
+++ b/kuma/static/styles/components/payments/_page.scss
@@ -119,7 +119,7 @@
                 padding-left: 1em;
             }
 
-            p:last-of-type {
+            p:last-child {
                 margin-bottom: 0;
             }
 

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -95,9 +95,6 @@ urlpatterns += i18n_patterns(
 )
 urlpatterns += [re_path("users/", include("kuma.users.urls"))]
 urlpatterns += i18n_patterns(
-    re_path(r"^payments/$", payment_views.contribute, name="payments"),
-)
-urlpatterns += i18n_patterns(
     re_path(
         r"^contribute/$",
         ensure_wiki_domain(RedirectView.as_view(url=reverse_lazy("payments"))),
@@ -105,6 +102,9 @@ urlpatterns += i18n_patterns(
     ),
 )
 urlpatterns += i18n_patterns(re_path(r"^payments/", include(payments_lang_urlpatterns)))
+urlpatterns += i18n_patterns(
+    re_path(r"payments$", payment_views.index, name="payments")
+)
 urlpatterns += i18n_patterns(
     re_path("", decorator_include(never_cache, users_lang_urlpatterns))
 )

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -97,11 +97,13 @@ urlpatterns += [re_path("users/", include("kuma.users.urls"))]
 urlpatterns += i18n_patterns(
     re_path(
         r"^contribute/$",
-        RedirectView.as_view(url=reverse_lazy("payments")),
+        RedirectView.as_view(url=reverse_lazy("payments_index")),
         name="redirect-to-payments",
     ),
 )
-urlpatterns += i18n_patterns(re_path(r"^payments/?", include(payments_lang_urlpatterns)))
+urlpatterns += i18n_patterns(
+    re_path(r"^payments/?", include(payments_lang_urlpatterns))
+)
 urlpatterns += i18n_patterns(
     re_path("", decorator_include(never_cache, users_lang_urlpatterns))
 )

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -14,7 +14,6 @@ from kuma.core.urlresolvers import i18n_patterns
 from kuma.dashboards.urls import lang_urlpatterns as dashboards_lang_urlpatterns
 from kuma.dashboards.views import index as dashboards_index
 from kuma.landing.urls import lang_urlpatterns as landing_lang_urlpatterns
-from kuma.payments import views as payment_views
 from kuma.payments.urls import lang_urlpatterns as payments_lang_urlpatterns
 from kuma.search.urls import (
     lang_base_urlpatterns as search_lang_base_urlpatterns,

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -101,10 +101,7 @@ urlpatterns += i18n_patterns(
         name="redirect-to-payments",
     ),
 )
-urlpatterns += i18n_patterns(re_path(r"^payments/", include(payments_lang_urlpatterns)))
-urlpatterns += i18n_patterns(
-    re_path(r"payments$", payment_views.index, name="payments")
-)
+urlpatterns += i18n_patterns(re_path(r"^payments/?", include(payments_lang_urlpatterns)))
 urlpatterns += i18n_patterns(
     re_path("", decorator_include(never_cache, users_lang_urlpatterns))
 )

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -97,7 +97,7 @@ urlpatterns += [re_path("users/", include("kuma.users.urls"))]
 urlpatterns += i18n_patterns(
     re_path(
         r"^contribute/$",
-        ensure_wiki_domain(RedirectView.as_view(url=reverse_lazy("payments"))),
+        RedirectView.as_view(url=reverse_lazy("payments")),
         name="redirect-to-payments",
     ),
 )


### PR DESCRIPTION
**Summary:** 
Convert existing FAQ page to the Subscription landing page in React. 

**To do:** 
- [ ] Translations are not working (see screenshots below, where locale is `FR` and header is translated, but not the main content.

**URLs** 
**/payments** is changing from wiki to non-wiki
**/contribute** currently redirects to /payments, is changing from wiki to non-wiki 
**/payments/recurring** is still on the wiki domain, same old Jinja page for now. Header says "Thank you for supporting MDN."

**To test:** 
Go to /payments (http://localhost.org:8000/en-US/payments): 
<img width="1223" alt="Screen Shot 2020-03-05 at 5 29 40 PM" src="https://user-images.githubusercontent.com/650/76032089-2053e400-5f07-11ea-8297-9d49b03ef157.png">

Make sure former /payments/recurring page still works by going to /payments/recurring:
<img width="1228" alt="Screen Shot 2020-03-05 at 5 29 47 PM" src="https://user-images.githubusercontent.com/650/76032084-1cc05d00-5f07-11ea-80be-f065d5c71683.png">
 
Closes #6582 