### PR TITLE
ability to scrape over a deleted document

### DIFF
--- a/kuma/scrape/storage.py
+++ b/kuma/scrape/storage.py
@@ -72,6 +72,8 @@ class Storage(object):
         tags = doc_data.pop("tags", [])
         redirect_to = doc_data.pop("redirect_to", None)
 
+        Document.deleted_objects.filter(locale=locale, slug=slug).delete()
+
         attempt = 0
         document = None
         while attempt < 2 and not document:


### PR DESCRIPTION
If you had a document with the same slug and locale, locally, but it's soft-deleted, then this happens:
```
▶ docker-compose exec web ./manage.py scrape_document https://wiki.developer.mozilla.org/ko/docs/Learn
INFO: Scrape progress, cycle 1: 1 Initializing, 1 Gathering Requirements
INFO: Scrape progress, cycle 2: 2 Initializing, 1 Gathering Requirements, 1 Done
WARNING: On locale "ko", slug "Learn", got error (1062, "Duplicate entry '151137' for key 'PRIMARY'")
....
    storage.save_document(doc_data)
  File "/app/kuma/scrape/storage.py", line 111, in save_document
    assert document is not None
AssertionError
```