### PR TITLE
Hide subscription form when stripe throws an exception

### DIFF
--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -128,7 +128,7 @@
         </li>
       </ul>
     </form>
-    {% if is_me and waffle.flag('subscription') and settings.STRIPE_PUBLIC_KEY %}
+    {% if is_me and waffle.flag('subscription') and settings.STRIPE_PUBLIC_KEY and not has_stripe_crashed %}
       {% include "users/includes/stripe_subscription.html" %}
     {% endif %}
   </div>

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -470,7 +470,7 @@ def user_edit(request, username):
     try:
         subscription_info = retrieve_stripe_subscription_info(edit_user)
         has_stripe_crashed = False
-    except Exception:
+    except stripe.InvalidRequestError:
         raven_client.captureException()
         subscription_info = None
         has_stripe_crashed = True


### PR DESCRIPTION
In the spirit of the chaos monkey, let's at least let users edit their profile when stripe throws an unforeseen error, like in the case of: #6690  (which is still mysterious to me)