### PR TITLE
translation over a deleted translation

### DIFF
--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -189,6 +189,15 @@ def translate(request, document_slug, document_locale):
             # If we are submitting the whole form, we need to check that
             # the Revision is valid before saving the Document.
             if doc_form.is_valid() and (which_form == "doc" or rev_form.is_valid()):
+
+                # If the document you're about to save already exists, as a
+                # soft-delete, then really delete it first.
+                for soft_deleted_document in Document.deleted_objects.filter(
+                    locale=doc_form.cleaned_data["locale"],
+                    slug=doc_form.cleaned_data["slug"],
+                ):
+                    soft_deleted_document.delete(purge=True)
+
                 doc = doc_form.save(parent=parent_doc)
 
                 if which_form == "doc":


### PR DESCRIPTION
Fixes #6673

Here's how I tested it. First I went to a localized piece of content that works and exists. 
E.g. http://wiki.localhost.org:8000/sv-SE/docs/Mozilla/Add-ons/WebExtensions
Then I (soft) deleted it on http://wiki.localhost.org:8000/sv-SE/docs/Mozilla/Add-ons/WebExtensions$delete
Now, if I go back to http://wiki.localhost.org:8000/sv-SE/docs/Mozilla/Add-ons/WebExtensions it actually (rather sneakily) draws from the en-US document despite the locale in the URL. On that now English document (but with Swedish header & footer) I use the language drop-down and pick "Add translation". Then pick Swedish in the list. Then I just go ahead and try to create the new swedish translation. Should not crash :)