### PR TITLE
TypeError in search-results-page on overly big page

### DIFF
--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -166,6 +166,14 @@ class ViewTests(ElasticTestCase):
         # rest_framework works.
         assert response.status_code == 404
 
+    def test_page_too_large(self):
+        # Note that this doesn't use the Wiki host
+        response = self.client.get("/en-US/search", {"page": 2, "q": "anything"})
+        # The search 'q' is fine and the page isn't too large on its own, but
+        # the pagination doesn't go beyond the first page so the rest_frameworks
+        # pagination will trigger an error.
+        assert response.status_code == 400
+
     def test_tokenize_camelcase_titles(self):
         for q in ("get", "element", "by", "id"):
             response = self.client.get(

--- a/kuma/search/views.py
+++ b/kuma/search/views.py
@@ -33,6 +33,10 @@ def search(request, *args, **kwargs):
     # If q is returned in the data, there was a validation error for that field,
     # so return 400 status.
     status = 200 if results.get("q") is None else 400
+    # If there was an error with the pagination you'll get...
+    if results.get("detail"):
+        error = str(results["detail"])
+        status = 400
 
     context = {"results": {"results": None if error else results, "error": error}}
 


### PR DESCRIPTION
Fixes #6350

To reproduce, make a search, on the read-only site, that yields few (less than 100) search results. You may or may not see a "Next" button at the bottom of the page. Click that till the "Next" button doesn't appear anymore. At the point increment the `page=NUMBER` to `page=NUMBER+1` 
E.g. http://localhost.org:8000/en-US/search?q=intersectionobserver&page=2
Before you would get an error inside SSR because the React code assumes there is a count. 
With this change you get this:
<img width="732" alt="Screen Shot 2020-03-17 at 4 44 42 PM" src="https://user-images.githubusercontent.com/26739/76900154-2b940180-686f-11ea-8d3a-18e8d8f56c25.png">
