### PR TITLE
ga tracking on server-side subscriptions

### DIFF
--- a/kuma/core/ga_tracking.py
+++ b/kuma/core/ga_tracking.py
@@ -54,6 +54,12 @@ ACTION_FREE_NEWSLETTER = "free-newsletter"
 # existing based on a *different* (already created profile) provider.
 ACTION_SOCIAL_AUTH_ADD = "social-auth-add"
 
+CATEGORY_MONTHLY_PAYMENTS = "monthly payments"
+# When a subscription is successfully set up
+ACTION_SUBSCRIPTION_CREATED = "subscription created"
+# When it's canceled either by webhook or by UI
+ACTION_SUBSCRIPTION_CANCELED = "subscription canceled"
+
 
 def track_event(
     event_category,

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1732,6 +1732,15 @@ STRIPE_MAX_NETWORK_RETRIES = config("STRIPE_MAX_NETWORK_RETRIES", default=5, cas
 CONTRIBUTION_SUPPORT_EMAIL = config(
     "CONTRIBUTION_SUPPORT_EMAIL", default="mdn-support@mozilla.com"
 )
+
+# The default amount suggested for monthly subscription payments.
+# As of March 2020, we only have 1 plan and the number is fixed.
+# In the future, we might have multiple plans and this might a dict of amount
+# per plan.
+# The reason it's not an environment variable is to simply indicate that it
+# can't be overridden at the moment based on the environment.
+CONTRIBUTION_AMOUNT_USD = 5.0
+
 CSP_CONNECT_SRC.append("https://checkout.stripe.com")
 CSP_FRAME_SRC.append("https://checkout.stripe.com")
 CSP_IMG_SRC.append("https://*.stripe.com")

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -95,3 +95,9 @@ ENABLE_BCD_SIGNAL = True
 STRIPE_PUBLIC_KEY = "testing"
 STRIPE_SECRET_KEY = "testing"
 STRIPE_PLAN_ID = "testing"
+
+# Amount for the monthly subscription.
+# It's hardcoded here in case some test depends on the number and it futureproofs
+# our tests to not deviate when the actual number changes since that number
+# change shouldn't affect the tests.
+CONTRIBUTION_AMOUNT_USD = 4.99


### PR DESCRIPTION
Fixes #6698

Let me know if you need help on how to test this. After all *you* invented the tooling in the first place. 

Also, I slowly realized that https://github.com/mdn/kuma/issues/6654 can actually wait. Once *this* PR lands, I'll go back to https://github.com/mdn/kuma/issues/6654 and refactor some code so it starts to depend on `settings.CONTRIBUTION_AMOUNT_USD`. I'm not in love with the naming of that but it's a start and incremental progress. 