### PR TITLE
Subscription banner to be hidden to active subscribers

### DIFF
--- a/kuma/javascript/src/active-banner.jsx
+++ b/kuma/javascript/src/active-banner.jsx
@@ -55,6 +55,9 @@ import CloseIcon from './icons/close.svg';
 import { getLocale, gettext, Interpolated } from './l10n.js';
 import UserProvider from './user-provider.jsx';
 
+export const DEVELOPER_NEEDS_ID = 'developer_needs';
+export const SUBSCRIPTION_ID = 'subscription_banner';
+
 // Set a localStorage key with a timestamp the specified number of
 // days into the future. When the user dismisses a banner we use this
 // to prevent the redisplay of the banner for a while.
@@ -98,6 +101,21 @@ function isEmbargoed(id) {
         // just won't work
         return false;
     }
+}
+
+// Certain banners don't apply to the user based on other reasons.
+// For example, the Subscription banner should not be displayed
+// if the user is authenticated and has 'isSubscriber'.
+function notForThisUser(id, userData) {
+    // If the banner is the subscription banner, and the user has a truthy
+    // 'isSubscriber' they don't get this banner.
+    if (id === SUBSCRIPTION_ID) {
+        if (userData.isSubscriber) {
+            // This user will NOT get this banner.
+            return true;
+        }
+    }
+    return false;
 }
 
 // The <Banner> component displays a simple call-to-action banner at
@@ -179,9 +197,6 @@ function Banner(props: BannerProps) {
     );
 }
 
-export const DEVELOPER_NEEDS_ID = 'developer_needs';
-export const SUBSCRIPTION_ID = 'subscription_banner';
-
 export default function ActiveBanner() {
     const userData = useContext(UserProvider.context);
     const locale = getLocale();
@@ -191,7 +206,11 @@ export default function ActiveBanner() {
     }
 
     for (const id in userData.waffle.flags) {
-        if (!userData.waffle.flags[id] || isEmbargoed(id)) {
+        if (
+            !userData.waffle.flags[id] ||
+            isEmbargoed(id) ||
+            notForThisUser(id, userData)
+        ) {
             continue;
         }
 

--- a/kuma/javascript/src/active-banner.jsx
+++ b/kuma/javascript/src/active-banner.jsx
@@ -55,9 +55,6 @@ import CloseIcon from './icons/close.svg';
 import { getLocale, gettext, Interpolated } from './l10n.js';
 import UserProvider from './user-provider.jsx';
 
-export const DEVELOPER_NEEDS_ID = 'developer_needs';
-export const SUBSCRIPTION_ID = 'subscription_banner';
-
 // Set a localStorage key with a timestamp the specified number of
 // days into the future. When the user dismisses a banner we use this
 // to prevent the redisplay of the banner for a while.
@@ -101,21 +98,6 @@ function isEmbargoed(id) {
         // just won't work
         return false;
     }
-}
-
-// Certain banners don't apply to the user based on other reasons.
-// For example, the Subscription banner should not be displayed
-// if the user is authenticated and has 'isSubscriber'.
-function notForThisUser(id, userData) {
-    // If the banner is the subscription banner, and the user has a truthy
-    // 'isSubscriber' they don't get this banner.
-    if (id === SUBSCRIPTION_ID) {
-        if (userData.isSubscriber) {
-            // This user will NOT get this banner.
-            return true;
-        }
-    }
-    return false;
 }
 
 // The <Banner> component displays a simple call-to-action banner at
@@ -197,6 +179,9 @@ function Banner(props: BannerProps) {
     );
 }
 
+export const DEVELOPER_NEEDS_ID = 'developer_needs';
+export const SUBSCRIPTION_ID = 'subscription_banner';
+
 export default function ActiveBanner() {
     const userData = useContext(UserProvider.context);
     const locale = getLocale();
@@ -206,12 +191,17 @@ export default function ActiveBanner() {
     }
 
     for (const id in userData.waffle.flags) {
-        if (
-            !userData.waffle.flags[id] ||
-            isEmbargoed(id) ||
-            notForThisUser(id, userData)
-        ) {
+        if (!userData.waffle.flags[id] || isEmbargoed(id)) {
             continue;
+        }
+
+        // The Subscription banner is special. It should not be displayed
+        // if the user has a truthy `isSubscriber`.
+        if (id === SUBSCRIPTION_ID) {
+            if (userData.isSubscriber) {
+                // This user will NOT get this banner.
+                return true;
+            }
         }
 
         switch (id) {

--- a/kuma/javascript/src/active-banner.test.js
+++ b/kuma/javascript/src/active-banner.test.js
@@ -7,11 +7,11 @@ import ActiveBanner, {
 } from './active-banner.jsx';
 import UserProvider from './user-provider.jsx';
 
-const mockUserData = { ...UserProvider.defaultUserData };
-
 describe('ActiveBanner', () => {
+    let mockUserData;
     beforeEach(() => {
         localStorage.clear();
+        mockUserData = { ...UserProvider.defaultUserData };
     });
 
     test('renders nothing if no waffle flags set', () => {
@@ -52,6 +52,22 @@ describe('ActiveBanner', () => {
                 ).toJSON()
             )
         ).toContain(SUBSCRIPTION_ID);
+    });
+
+    test('renders nothing for logged in users is active subscriber', () => {
+        mockUserData.isAuthenticated = true;
+        mockUserData.isSubscriber = true;
+        mockUserData.waffle.flags = {
+            [SUBSCRIPTION_ID]: true
+        };
+
+        expect(
+            create(
+                <UserProvider.context.Provider value={mockUserData}>
+                    <ActiveBanner />
+                </UserProvider.context.Provider>
+            ).toJSON()
+        ).toBe(null);
     });
 
     test('renders nothing if user not logged in', () => {

--- a/kuma/javascript/src/user-provider.jsx
+++ b/kuma/javascript/src/user-provider.jsx
@@ -13,6 +13,7 @@ export type UserData = {
     isSuperuser: boolean,
     timezone: ?string,
     avatarUrl: ?string,
+    isSubscriber: boolean,
     waffle: {
         flags: { [flag_name: string]: boolean },
         switches: { [switch_name: string]: boolean },
@@ -28,6 +29,7 @@ const defaultUserData: UserData = {
     isSuperuser: false,
     timezone: null,
     avatarUrl: null,
+    isSubscriber: false,
     waffle: {
         flags: {},
         switches: {},
@@ -62,6 +64,7 @@ export default function UserProvider(props: {
                     isSuperuser: data.is_super_user,
                     timezone: data.timezone,
                     avatarUrl: data.avatar_url,
+                    isSubscriber: data.is_subscriber,
                     // NOTE: if we ever decide that waffle data should
                     // be re-fetched on client-side navigation, we'll
                     // have to create a separate context for it.

--- a/kuma/javascript/src/user-provider.test.js
+++ b/kuma/javascript/src/user-provider.test.js
@@ -68,6 +68,7 @@ describe('UserProvider', () => {
                         is_beta_tester: false,
                         is_staff: true,
                         is_super_user: false,
+                        is_subscriber: false,
                         timezone: null,
                         avatar_url: null,
                         waffle: waffleFlags


### PR DESCRIPTION
Fixes #6702

I didn't realize this but in our jsx files, we're converting the result of `/api/v1/whoami` into a brand new object and I didn't update that when I added the `is_subscriber` to Django. And the tests didn't notice :(