### PR TITLE
redirect to parent of deleted documents if possible

### DIFF
--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -894,7 +894,7 @@ def react_document(request, document_slug, document_locale):
                 return redirect(redirect_url)
         else:
             # It could be that the document you're trying to view was deleted and
-            # the reason we're not finding a fallback is the because the slug
+            # the reason we're not finding a fallback is because the slug
             # doesn't match.
             # E.g. you're trying to view `/sv-SE/docs/Foö/Bår` but that document
             # was deleted and as a soft-delete its parent was `/en-US/docs/Foo/Bar`

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -897,7 +897,7 @@ def react_document(request, document_slug, document_locale):
             # the reason we're not finding a fallback is because the slug
             # doesn't match.
             # E.g. you're trying to view `/sv-SE/docs/Foö/Bår` but that document
-            # was deleted and as a soft-delete its parent was `/en-US/docs/Foo/Bar`
+            # was soft-deleted and its parent was `/en-US/docs/Foo/Bar`
             if document_locale != settings.LANGUAGE_CODE:  # Not in English!
                 redirect_url = _get_deleted_parent_redirect_url(
                     document_locale, document_slug

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -247,6 +247,14 @@ def _default_locale_fallback(request, document_slug, document_locale):
     return fallback_doc, fallback_reason, redirect_url
 
 
+def _get_deleted_parent_redirect_url(document_locale, document_slug):
+    for document in Document.deleted_objects.filter(
+        locale=document_locale, slug=document_slug, parent__isnull=False
+    ):
+        if document.parent:
+            return document.parent.get_absolute_url()
+
+
 def _get_doc_and_fallback_reason(document_locale, document_slug):
     """
     Attempt to fetch a Document at the given locale and slug, and
@@ -885,6 +893,18 @@ def react_document(request, document_slug, document_locale):
             if redirect_url is not None:
                 return redirect(redirect_url)
         else:
+            # It could be that the document you're trying to view was deleted and
+            # the reason we're not finding a fallback is the because the slug
+            # doesn't match.
+            # E.g. you're trying to view `/sv-SE/docs/Foö/Bår` but that document
+            # was deleted and as a soft-delete its parent was `/en-US/docs/Foo/Bar`
+            if document_locale != settings.LANGUAGE_CODE:  # Not in English!
+                redirect_url = _get_deleted_parent_redirect_url(
+                    document_locale, document_slug
+                )
+                if redirect_url:
+                    return redirect(redirect_url)
+
             raise Http404
 
     # We found a Document. Now we need to figure out how we're going


### PR DESCRIPTION
Fixes #6708

Steps to reproduce. 
Go to any en-US page on wiki.localhost.org:8000 and click to make a translation of it. Pick a language. When you edit, the only thing you change is the title and publish. Make a page like this for example: http://wiki.localhost.org:8000/sv-SE/docs/Web/HTML/Element/l%C3%A4nk
Now, once published, use the Wiki to delete it. That means you'll get a 404, in `curl`, on http://localhost.org:8000/sv-SE/docs/Web/HTML/Element/l%C3%A4nk
Now, enable this branch and that 404 will turn into a 302. 