### PR TITLE
NoReverseMatch on users.user_delete

### DIFF
--- a/kuma/users/jinja2/users/includes/delete-user-content.html
+++ b/kuma/users/jinja2/users/includes/delete-user-content.html
@@ -1,5 +1,5 @@
 <div class="text-content delete-user-content" id="user-delete">
-
+    {% if username %}
     <form id="delete-user-form" action="{{ url('users.user_delete', username) }}" method="post">
         {% csrf_token %}
 
@@ -24,4 +24,5 @@
         <button type="button" id="cancel-button" class="simple-text" data-first-focusable="true">{{ _('Cancel') }}</button>
         <button type="submit" id="delete-user-confirm" {% if revisions.exists() %}class="disabled" disabled{% else %}class="negative"{% endif %}>{{ _('Yes, Delete my Account') }}</button>
     </form>
+    {% endif %}
 </div>


### PR DESCRIPTION
Fixes #6696

## Steps to reproduce:

1. Go to Edit Profile
2. Change username to an empty string
3. Press "Save profile"

## Expected behavior:

<img width="856" alt="Screen Shot 2020-03-20 at 1 16 49 PM" src="https://user-images.githubusercontent.com/26739/77188961-33d98000-6aad-11ea-876f-e83fbd140e19.png">

## Actual behavior:

Crash! 💥 🥵