### PR TITLE
list children when you can't delete a parent

### DIFF
--- a/kuma/wiki/jinja2/wiki/confirm_document_delete.html
+++ b/kuma/wiki/jinja2/wiki/confirm_document_delete.html
@@ -5,9 +5,18 @@
 
   <article class="delete-document">
 
-    {% if prevent %}
+    {# HACK: https://bugzil.la/972545 - Don't delete pages that have children #}
+    {# TODO: https://bugzil.la/972541 - Deleting a page that has subpages #}
+    {% if document.children.exists() %}
         <p class="warning">{{ _('Cannot delete pages with children until we fix this bug:') }} <a target="_blank" rel="noopener" href="https://bugzilla.mozilla.org/show_bug.cgi?id=972541">https://bugzilla.mozilla.org/show_bug.cgi?id=972541</a>
         </p>
+
+        <p>{{ _('Here are the the children of this page') }}</p>
+        <ul>
+          {% for document in document.children.all().order_by('title') %}
+              <li><a href="{{ document.get_absolute_url() }}">{{ document.title }}</a></li>
+          {% endfor %}
+        </ul>
     {% else %}
 
     {{ build_document_crumbs(document) }}

--- a/kuma/wiki/views/delete.py
+++ b/kuma/wiki/views/delete.py
@@ -82,10 +82,6 @@ def delete_document(request, document_slug, document_locale):
     """
     document = get_object_or_404(Document, locale=document_locale, slug=document_slug)
 
-    # HACK: https://bugzil.la/972545 - Don't delete pages that have children
-    # TODO: https://bugzil.la/972541 - Deleting a page that has subpages
-    prevent = document.children.exists()
-
     first_revision = document.revisions.all()[0]
 
     if request.method == "POST":
@@ -108,7 +104,6 @@ def delete_document(request, document_slug, document_locale):
         "form": form,
         "request": request,
         "revision": first_revision,
-        "prevent": prevent,
     }
     return render(request, "wiki/confirm_document_delete.html", context)
 


### PR DESCRIPTION
If you stumble on a page that is actually a "parent" you get that red warning with no info about  how many children there are. So this can help in realizing "Oh there's only 2 children that might need to be deleted."

Looks like this:
<img width="828" alt="Screen Shot 2020-03-26 at 11 41 43 AM" src="https://user-images.githubusercontent.com/26739/77666704-a5a34500-6f57-11ea-9bc4-3e9d6407d8ae.png">
