### PR TITLE
auth modal available outside login

### DIFF
--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -397,7 +397,6 @@ exports[`Header snapshot 1`] = `
   </form>
   <a
     className="signin-link"
-    data-service="GitHub"
     href="/en-US/users/account/signup-landing?next=/[fake%20absolute%20url]"
     onClick={[Function]}
     rel="nofollow"

--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -66,7 +66,6 @@ exports[`Login component when user is logged in 1`] = `
 exports[`Login component when user is not logged in 1`] = `
 <a
   className="signin-link"
-  data-service="GitHub"
   href="/en-US/users/account/signup-landing?next=/"
   onClick={[Function]}
   rel="nofollow"

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -5,10 +5,8 @@ import { useContext } from 'react';
 import Dropdown from './dropdown.jsx';
 import { getLocale, gettext } from '../l10n.js';
 import UserProvider from '../user-provider.jsx';
-import GAProvider from '../ga-provider.jsx';
 
 export default function Login(): React.Node {
-    const ga = useContext(GAProvider.context);
     const locale = getLocale();
     const userData = useContext(UserProvider.context);
 
@@ -24,19 +22,20 @@ export default function Login(): React.Node {
     const LOCATION = window.location.pathname;
 
     /**
-     * Send a signal to GA when a user clicks on the Sing In
-     * lnk in the header.
-     * @param {Object} event - The event object that was triggered
+     * If you click the "Sign in" link, reach out to the global
+     * 'windown.mdn.triggerAuthModal' if it's available.
+     *
+     * @param {Object} event - The click event
      */
-    function sendSignInEvent(event) {
-        const service = event.target.dataset.service;
-
-        ga('send', {
-            hitType: 'event',
-            eventCategory: 'Authentication',
-            eventAction: 'Started sign-in',
-            eventLabel: service
-        });
+    function triggerAuthModal(event) {
+        // If window.mdn.triggerAuthModal is available, use that. But note, the
+        // 'event' here is a React synthetic event object, not a regular DOM
+        // event. So, we prevent *this* synthetic event and hand over to the
+        // global window.mdn.triggerAuthModal() function to take over.
+        if (window.mdn && window.mdn.triggerAuthModal) {
+            event.preventDefault();
+            window.mdn.triggerAuthModal();
+        }
     }
 
     if (userData.isAuthenticated && userData.username) {
@@ -85,10 +84,9 @@ export default function Login(): React.Node {
         return (
             <a
                 href={`/${locale}/users/account/signup-landing?next=${LOCATION}`}
-                data-service="GitHub"
                 rel="nofollow"
                 className="signin-link"
-                onClick={sendSignInEvent}
+                onClick={triggerAuthModal}
             >
                 {gettext('Sign in')}
             </a>

--- a/kuma/static/js/components/modal.js
+++ b/kuma/static/js/components/modal.js
@@ -26,7 +26,9 @@
          */
         closeModal: function(modal, modalTrigger) {
             modal.classList.add('hidden');
-            modalTrigger.focus();
+            if (modalTrigger) {
+                modalTrigger.focus();
+            }
         },
         /**
          * Handles the following keyboard events:

--- a/kuma/static/js/components/user-signup/auth-modal.js
+++ b/kuma/static/js/components/user-signup/auth-modal.js
@@ -10,8 +10,8 @@
         return;
     }
 
-    var pageHeader = document.querySelector('.page-header');
-    pageHeader.addEventListener('click', function(event) {
+    function triggerAuthModal() {
+
         function handleKeyup(event) {
             if (event.key === 'Escape') {
                 closeModalButton.click();
@@ -19,27 +19,21 @@
         }
 
         var closeModalButton = document.getElementById('close-modal');
+        var modalContentContainer = authModalContainer.querySelector('section');
+        authModalContainer.classList.remove('hidden');
+        modalContentContainer.focus();
 
-        if (event.target.classList.contains('signin-link')) {
-            event.preventDefault();
-            var modalContentContainer = authModalContainer.querySelector(
-                'section'
-            );
+        closeModalButton.addEventListener('click', function() {
+            window.mdn.modalDialog.closeModal(authModalContainer);
+            document.removeEventListener('keyup', handleKeyup);
+        });
 
-            authModalContainer.classList.remove('hidden');
-            modalContentContainer.focus();
+        window.mdn.modalDialog.handleKeyboardEvents(authModalContainer);
 
-            closeModalButton.addEventListener('click', function() {
-                window.mdn.modalDialog.closeModal(
-                    authModalContainer,
-                    event.target
-                );
-                document.removeEventListener('keyup', handleKeyup);
-            });
+        document.addEventListener('keyup', handleKeyup);
 
-            window.mdn.modalDialog.handleKeyboardEvents(authModalContainer);
+    }
 
-            document.addEventListener('keyup', handleKeyup);
-        }
-    });
+    window.mdn.triggerAuthModal = triggerAuthModal;
+
 })();


### PR DESCRIPTION
Fixes #6740
Fixes #6747

Here's how I tested it;
I future-guessed what it could be used for. In `subscription-form.jsx`. So I put this in
```javascript
    function triggerAuthModal(event) {
        // If window.mdn.triggerAuthModal is available, use that. But note, the
        // 'event' here is a React synthetic event object, not a regular DOM
        // event. So, we prevent *this* synthetic event and hand over to the
        // global window.mdn.triggerAuthModal() function to take over.
        if (window.mdn && window.mdn.triggerAuthModal) {
            event.preventDefault();
            window.mdn.triggerAuthModal();
        }
    }
...

<a href="later" onClick={triggerAuthModal}>Test sign in</a>
```

That triggers the auth modal. 

Now, as part of https://github.com/mdn/kuma/issues/6557 I'll be able to use this to display the subscription form to *everyone* but if `!userData.isAuthenticated` then I can *instead* make a trigger to `triggerAuthModal`.