### PR TITLE
allow all for robots on prod wiki

### DIFF
--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -101,6 +101,23 @@ def test_robots_allowed_main_website(client, settings):
     assert b"Disallow: /admin/\n" in content
 
 
+def test_robots_all_allowed_wiki_website(client, settings):
+    """On the wiki website, allow robots with NO restrictions."""
+    host = "main.mdn.moz.works"
+    wiki_host = "wiki." + host
+    settings.WIKI_HOST = wiki_host
+    settings.ALLOWED_HOSTS = [host, wiki_host]
+    settings.ALLOW_ROBOTS_WEB_DOMAINS = [host, wiki_host]
+    response = client.get(reverse("robots_txt"), HTTP_HOST=wiki_host)
+    assert response.status_code == 200
+    assert_shared_cache_header(response)
+    assert response["Content-Type"] == "text/plain"
+    content = response.content
+    assert b"Sitemap: " in content
+    assert b"Disallow:\n" in content
+    assert b"Disallow: /" not in content
+
+
 def test_robots_allowed_main_attachment_host(client, settings):
     """On the main attachment host, allow robots without restrictions."""
     host = "samples.mdn.moz.works"

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -50,6 +50,13 @@ def promote_buttons(request):
     return render(request, "landing/promote_buttons.html")
 
 
+ROBOTS_ALL_ALLOWED_TXT = """\
+User-agent: *
+Sitemap: https://wiki.developer.mozilla.org/sitemap.xml
+
+Disallow:
+"""
+
 ROBOTS_ALLOWED_TXT = """\
 User-agent: *
 Sitemap: https://developer.mozilla.org/sitemap.xml
@@ -119,7 +126,10 @@ def robots_txt(request):
     if host in settings.ALLOW_ROBOTS_DOMAINS:
         robots = ""
     elif host in settings.ALLOW_ROBOTS_WEB_DOMAINS:
-        robots = ROBOTS_ALLOWED_TXT
+        if host == settings.WIKI_HOST:
+            robots = ROBOTS_ALL_ALLOWED_TXT
+        else:
+            robots = ROBOTS_ALLOWED_TXT
     else:
         robots = ROBOTS_GO_AWAY_TXT
     return HttpResponse(robots, content_type="text/plain")

--- a/tests/headless/__init__.py
+++ b/tests/headless/__init__.py
@@ -17,7 +17,8 @@ INDEXED_ATTACHMENT_DOMAINS = {
 }
 
 # Kuma web domains that are indexed
-INDEXED_WEB_DOMAINS = {"developer.mozilla.org", "wiki.developer.mozilla.org"}
+WIKI_HOST = "wiki.developer.mozilla.org"
+INDEXED_WEB_DOMAINS = {"developer.mozilla.org", WIKI_HOST}
 
 
 def request(method, url, **kwargs):

--- a/tests/headless/test_robots.py
+++ b/tests/headless/test_robots.py
@@ -3,13 +3,13 @@ from urllib.parse import urlsplit
 import pytest
 import requests
 
-from . import INDEXED_ATTACHMENT_DOMAINS, INDEXED_WEB_DOMAINS
+from . import INDEXED_ATTACHMENT_DOMAINS, INDEXED_WEB_DOMAINS, WIKI_HOST
 
 
 @pytest.mark.smoke
 @pytest.mark.headless
 @pytest.mark.nondestructive
-def test_robots(any_host_url):
+def test_robots(any_host_url, wiki_host):
     url = any_host_url + "/robots.txt"
     response = requests.get(url)
     assert response.status_code == 200
@@ -20,6 +20,10 @@ def test_robots(any_host_url):
         assert response.text.strip() == ""
     elif hostname in INDEXED_WEB_DOMAINS:
         assert "Sitemap: " in response.text
-        assert "Disallow: /admin/\n" in response.text
+        if hostname == WIKI_HOST:
+            assert "Disallow:\n" in response.text
+            assert "Disallow: /" not in response.text
+        else:
+            assert "Disallow: /admin/\n" in response.text
     else:
         assert "Disallow: /\n" in response.text


### PR DESCRIPTION
Fixes #6340 

This PR opens up all of the endpoints on the production wiki domain (https://wiki.developer.mozilla.org) to robots. We already put `noindex, nofollow` in place for all of the wiki endpoints via #6502.