### PR TITLE
BCD - Icons overlap labels for RTL locales

### DIFF
--- a/kuma/static/styles/components/compat-tables/_bc-icons.scss
+++ b/kuma/static/styles/components/compat-tables/_bc-icons.scss
@@ -2,24 +2,25 @@
     .bc-head-txt-label {
         display: inline-block;
         bottom: 0;
-        margin: 0 0 20px 10px;
+        margin: 0 0 0 10px;
+        @include bidi(((margin-bottom, 20px, 40px),));
         padding: 0;
         width: 20px;
         height: 20px;
-        transform: rotate(-90deg);
-        transform-origin: left;
+        @include bidi(((transform, rotate(-90deg), rotate(90deg)),));
+        @include bidi(((transform-origin, left, center),));
         @include set-font-size($small-bump-font-size);
         text-align: left;
         white-space: nowrap;
 
         &:before {
             position: absolute;
-            top: 2px;
-            left: -28px;
+            @include bidi(((top, 2px, 5px),));
+            @include bidi(((left, -28px, 28px),));
             display: inline-block;
             content: '';
             background-repeat: no-repeat;
-            transform: rotate(90deg);
+            @include bidi(((transform, rotate(90deg), rotate(-90deg)),));
         }
     }
 

--- a/kuma/static/styles/components/compat-tables/_bc-table.scss
+++ b/kuma/static/styles/components/compat-tables/_bc-table.scss
@@ -16,6 +16,10 @@ table.bc-table {
     border-collapse: separate; /* to over-ride .text-content styles */
     border-spacing: 0;
     @include rgba-fallback('background-color', $table-blue, .5);
+
+    th {
+        text-align: center;
+    }
 }
 
 .bc-table,
@@ -72,7 +76,7 @@ table.bc-table {
 /* second column */
 .bc-table thead td + th,
 .bc-table tbody th + td {
-    border-left: 0;
+    @include bidi(((border-left, 0, 1px solid),));
 }
 
 /* thicker border between platforms */
@@ -116,8 +120,12 @@ table.bc-table {
 }
 
 .bc-table tbody th {
-    border-right: $bc-border-width-thick solid $bc-border-color;
-    border-left: 0;
+    border-width: $bc-border-width-thick;
+    border-color: $bc-border-color;
+    border-style: none;
+    border-top: 1px solid $bc-border-color;
+    @include bidi(((border-right, solid, 0), ));
+    @include bidi(((border-left, 0, solid), ));
     text-align: left;
 }
 
@@ -126,9 +134,12 @@ table.bc-table {
 
 /* empty td in thead */
 .bc-table thead td {
+    border-width: $bc-border-width-thick;
+    border-color: $bc-border-color;
+    border-style: none;
     border-top: 0;
-    border-right: $bc-border-width-thick solid $bc-border-color;
-    border-left: 0;
+    @include bidi(((border-right, solid, 0), ));
+    @include bidi(((border-left, 0, solid), ));
 }
 
 /* make outline more visible */


### PR DESCRIPTION
Fixes alignment of icons and other small table updates for RTL BCD tables

## Before

![77130853-20ed8e00-6a62-11ea-93ab-c26d37765b34](https://user-images.githubusercontent.com/10350960/77903411-1d88ac80-7283-11ea-8d7b-3c4f59f63f4d.png)

## After

![Screenshot 2020-03-30 at 12 34 38](https://user-images.githubusercontent.com/10350960/77903492-3f822f00-7283-11ea-8c59-7b9dfc5190fd.png)

### Testing

* http://localhost.org:8000/he/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
* http://localhost.org:8000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray

If you do not have those document locally, you can scrape them with:

```
make bash
# wait :)
./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Browser_compatibility
# wait
./manage.py https://developer.mozilla.org/he/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Browser_compatibility
```

@mindy r?

fixes #6710 