### PR TITLE
Privacy checkbox hidden with JS disabled

### DIFF
--- a/jinja2/includes/newsletter.html
+++ b/jinja2/includes/newsletter.html
@@ -18,7 +18,7 @@
                 <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="{{ _('you@example.com') }}" size="30">
             </div>
 
-            <div id="newsletterPrivacy" class="form-group form-group-agree newsletter-group-privacy hidden">
+            <div id="newsletterPrivacy" class="form-group form-group-agree newsletter-group-privacy">
                 <input type="checkbox" id="newsletterPrivacyInput" name="privacy" required>
                 <label for="newsletterPrivacyInput">
                 {% trans policy_url="https://www.mozilla.org/privacy/" %}

--- a/kuma/javascript/src/__snapshots__/newsletter.test.jsx.snap
+++ b/kuma/javascript/src/__snapshots__/newsletter.test.jsx.snap
@@ -66,8 +66,8 @@ exports[`Newsletter de-DE 1`] = `
           />
         </div>
         <div
-          aria-hidden={true}
-          className="hidden"
+          aria-hidden={false}
+          className="form-group form-group-agree newsletter-group-privacy"
           id="newsletter-privacy"
         >
           <input
@@ -182,8 +182,8 @@ exports[`Newsletter en-US 1`] = `
           />
         </div>
         <div
-          aria-hidden={true}
-          className="hidden"
+          aria-hidden={false}
+          className="form-group form-group-agree newsletter-group-privacy"
           id="newsletter-privacy"
         >
           <input

--- a/kuma/javascript/src/newsletter.jsx
+++ b/kuma/javascript/src/newsletter.jsx
@@ -44,7 +44,7 @@ export default function Newsletter() {
     const newsletterFormat = 'H';
 
     const [showNewsletter, setShowNewsletter] = useState(true);
-    const [showPrivacyCheckbox, setShowPrivacyCheckbox] = useState(false);
+    const [showPrivacyCheckbox, setShowPrivacyCheckbox] = useState(true);
     const [errors, setError] = useState([]);
     const [
         showSuccessfulSubscription,
@@ -145,6 +145,9 @@ export default function Newsletter() {
         if (disableNewsletter) {
             setShowNewsletter(false);
         }
+        // if JS is enabled client-side, hide the privacy checkbox until
+        // the email input field receive focus
+        setShowPrivacyCheckbox(false);
     }, []);
 
     if (!showNewsletter) {

--- a/kuma/static/js/newsletter.js
+++ b/kuma/static/js/newsletter.js
@@ -30,6 +30,10 @@
         var newsletterEmailInput = doc.getElementById('newsletterEmailInput');
         var newsletterPrivacy = doc.getElementById('newsletterPrivacy');
 
+        // if JS is enabled client-side, hide the privacy checkbox until
+        // the email input field receive focus
+        newsletterPrivacy.classList.add('hidden');
+
         // handle errors
         var errorArray = [];
         var newsletterErrors = doc.getElementById('newsletterErrors');


### PR DESCRIPTION
When JavaScript is disabled or failed to execute the privacy checkbox field is hidden. This makes submitting the form impossible as this is a required field, but is not accessible via the UI.

The pull requests address the issue:

## Landing page

### With JS disabled

![Screenshot 2020-03-30 at 14 43 10](https://user-images.githubusercontent.com/10350960/77914015-89741080-7295-11ea-991f-4e1ad2375f89.png)

### With JS enabled

![Screenshot 2020-03-30 at 14 44 03](https://user-images.githubusercontent.com/10350960/77914030-9133b500-7295-11ea-932f-fff65965524a.png)

## Documentation pages

### With JS disabled

![Screenshot 2020-03-30 at 14 39 58](https://user-images.githubusercontent.com/10350960/77914066-9e50a400-7295-11ea-85fd-f8782b12bbb0.png)

### With JS enabled

![Screenshot 2020-03-30 at 14 40 44](https://user-images.githubusercontent.com/10350960/77914077-a577b200-7295-11ea-9556-fcd7b6b4a0c1.png)

@mindy r?

fixes #5977 