### PR TITLE
Fix cancel button behavior, adjust button styles

### DIFF
--- a/kuma/static/js/components/account-management/delete-user-modal.js
+++ b/kuma/static/js/components/account-management/delete-user-modal.js
@@ -51,9 +51,9 @@
         });
 
         cancelButton.addEventListener('click', function(event) {
+            event.preventDefault();
             window.mdn.modalDialog.closeModal(
-                deleteUserModalContainer,
-                event.target
+                deleteUserModalContainer
             );
         });
     }

--- a/kuma/static/styles/minimalist/atoms/_buttons.scss
+++ b/kuma/static/styles/minimalist/atoms/_buttons.scss
@@ -52,9 +52,8 @@ button.negative,
 button.positive,
 button.disabled {
     display: inline-block;
-    padding: 5px 10px;
-    border: 3px solid #000;
-    border-radius: 3px;
+    padding: 0 7px;
+    border: 2px solid #000;
     min-height: 28px;
     font-weight: bold;
     box-sizing: content-box;

--- a/kuma/static/styles/minimalist/components/user-settings/_delete-user.scss
+++ b/kuma/static/styles/minimalist/components/user-settings/_delete-user.scss
@@ -14,12 +14,6 @@
     }
 
     form {
-        text-align: right;
-
-        .simple-text {
-            margin-right: 10px;
-        }
-
         ul {
             margin: 0;
             padding: 0;
@@ -33,6 +27,10 @@
                     margin-bottom: 24px;
                 }
             }
+        }
+        a {
+            margin-left: 20px;
+            font-weight: bold;
         }
     }
 }

--- a/kuma/static/styles/user-delete.scss
+++ b/kuma/static/styles/user-delete.scss
@@ -6,11 +6,6 @@
 .delete-user-content {
     margin-top: 20px;
 
-    .simple-text {
-        margin-right: 10px;
-        padding-left: 0;
-    }
-
     ul {
         margin: 0;
         padding: 0;
@@ -23,5 +18,9 @@
                 margin-bottom: 24px;
             }
         }
+    }
+    a {
+        margin-left: 20px;
+        font-weight: bold;
     }
 }

--- a/kuma/users/jinja2/users/includes/delete-user-content.html
+++ b/kuma/users/jinja2/users/includes/delete-user-content.html
@@ -21,8 +21,8 @@
 
         <p>{{ _('Are you sure you want to continue?') }}</p>
 
-        <button type="submit" id="delete-user-confirm" {% if revisions.exists() %}class="disabled" disabled{% else %}class="negative"{% endif %}>{{ _('Yes, Delete my Account') }}</button>
-        <a id="cancel-button" href="{{ url('users.user_edit', username=user.username) }}" data-first-focusable="true">{{ _('Cancel') }}</a>
+        <button type="submit" id="delete-user-confirm" {% if revisions.exists() %}class="disabled" disabled{% else %}class="negative"{% endif %} data-first-focusable="true">{{ _('Yes, Delete my Account') }}</button>
+        <a id="cancel-button" href="{{ url('users.user_edit', username=user.username) }}" >{{ _('Cancel') }}</a>
     </form>
     {% endif %}
 </div>

--- a/kuma/users/jinja2/users/includes/delete-user-content.html
+++ b/kuma/users/jinja2/users/includes/delete-user-content.html
@@ -21,8 +21,8 @@
 
         <p>{{ _('Are you sure you want to continue?') }}</p>
 
-        <button type="button" id="cancel-button" class="simple-text" data-first-focusable="true">{{ _('Cancel') }}</button>
         <button type="submit" id="delete-user-confirm" {% if revisions.exists() %}class="disabled" disabled{% else %}class="negative"{% endif %}>{{ _('Yes, Delete my Account') }}</button>
+        <a id="cancel-button" href="{{ url('users.user_edit', username=user.username) }}" data-first-focusable="true">{{ _('Cancel') }}</a>
     </form>
     {% endif %}
 </div>

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -127,8 +127,8 @@
         </li>
         <li>
           {% if is_me %}
-            <a id="delete-user-button" class="negative"
-              href="{{ url('users.user_delete', username=request.user.username) }}">{{ _('Delete Account.') }}</a>
+            <a id="delete-user-button"
+              href="{{ url('users.user_delete', username=request.user.username) }}">{{ _('Delete your account') }}</a>
           {% endif %}
         </li>
       </ul>


### PR DESCRIPTION
### Changes
- Change "Cancel" button to an anchor tag, which points to /edit 
- Make modal and /edit page look more like general designs in Abstract
  - Buttons are aligned left
  - Update delete text
  - Remove border-radius and reduce border-width on positive / negative buttons 

**Modal**
Before:
<img width="697" alt="modal-before" src="https://user-images.githubusercontent.com/650/77966649-70795880-72b1-11ea-87c3-32db8bf45eb5.png">

After:
<img width="673" alt="modal-after" src="https://user-images.githubusercontent.com/650/77966657-77a06680-72b1-11ea-9bad-768b459737ed.png">


**Delete page**
Before:
<img width="712" alt="delete-before" src="https://user-images.githubusercontent.com/650/77966565-4c1d7c00-72b1-11ea-892a-d521ff60631b.png">

After:
<img width="687" alt="delete-after" src="https://user-images.githubusercontent.com/650/77966551-4758c800-72b1-11ea-8d3e-6d0e5544c0b2.png">


**Edit page**
Before:
<img width="712" alt="publish-delete-before" src="https://user-images.githubusercontent.com/650/77966702-8850dc80-72b1-11ea-9cb1-8fcdd8d38429.png">

After:
<img width="564" alt="publish-delete-after" src="https://user-images.githubusercontent.com/650/77966706-8a1aa000-72b1-11ea-86db-45ce073fb0bf.png">

### To test
Make sure the modal cancel button still works: 
1. Go to http://localhost.org:8000/en-US/profiles/{username}/edit
2. Click on "Delete your account"
3. When modal appears, click on "Cancel" button, modal should close

Now check that the actual bug is fixed:
4. Go to http://localhost.org:8000/en-US/profiles/{username}/delete
5. Click on "Cancel", should be taken back to http://localhost.org:8000/en-US/profiles/{username}/edit

Closes #6495 