### PR TITLE
links to untranslated pages

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -118,10 +118,20 @@ export default function Article({ document }: DocumentProps) {
      * like that on the Wiki and click it, it will take you to the
      * form to *create* the page. Disable all of that here in the read-only
      * site.
+     *
+     * The reason we're only going ahead with this mutation for 'en-US' documents
+     * is that many non-en-US documents might have links to slugs that don't
+     * exist in *this* locale but will fall back on the en-US. For example,
+     * a link like this:
+     *
+     *     <a href="/pt-BR/docs/Foo/bar" class="new">Foo bar</a>
+     *
+     * ...might actually work. Even if there is no document with that locale +
+     * slug combination.
      */
     useEffect(() => {
         let rootElement = article.current;
-        if (rootElement) {
+        if (rootElement && document.locale === 'en-US') {
             for (let link of rootElement.querySelectorAll('a.new')) {
                 // Makes it not be clickable and no "pointer" cursor when
                 // hovering. Better than clicking on it and being


### PR DESCRIPTION
Fixes #6727

How to review this? Basically, brew a thermos of tea and read through the notes in the issue. 

I do dare to speculate there's something rather rotten in the Kuma wiki code that sits between KS rendering and the saving of `rendered_html`. 

The whole idea of putting `class="new"` is a Wiki concept. In a traditional wiki, to make a new page you make a link to it and when you render it the first time, that link is now a link to the wizard for creating the page. I.e. I type:

```
I'm going to create a page about DocLegacy.
```
and when rendered it becomes:
```html
I'm going to create a page about <a href="/create.cgi?url=DocLegacy" class="new">DocLegacy(?)</a>.
```

On the MDN wiki we don't quite do it like that. You create a link like this:
```
I'm going to create a page about <a href="/uk/docs/web/doc/legacy">doc legacy</a>.
```
and when you view it, it becomes:
```html
I'm going to create a page about <a href="/uk/docs/web/doc/legacy" class="new">doc legacy</a>.
```

Then, when/if you click that, on the wiki it *redirects* to `/uk/docs/new?slug=web/doc/legacy`.

But all of that is moot on the read-only site. So, letting it be left like this: `<a href="/uk/docs/web/doc/legacy" class="new">` when viewing it means that you'll have a hyperlink that just leads to a 404. That's ugly. That's because, on the *read-only site*, we don't take a `Document.DoesNotExist` to mean a redirect to `/$locale/docs/new?slug=...`.

So for en-US documents, it's better to not link than to link to a page that will 404. I analyzed 150 random en-US documents, in prod, that are all pretty recent. Less than 10% of `a.new` links would have actually worked. (Of that 10% a majority can be explained as out-of-date or just weird links like those that go to `/en-US/docs/`)

Take this page for example; https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/multiple the links to [`size`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) and [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required) get disabled by the JS code but they would have actually worked if you were allowed to click on them. You can verify that by visiting the [wiki page](https://wiki.developer.mozilla.org/en-US/docs/Web/HTML/Attributes/multiple). **Except!**, in writing this I noticed that if you just shift-refresh the page, those links get fixed! So the rendered HTML was just not up-to-date. 

Therefore, I'm fairly confident that this PR is the right thing to do. For now. That's because non-en-US documents have a trick up their sleeve. They can fallback but the en-US ones can't. Additionally, non-en-US pages that have recently been deleted and have a translated slug, can often become perfectly sensible redirects. That's because they're soft-deletes and they can look up their parent and redirect to that. E.g. `/pt-BR/docs/Web/Translato` might 302 to `/en-US/docs/Web/Translations`. 
