### PR TITLE
fix all outbound links when Tracking Protection is off

### DIFF
--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -41,10 +41,6 @@
             if(ga && ga.create) {
                 // Send event to GA
                 ga('send', data);
-                // execute callback now
-                if(callback) {
-                    callback();
-                }
             }
             else if(ga && !ga.create) {
                 // GA blocked or not yet initialized
@@ -52,14 +48,9 @@
                 data.hitCallback = null;
                 // add to queue without callback
                 ga('send', data);
-                // execute callback now
-                if(callback) {
-                    callback();
-                }
             }
-            else if(callback) {
-                // GA disabled or blocked or something, make sure we still
-                // call the caller's callback:
+
+            if(callback) {
                 callback();
             }
         },

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -41,6 +41,10 @@
             if(ga && ga.create) {
                 // Send event to GA
                 ga('send', data);
+                // execute callback now
+                if(callback) {
+                    callback();
+                }
             }
             else if(ga && !ga.create) {
                 // GA blocked or not yet initialized


### PR DESCRIPTION
Fixes #6758

Before checking out this branch; go to the home page. Change your Firefox to disable tracking protection. I.e. clicking the little toggle so it looks like this:
<img width="477" alt="Screen Shot 2020-03-31 at 1 27 45 PM" src="https://user-images.githubusercontent.com/26739/78058162-e6370000-7355-11ea-81ea-4c728825a0bf.png">
(doing that will reload the page)
Now, try to click any link to a Hacks post on the home page. 