### PR TITLE
Add .gitattributes for keeping LF EOL for all text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*	text eol=lf


### PR DESCRIPTION
I once again ran into the problem that kuma will fail to run fairly cryptically if one has CRLF as line endings. Unfortunately git for Windows defaults to applying those for text on checkout (aka `autocrlf`). If one unsets it and updates git, it'll be set again. So this adds a `.gitattributes` file that tells git to use LF for all files, independently of system settings.

This should only affect Windows users and all editors I know of know how to read LFs, so currently I don't foresee any downsides to this.