### PR TITLE
Add task completion survey to landing page

### DIFF
--- a/kuma/javascript/src/landing-page.jsx
+++ b/kuma/javascript/src/landing-page.jsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import A11yNav from './a11y/a11y-nav.jsx';
 import ActiveBanner from './active-banner.jsx';
 import Header from './header/header.jsx';
+import TaskCompletionSurvey from './task-completion-survey.jsx';
 import UserProvider from './user-provider.jsx';
 
 /**
@@ -18,6 +19,7 @@ export default function LandingPage() {
             <A11yNav />
             <Header />
             <ActiveBanner />
+            <TaskCompletionSurvey document={null} />
         </UserProvider>
     );
 }


### PR DESCRIPTION
This turned out _much_ simpler than I anticipated 😸 

@atopal I only added this to the modern front-end as it does not really make much sense to me to have this on the retired `wiki`. Let me know if that was the wrong call.

@Gregoor r?

Fixes #6522 