### PR TITLE
Remove "Experimental" or "Deprecated" from select dropdown on BCD table

### DIFF
--- a/kuma/javascript/src/bcd-signal.jsx
+++ b/kuma/javascript/src/bcd-signal.jsx
@@ -399,11 +399,16 @@ window.activateBCDSignals = (slug: string, locale: string) => {
 
         const rows = document.querySelectorAll('.bc-table th[scope=row]');
         for (const elem of rows) {
-            const featureName = elem.innerText;
-            const option = document.createElement('option');
-            option.innerText = featureName;
-            option.setAttribute('value', featureName);
-            selectControl.appendChild(option);
+            // elemNode can be an HTML element (typically an <a /> tag) or string
+            const elemNode = elem.firstChild;
+            const featureName =
+                elemNode && (elemNode.nodeValue || elemNode.innerText);
+            if (featureName) {
+                const option = document.createElement('option');
+                option.innerText = featureName;
+                option.setAttribute('value', featureName);
+                selectControl.appendChild(option);
+            }
         }
 
         rowControlBlock.appendChild(selectControl);


### PR DESCRIPTION
Changes:
- Get feature name from first child, which excludes "Experimental" and "Deprecated" labels

Before:
<img width="630" alt="Screen Shot 2020-04-06 at 12 28 07 PM" src="https://user-images.githubusercontent.com/650/78581843-6819a400-7802-11ea-902c-faad7151190e.png">

After: 
<img width="620" alt="Screen Shot 2020-04-06 at 12 27 38 PM" src="https://user-images.githubusercontent.com/650/78581858-6ea81b80-7802-11ea-8930-df42e6f3ab61.png">

Closes #6374 