### PR TITLE
link to auth with next

### DIFF
--- a/jinja2/includes/auth-modal-content.html
+++ b/jinja2/includes/auth-modal-content.html
@@ -2,10 +2,10 @@
     {{ _('Sign in to enjoy the benefits of an MDN account. If you haven’t already created an account, you will be prompted to do so after signing in.') }}
 </p>
 <div class="auth-button-container">
-    <a href="{{ provider_login_url('github') }}" class="github-auth" data-first-focusable="true">
+    <a href="{{ provider_login_url('github', next=next_url()) }}" class="github-auth" data-first-focusable="true">
         {{ _('Sign in with Github') }}
     </a>
-    <a href="{{ provider_login_url('google') }}" class="google-auth">
+    <a href="{{ provider_login_url('google', next=next_url()) }}" class="google-auth">
         {{ _('Sign in with Google') }}
     </a>
 </div>

--- a/jinja2/includes/login.html
+++ b/jinja2/includes/login.html
@@ -11,14 +11,14 @@
                     <li><a href="{{ user.get_absolute_url() }}">{{ _('View profile') }}</a></li>
                     <li><a href="{{ url('users.user_edit', username=user.username) }}">{{ _('Edit profile') }}</a></li>
                     <li><form class="login-form" action="{{ url('account_logout') }}" method="post">
-                        <input name="next" type="hidden" value="{{ next_url }}">
+                        <input name="next" type="hidden" value="{{ next_url() }}">
                         <button class="logout button link" type="submit">{{ _('Sign out') }}</button>
                     </form></li>
                 </ul>
             </div>
         </div>
     {% else %}
-        {% set login_url = login_url(next=next_url) %}
+        {% set login_url = login_url(next=next_url()) %}
         <a href="{{ login_url }}" class="login-link js-login-link" rel="nofollow">
             {{ _('Sign in') }}
         </a>

--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -65,7 +65,7 @@ def next_url(request):
 
         {% set url = next_url() %}
 
-    which means that the actual content processor function isn't executed
+    which means that the actual context processor function isn't executed
     every single time any jinja template is rendered. Now, only if the
     context processor is actually needed, it gets executed.
 

--- a/kuma/core/tests/test_misc.py
+++ b/kuma/core/tests/test_misc.py
@@ -1,23 +1,34 @@
 from django.test import RequestFactory
 
-from . import KumaTestCase
-from ..context_processors import next_url
+from kuma.core.context_processors import next_url
+from kuma.core.urlresolvers import reverse
 
 
-class TestNextUrl(KumaTestCase):
-    """
-    Tests that the next_url value is properly set,
-    including query string
-    """
+def test_next_url_basic():
+    path = "/one/two"
+    request = RequestFactory().get(path)
+    assert path == next_url(request)["next_url"]()
 
-    rf = RequestFactory()
 
-    def test_basic(self):
-        path = "/one/two"
-        request = self.rf.get(path)
-        assert path == next_url(request)["next_url"]
+def test_next_url_querystring():
+    path = "/one/two?something"
+    request = RequestFactory().get(path)
+    assert path == next_url(request)["next_url"]()
 
-    def test_querystring(self):
-        path = "/one/two?something"
-        request = self.rf.get(path)
-        assert path == next_url(request)["next_url"]
+
+def test_next_url_with_next_querystring():
+    path = "/one/two?next=/foo/bar"
+    request = RequestFactory().get(path)
+    assert next_url(request)["next_url"]() == "/foo/bar"
+
+
+def test_next_url_with_next_querystring_but_remote():
+    path = "/one/two?next=http://foo/bar"
+    request = RequestFactory().get(path)
+    assert next_url(request)["next_url"]() is None
+
+
+def test_next_url_already_on_login_url(settings):
+    path = reverse(settings.LOGIN_URL)
+    request = RequestFactory().get(path)
+    assert next_url(request)["next_url"]() is None

--- a/kuma/users/jinja2/socialaccount/snippets/provider_list.html
+++ b/kuma/users/jinja2/socialaccount/snippets/provider_list.html
@@ -6,12 +6,12 @@
             {% for brand in provider.get_brands() %}
               <li><a title="{{ brand.name }}"
                  class="socialaccount_provider {{ provider.id }} {{ brand.id }}"
-                 href="{{ provider_login_url(provider.id, openid=brand.openid_url, process=process, next=next_url) }}"
+                 href="{{ provider_login_url(provider.id, openid=brand.openid_url, process=process, next=next_url()) }}"
                  >{{ brand.name }}</a></li>
             {% endfor %}
         {% endif %}
         {% if provider.id == "github" %}
-            <li><a href="{{ provider_login_url(provider.id, process=process, next=next_url) }}" class="github-button js-login-link" data-next="{{ next_url }}" data-service="{{ provider.name }}" data-process="{{ process }}">
+            <li><a href="{{ provider_login_url(provider.id, process=process, next=next_url()) }}" class="github-button js-login-link" data-next="{{ next_url() }}" data-service="{{ provider.name }}" data-process="{{ process }}">
               <span class="github-icon">
                   {% include 'includes/icons/social/github.svg' %}
               </span>
@@ -23,8 +23,6 @@
               {% endif %}
               </span>
             </a></li>
-        {# {% else %}
-          <li><a title="{{ provider.name }}" class="socialaccount_provider {{ provider.id }}" href="{{ provider_login_url(provider.id, process=process, next=next_url) }}">{{ provider.name }}</a></li> #}
         {% endif %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
Fixes #6805 

To test, start by being anonymous, then...

1. go to a page like http://localhost.org:8000/en-US/docs/Web/JavaScript and click "Sign in" clicking on either Google or GitHub will have the `?next=%2Fen-US%2Fdocs%2FWeb%2FJavaScript` thing on it/ 
2. instead of single-clicking the "Sign in" link, right-click and "Open link in a new tab". It should take you to a page like http://localhost.org:8000/en-US/users/account/signup-landing?next=/en-US/docs/Web/JavaScript Observe that the GitHub and Google buttons have `?next=%2Fen-US%2Fdocs%2FWeb%2FJavaScript` on it. 
3. go straight to the sign in landing page http://localhost.org:8000/en-US/users/account/signup-landing and note that the Google and GitHub buttons *don't* have a `?next=...` on them because it doesn't want to redirect back to this page and it should instead redirect to whatever the default is. 
4. type in `http://localhost.org:8000/en-US/profiles/$username/edit` (replace `$username` for something that exists). It should have a "Sign in" link with `?next=%2Fen-US%2Fprofiles%2Fpeterbe%2Fedit` on it. 