### PR TITLE
remove GOOGLE_ANALYTICS_ACCOUNT from constance

### DIFF
--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -1,6 +1,5 @@
 from urllib.parse import urlparse
 
-from constance import config
 from django.conf import settings
 from django.utils import translation
 
@@ -22,18 +21,6 @@ def global_settings(request):
                 netloc="username:secret@" + parsed.netloc.split("@")[-1]
             )
         return parsed.geturl()
-
-    # TODO: Ideally, GOOGLE_ANALYTICS_ACCOUNT is only set in settings (from
-    # an environment variable) but for safe transition, we rely on
-    # constance if it hasn't been put into settings yet.
-    # Once we know with confidence, that GOOGLE_ANALYTICS_ACCOUNT is set
-    # and a valid value in the environment (for production!) then we
-    # can delete these lines of code.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1570076
-    google_analytics_account = getattr(settings, "GOOGLE_ANALYTICS_ACCOUNT", None)
-    if google_analytics_account is None:
-        if config.GOOGLE_ANALYTICS_ACCOUNT != "0":
-            settings.GOOGLE_ANALYTICS_ACCOUNT = config.GOOGLE_ANALYTICS_ACCOUNT
 
     return {
         "settings": settings,

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1446,10 +1446,6 @@ CONSTANCE_CONFIG = dict(
         ),
         "Regex comprised of domain names that are allowed for IFRAME SRCs",
     ),
-    # TODO: Delete this line once we know that the production environment
-    # definitely has 'GOOGLE_ANALYTICS_ACCOUNT' set.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1570076
-    GOOGLE_ANALYTICS_ACCOUNT=("0", "(This is deprecated and will disappear)",),
     GOOGLE_ANALYTICS_CREDENTIALS=(
         "{}",
         "Google Analytics (read-only) API credentials",


### PR DESCRIPTION
Part of #6848

Instead of auditing our env vars in `infra`, here's how I checked that it has fully moved already:

In prod...
```
>>> from constance import config
>>> config.GOOGLE_ANALYTICS_ACCOUNT
'UA-36116321-5'
>>> from django.conf import settings
>>> settings.GOOGLE_ANALYTICS_ACCOUNT
'UA-36116321-5'
```