### PR TITLE
Add @testing-library/jest-dom package 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,12 +10,20 @@ module.exports = {
     parserOptions: {
         ecmaVersion: 6,
     },
-    plugins: ['jest', 'flowtype', 'import', 'jsx-a11y', 'react-hooks'],
+    plugins: [
+        'jest',
+        'jest-dom',
+        'flowtype',
+        'import',
+        'jsx-a11y',
+        'react-hooks',
+    ],
     extends: [
         'eslint:recommended',
         'plugin:import/errors',
         'plugin:flowtype/recommended',
         'plugin:jsx-a11y/recommended',
+        'plugin:jest-dom/recommended',
         'prettier',
     ],
     rules: {

--- a/kuma/javascript/src/payments/feedback-form.test.jsx
+++ b/kuma/javascript/src/payments/feedback-form.test.jsx
@@ -1,7 +1,10 @@
 //@flow
 import React from 'react';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { toHaveAttribute } from '@testing-library/jest-dom/matchers';
 import FeedbackForm, { FEEDBACK_URL } from './feedback-form.jsx';
+
+expect.extend({ toHaveAttribute });
 
 // Fixes "ReferenceError: regeneratorRuntime is not defined" when running jest tests
 require('regenerator-runtime/runtime');

--- a/kuma/javascript/src/payments/feedback-form.test.jsx
+++ b/kuma/javascript/src/payments/feedback-form.test.jsx
@@ -118,10 +118,11 @@ describe('Payments Feedback Form', () => {
 
             // Check that our email address was rendered correctly
             expect(
-                getByText(window.mdn.contributionSupportEmail).getAttribute(
-                    'href'
-                )
-            ).toEqual(`mailto:${window.mdn.contributionSupportEmail}`);
+                getByText(window.mdn.contributionSupportEmail)
+            ).toHaveAttribute(
+                'href',
+                `mailto:${window.mdn.contributionSupportEmail}`
+            );
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "@babel/preset-env": "^7.3.1",
         "@babel/preset-flow": "^7.0.0",
         "@babel/preset-react": "^7.0.0",
+        "@testing-library/jest-dom": "^5.5.0",
         "@testing-library/react": "^10.0.2",
         "babel-eslint": "^10.0.1",
         "babel-loader": "^8.0.5",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "eslint-plugin-flowtype": "^3.4.2",
         "eslint-plugin-import": "^2.16.0",
         "eslint-plugin-jest": "22.1.2",
+        "eslint-plugin-jest-dom": "^2.0.1",
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-prettier": "^3.0.1",
         "eslint-plugin-react": "^7.12.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,21 @@
     dom-accessibility-api "^0.4.2"
     pretty-format "^25.1.0"
 
+"@testing-library/jest-dom@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.5.0.tgz#4707023e8f572021e8a84f65721303ff60828d88"
+  integrity sha512-7sWHrpxG4Yd8TmryI7Rtbx8Ff4mbs3ASye3oshQIuHvsCR+QHgr7rTR/PfeXvOmwUwR36wSTTAvrLKsPmr6VEQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.0.2"
+    chalk "^3.0.0"
+    css "^2.2.4"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react@^10.0.2":
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.2.tgz#8eca7aa52d810cf7150048a2829fdc487162006d"
@@ -1344,6 +1359,14 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.1.tgz#9544cd438607955381c1bdbdb97767a249297db5"
+  integrity sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
 "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1405,6 +1428,13 @@
   integrity sha512-WokGRksRJb3Dla6h02/0/NNHTkjsj4S8aJZiwMj/5/UL8VZ1iCe3H8SHzfpmBeH8Vp4SPRT8iC2o9kYULFhDIw==
   dependencies:
     pretty-format "^25.1.0"
+
+"@types/testing-library__jest-dom@^5.0.2":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.3.tgz#8efef348eeedc62e7de21acbe455a779936417c4"
+  integrity sha512-NdbKc6yseg6uq4UJFwimPws0iwsGugVbPoOTP2EH+PJMJKiZsoSg5F2H3XYweOyytftCOuIMuXifBUrF9CSvaQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/testing-library__react@^10.0.0":
   version "10.0.1"
@@ -3025,7 +3055,12 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
 
-css@^2.2.1:
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.1, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -5222,7 +5257,7 @@ jest-config@^25.3.0:
     pretty-format "^25.3.0"
     realpath-native "^2.0.0"
 
-jest-diff@^25.3.0:
+jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.3.0.tgz#0d7d6f5d6171e5dacde9e05be47b3615e147c26f"
   integrity sha512-vyvs6RPoVdiwARwY4kqFWd4PirPLm2dmmkNzKqo38uZOzJvLee87yzDjIZLmY1SjM3XR5DwsUH+cdQ12vgqi1w==
@@ -5344,7 +5379,7 @@ jest-leak-detector@^25.3.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.3.0"
 
-jest-matcher-utils@^25.3.0:
+jest-matcher-utils@^25.1.0, jest-matcher-utils@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.3.0.tgz#76765788a26edaa8bc5f0100aea52ae383559648"
   integrity sha512-ZBUJ2fchNIZt+fyzkuCFBb8SKaU//Rln45augfUtbHaGyVxCO++ANARdBK9oPGXU3hEDgyy7UHnOP/qNOJXFUg==
@@ -7241,7 +7276,7 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^25.1.0, pretty-format@^25.3.0:
+pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.3.0.tgz#d0a4f988ff4a6cd350342fdabbb809aeb4d49ad5"
   integrity sha512-wToHwF8bkQknIcFkBqNfKu4+UZqnrLn/Vr+wwKQwwvPzkBfDDKp/qIabFqdgtoi5PEnM8LFByVsOrHoa3SpTVA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3577,6 +3577,13 @@ eslint-plugin-import@^2.16.0:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-jest-dom@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-2.0.1.tgz#6df85a46992a86ac800b23304a9285b8c5d701f5"
+  integrity sha512-LY2BP5ucZbKO58I71QHnjH18YcL/XFarZEKBB3aQH+BKtMO+Da4t756JfnCpR4ELydYOr5B0DB8hzjgeQlhLBw==
+  dependencies:
+    requireindex "~1.2.0"
+
 eslint-plugin-jest@22.1.2:
   version "22.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.1.2.tgz#1ea36cc3faedbdb788e702ca633d635ca14e91e8"
@@ -7861,6 +7868,11 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Changes**
- Add `@testing-library/jest-dom` which provides more custom matchers
- Add recommened `eslint-plugin-jest-dom` plugin

**Reasons**
I've been wanting to add this package after `@testing-library/react`, but was afraid of messing up `package-lock.json`, and since we now use `yarn`, I thought I would try. 

I think some of the biggest benefits are readability, clarity, and better assertions. For example, I was writing tests like `expect(...).toBeTruthy(...)`, or `expect(...).toHaveLength(1)`, which both work but are vague. I think it's more meaningful to write, `toHaveTextContent()` or `toBeInDocument()`, for example. Create React App recommends using jest-dom in tandem with React Testing Library.

Here's a bit of code that `eslint-plugin-jest-dom` caught and fixed on commit (it works!). I think the latter is more concise and readable: 

**Before**
```
            // Check that our email address was rendered correctly
            expect(
                getByText(window.mdn.contributionSupportEmail).getAttribute(
                    'href'
                )
            ).toEqual(`mailto:${window.mdn.contributionSupportEmail}`);
```

**After**
```
            // Check that our email address was rendered correctly
            expect(
                getByText(window.mdn.contributionSupportEmail)
            ).toHaveAttribute(
                'href',
                `mailto:${window.mdn.contributionSupportEmail}`
            );
```

