### PR TITLE
merge-when-green config

### DIFF
--- a/.github/merge-when-green.yml
+++ b/.github/merge-when-green.yml
@@ -1,0 +1,3 @@
+# From https://github.com/phstc/probot-merge-when-green#configuration
+mergeMethod: squash
+requireApprovalFromRequestedReviewers: true


### PR DESCRIPTION
I don't yet know why `merge when green` isn't working. Look at https://github.com/mdn/kuma/pull/6861 for example. 
Perhaps you need to have a config file. Either way, that's how I found out to change tell Merge-when-green to use the "Squash and merge" method. 
