### PR TITLE
move constance EMAIL_LIST_MDN_ADMINS to settings

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1512,12 +1512,12 @@ CONSTANCE_CONFIG = dict(
         "Email address from which welcome emails will be sent",
     ),
     AKISMET_KEY=("", "API key for Akismet spam checks, leave empty to disable"),
-    EMAIL_LIST_MDN_ADMINS=(
-        "mdn-admins@mozilla.org",
-        "Email address to request admin intervention",
-    ),
 )
 
+# Email address to request admin intervention
+EMAIL_LIST_MDN_ADMINS = config(
+    "EMAIL_LIST_MDN_ADMINS", default="mdn-admins@mozilla.org"
+)
 
 # Name of the django.contrib.auth.models.Group to use as beta testers
 BETA_GROUP_NAME = config("BETA_GROUP_NAME", default="Beta Testers")

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -1,5 +1,5 @@
 import newrelic.agent
-from constance import config
+from django.conf import settings
 from django.shortcuts import redirect, render
 from django.views.decorators.cache import never_cache
 
@@ -31,7 +31,7 @@ def create(request):
         context = {
             "reason": "create-page",
             "request_page_url": DEV_DOC_REQUEST_FORM,
-            "email_address": config.EMAIL_LIST_MDN_ADMINS,
+            "email_address": settings.EMAIL_LIST_MDN_ADMINS,
         }
         return render(request, "403-create-page.html", context=context, status=403)
 


### PR DESCRIPTION
Part of #6848

Here's how I checked the default on prod:
```
>>> from constance import config
>>> config.EMAIL_LIST_MDN_ADMINS
'mdn-admins@mozilla.org'
```