### PR TITLE
Visual edits to subscription form

### DIFF
--- a/kuma/javascript/src/payments/subscription-form.jsx
+++ b/kuma/javascript/src/payments/subscription-form.jsx
@@ -267,7 +267,7 @@ export default function SubscriptionForm() {
                             setPaymentAuthorized(event.target.checked);
                         }}
                     />
-                    <div>
+                    <span>
                         <Interpolated
                             id={gettext(
                                 'By clicking this button, I authorize Mozilla to charge this payment method each month, according to the <paymentTermsLink />, until I cancel my subscription.'
@@ -282,7 +282,7 @@ export default function SubscriptionForm() {
                                 </a>
                             }
                         />
-                    </div>
+                    </span>
                 </label>
                 <button type="submit" className="button cta primary">
                     {gettext(

--- a/kuma/javascript/src/payments/subscription-form.jsx
+++ b/kuma/javascript/src/payments/subscription-form.jsx
@@ -267,7 +267,7 @@ export default function SubscriptionForm() {
                             setPaymentAuthorized(event.target.checked);
                         }}
                     />
-                    <span>
+                    <small>
                         <Interpolated
                             id={gettext(
                                 'By clicking this button, I authorize Mozilla to charge this payment method each month, according to the <paymentTermsLink />, until I cancel my subscription.'
@@ -282,16 +282,16 @@ export default function SubscriptionForm() {
                                 </a>
                             }
                         />
-                    </span>
+                    </small>
                 </label>
                 <button type="submit" className="button cta primary">
                     {gettext(
                         formStep === 'submitting' ? 'Submitting...' : 'Continue'
                     )}
                 </button>
-                <span className="subtext">
+                <small className="subtext">
                     {gettext('Payments are not tax deductible')}
-                </span>
+                </small>
             </form>
         );
     }

--- a/kuma/javascript/src/payments/subscription-form.jsx
+++ b/kuma/javascript/src/payments/subscription-form.jsx
@@ -267,7 +267,7 @@ export default function SubscriptionForm() {
                             setPaymentAuthorized(event.target.checked);
                         }}
                     />
-                    <small>
+                    <div>
                         <Interpolated
                             id={gettext(
                                 'By clicking this button, I authorize Mozilla to charge this payment method each month, according to the <paymentTermsLink />, until I cancel my subscription.'
@@ -282,16 +282,16 @@ export default function SubscriptionForm() {
                                 </a>
                             }
                         />
-                    </small>
+                    </div>
                 </label>
                 <button type="submit" className="button cta primary">
                     {gettext(
                         formStep === 'submitting' ? 'Submitting...' : 'Continue'
                     )}
                 </button>
-                <small className="subtext">
+                <span className="subtext">
                     {gettext('Payments are not tax deductible')}
-                </small>
+                </span>
             </form>
         );
     }

--- a/kuma/static/styles/minimalist/components/subscriptions/_subscription-form.scss
+++ b/kuma/static/styles/minimalist/components/subscriptions/_subscription-form.scss
@@ -27,7 +27,6 @@
         section,
         form {
             font-size: 12px;
-
             padding: 20px 20px 5px;
 
             &.error {
@@ -40,9 +39,6 @@
 
             label {
                 display: flex;
-                input {
-                    margin: 0 10px 0 0;
-                }
             }
 
             button {
@@ -53,7 +49,6 @@
 
                 &::after {
                     float: right;
-                    display: inline-block;
                     content: '';
                     background: transparent
                         url('../../../../arrows/arrow-right.svg') 0 0 no-repeat;
@@ -68,8 +63,11 @@
             // and haven't even started paying attention to the form, the checkbox,
             // in Firefox, will appear red. Like something is wrong!
             // This will undo that.
-            input[type='checkbox']:required {
-                box-shadow: none;
+            input[type='checkbox'] {
+                margin: 0 10px 0 0;
+                &:required {
+                    box-shadow: none;
+                }
             }
         }
 

--- a/kuma/static/styles/minimalist/components/subscriptions/_subscription-form.scss
+++ b/kuma/static/styles/minimalist/components/subscriptions/_subscription-form.scss
@@ -21,12 +21,14 @@
         background-color: #fff;
         border-radius: 4px;
         box-shadow: $box-shadow-blue;
-        max-width: 460px;
-        min-height: 320px;
+        min-width: 470px;
+        width: 470px;
 
         section,
         form {
-            padding: 20px 20px 0;
+            font-size: 12px;
+
+            padding: 20px 20px 5px;
 
             &.error {
                 padding: 20px;
@@ -34,6 +36,13 @@
 
             h2 {
                 margin: 0;
+            }
+
+            label {
+                display: flex;
+                input {
+                    margin: 0 10px 0 0;
+                }
             }
 
             button {

--- a/kuma/static/styles/minimalist/components/subscriptions/_subscription-form.scss
+++ b/kuma/static/styles/minimalist/components/subscriptions/_subscription-form.scss
@@ -26,7 +26,7 @@
 
         section,
         form {
-            font-size: 12px;
+            font-size: 14.5px; // this sets the <small /> text to about 12px
             padding: 20px 20px 5px;
 
             &.error {
@@ -39,6 +39,7 @@
 
             label {
                 display: flex;
+                align-items: flex-start;
             }
 
             button {
@@ -64,7 +65,7 @@
             // in Firefox, will appear red. Like something is wrong!
             // This will undo that.
             input[type='checkbox'] {
-                margin: 0 10px 0 0;
+                margin: 2px 8px 0 0;
                 &:required {
                     box-shadow: none;
                 }


### PR DESCRIPTION
**Changes**
- Decrease form font size to 12px
- Set width of form to 470px
- Disallow wrapping of text around checkbox 

**To test**
Visit http://localhost.org:8000/en-US/payments/

**Before**
<img width="971" alt="Screen Shot 2020-04-13 at 3 39 44 PM" src="https://user-images.githubusercontent.com/650/79164447-15fef280-7daf-11ea-8a2f-1023af8ec353.png">

**After**
<img width="1044" alt="Screen Shot 2020-04-13 at 3 19 53 PM" src="https://user-images.githubusercontent.com/650/79164466-1c8d6a00-7daf-11ea-9588-3775768df7a7.png">


