### PR TITLE
Events for (un)authenticated user subscription conversion

### DIFF
--- a/kuma/javascript/src/active-banner.jsx
+++ b/kuma/javascript/src/active-banner.jsx
@@ -56,7 +56,7 @@ import { getLocale, gettext, interpolate } from './l10n.js';
 import UserProvider from './user-provider.jsx';
 import GAProvider, {
     CATEGORY_MONTHLY_PAYMENTS,
-    gaQuery,
+    gaSendOnNextPage,
 } from './ga-provider.jsx';
 
 // Set a localStorage key with a timestamp the specified number of
@@ -234,7 +234,17 @@ function SubscriptionBanner() {
                 }
             )}
             cta={gettext('Learn more')}
-            url={`/${locale}/payments/?${gaQuery(['banner-cta'])}`}
+            url={`/${locale}/payments/`}
+            onCTAClick={() => {
+                gaSendOnNextPage([
+                    {
+                        hitType: 'event',
+                        eventCategory: CATEGORY_MONTHLY_PAYMENTS,
+                        eventAction: 'subscribe intent',
+                        eventLabel: 'banner',
+                    },
+                ]);
+            }}
             embargoDays={7}
         />
     );

--- a/kuma/javascript/src/active-banner.jsx
+++ b/kuma/javascript/src/active-banner.jsx
@@ -234,7 +234,7 @@ function SubscriptionBanner() {
                 }
             )}
             cta={gettext('Learn more')}
-            url={`/${locale}/payments/?${gaQuery('banner-cta')}`}
+            url={`/${locale}/payments/?${gaQuery(['banner-cta'])}`}
             embargoDays={7}
         />
     );

--- a/kuma/javascript/src/ga-provider.jsx
+++ b/kuma/javascript/src/ga-provider.jsx
@@ -9,9 +9,13 @@ export const CATEGORY_MONTHLY_PAYMENTS = 'monthly payments';
 const GA_SESSION_STORAGE_KEY = 'ga';
 
 function getPostponedEvents() {
-    return JSON.parse(
-        sessionStorage.getItem(GA_SESSION_STORAGE_KEY) || JSON.stringify([])
-    );
+    try {
+        return JSON.parse(
+            sessionStorage.getItem(GA_SESSION_STORAGE_KEY) || JSON.stringify([])
+        );
+    } catch (e) {
+        // No sessionStorage support
+    }
 }
 
 /**
@@ -21,11 +25,15 @@ function getPostponedEvents() {
  * requests).
  */
 export function gaSendOnNextPage(newEvents: any[]) {
-    const events = getPostponedEvents();
-    sessionStorage.setItem(
-        GA_SESSION_STORAGE_KEY,
-        JSON.stringify(events.concat(newEvents))
-    );
+    try {
+        const events = getPostponedEvents();
+        sessionStorage.setItem(
+            GA_SESSION_STORAGE_KEY,
+            JSON.stringify(events.concat(newEvents))
+        );
+    } catch (e) {
+        // No sessionStorage support
+    }
 }
 
 function ga(...args) {
@@ -58,7 +66,11 @@ export default function GAProvider(props: {
      */
     useEffect(() => {
         const events = getPostponedEvents();
-        sessionStorage.removeItem(GA_SESSION_STORAGE_KEY);
+        try {
+            sessionStorage.removeItem(GA_SESSION_STORAGE_KEY);
+        } catch (e) {
+            // No sessionStorage support
+        }
         for (const event of events) {
             ga('send', event);
         }

--- a/kuma/javascript/src/ga-provider.jsx
+++ b/kuma/javascript/src/ga-provider.jsx
@@ -15,6 +15,18 @@ const QUERY_PARAM_GA_DATA = {
         eventAction: 'successful subscription',
         eventLabel: 'subscription-landing-page',
     },
+    'subscription-success-authenticated': {
+        hitType: 'event',
+        eventCategory: CATEGORY_MONTHLY_PAYMENTS,
+        eventAction: 'successful subscription (authenticated)',
+        eventLabel: 'subscription-landing-page',
+    },
+    'subscription-success-unauthenticated': {
+        hitType: 'event',
+        eventCategory: CATEGORY_MONTHLY_PAYMENTS,
+        eventAction: 'successful subscription (unauthenticated)',
+        eventLabel: 'subscription-landing-page',
+    },
     'banner-cta': {
         hitType: 'event',
         eventCategory: CATEGORY_MONTHLY_PAYMENTS,
@@ -23,8 +35,8 @@ const QUERY_PARAM_GA_DATA = {
     },
 };
 
-export function gaQuery(id: $Keys<typeof QUERY_PARAM_GA_DATA>) {
-    return GA_QUERY_KEY + '=' + id;
+export function gaQuery(ids: $Keys<typeof QUERY_PARAM_GA_DATA>[]) {
+    return new URLSearchParams(ids.map((id) => [GA_QUERY_KEY, id])).toString();
 }
 
 function ga(...args) {
@@ -57,9 +69,7 @@ export default function GAProvider(props: {
      * analytics data.
      */
     useEffect(() => {
-        const analyticIds = new URLSearchParams(
-            window.location.search.substr(1)
-        )
+        const analyticIds = new URLSearchParams(window.location.search)
             .getAll(GA_QUERY_KEY)
             .filter((id) => id in QUERY_PARAM_GA_DATA);
 

--- a/kuma/javascript/src/ga-provider.jsx
+++ b/kuma/javascript/src/ga-provider.jsx
@@ -9,14 +9,14 @@ export const CATEGORY_MONTHLY_PAYMENTS = 'monthly payments';
 const GA_SESSION_STORAGE_KEY = 'ga';
 
 function getPostponedEvents() {
+    let value;
     try {
-        return JSON.parse(
-            sessionStorage.getItem(GA_SESSION_STORAGE_KEY) || JSON.stringify([])
-        );
+        value = sessionStorage.getItem(GA_SESSION_STORAGE_KEY);
     } catch (e) {
         // No sessionStorage support
         return [];
     }
+    return JSON.parse(value || JSON.stringify([]));
 }
 
 /**
@@ -26,12 +26,10 @@ function getPostponedEvents() {
  * requests).
  */
 export function gaSendOnNextPage(newEvents: any[]) {
+    const events = getPostponedEvents();
+    const value = JSON.stringify(events.concat(newEvents));
     try {
-        const events = getPostponedEvents();
-        sessionStorage.setItem(
-            GA_SESSION_STORAGE_KEY,
-            JSON.stringify(events.concat(newEvents))
-        );
+        sessionStorage.setItem(GA_SESSION_STORAGE_KEY, value);
     } catch (e) {
         // No sessionStorage support
     }

--- a/kuma/javascript/src/ga-provider.jsx
+++ b/kuma/javascript/src/ga-provider.jsx
@@ -15,6 +15,7 @@ function getPostponedEvents() {
         );
     } catch (e) {
         // No sessionStorage support
+        return [];
     }
 }
 


### PR DESCRIPTION
Fixes #6827

## What changed
- creating the analytics search params now also uses `URLSearchParams` (thanks for the reminder, Peter!) and the function accepts multiple params
- send new analytic events:
  - `subscribe intent (unauthenticated)`
  - `subscribe intent (authenticated)`
  - `successful subscription (unauthenticated)`
  - `successful subscription (authenticated)`
-  rename the `xStripeContinuation` functions using `sessionStorage` to `xStartedUnauthenticated` to
   - reflect what users did and not what we're using it for
   - reuse it to decide which of the new analytics events to send

## How to test it:
Run through the subscription flow on http://localhost.org:8000/en-US/payments, once already logged-in and once logged-out (which will force you to login during the process).