### PR TITLE
tighten payments urls

### DIFF
--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -36,6 +36,19 @@ def test_payments_index(client):
 
 
 @pytest.mark.django_db
+def test_payments_url_fixes(client):
+    """These tests just make sure that the use of trailing slashes are correct."""
+    url = reverse("payments_index")
+    # if you remove the trailing / it should redirect back to that
+    assert url.endswith("/")
+    response = client.get(url[:-1], follow=False)
+    assert response.status_code == 301
+    assert response["location"] == url
+    response = client.get(url + "xxxx", follow=False)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 @override_flag("subscription", True)
 @mock.patch("kuma.payments.views.get_stripe_customer_data", return_value=True)
 def test_recurring_payment_management_no_customer_id(get, user_client):

--- a/kuma/payments/urls.py
+++ b/kuma/payments/urls.py
@@ -1,14 +1,14 @@
-from django.urls import re_path
+from django.urls import path
 
 from . import views
 
 lang_urlpatterns = [
-    re_path(r"^terms/$", views.payment_terms, name="payment_terms"),
-    re_path(r"^thank-you/$", views.thank_you, name="thank_you"),
-    re_path(
-        r"^recurring/management/$",
+    path("terms/", views.payment_terms, name="payment_terms"),
+    path("thank-you/", views.thank_you, name="thank_you"),
+    path(
+        "recurring/management/",
         views.recurring_payment_management,
         name="recurring_payment_management",
     ),
-    re_path(r"", views.index, name="payments_index"),
+    path("", views.index, name="payments_index"),
 ]


### PR DESCRIPTION
@mindy I'm trying to get my sanity with these payments URLs. One thing I noticed is that the index page is used for any broken URL. E.g.

```
▶ curl -I https://developer.mozilla.org/en-US/payments/xxxxx
HTTP/2 200
...
```

As of this little PR, all of that is fixed. Hopefully it helps you on your crusade with the reactifying. Here's how I tested it:

```
▶ python ~/dummy.py https://developer.allizom.org/en-US
/payments                      EXPECT 301 GOT 301 YAY!
/payments/                     EXPECT 200 GOT 200 YAY!
/payments/XXX                  EXPECT 404 GOT 200 FAIL
/payments/terms                EXPECT 301 GOT 200 FAIL
/payments/terms/               EXPECT 200 GOT 404 FAIL
/payments/terms/xxxxx          EXPECT 404 GOT 200 FAIL
/payments/thank-you            EXPECT 301 GOT 200 FAIL
/payments/thank-you/           EXPECT 200 GOT 404 FAIL
/payments/thank-you/xxxxx      EXPECT 404 GOT 200 FAIL
```
and 
```
▶ python ~/dummy.py http://localhost.org:8000/en-US
/payments                      EXPECT 301 GOT 301 YAY!
/payments/                     EXPECT 200 GOT 200 YAY!
/payments/XXX                  EXPECT 404 GOT 404 YAY!
/payments/terms                EXPECT 301 GOT 301 YAY!
/payments/terms/               EXPECT 200 GOT 200 YAY!
/payments/terms/xxxxx          EXPECT 404 GOT 404 YAY!
/payments/thank-you            EXPECT 301 GOT 301 YAY!
/payments/thank-you/           EXPECT 200 GOT 200 YAY!
/payments/thank-you/xxxxx      EXPECT 404 GOT 404 YAY!
```
[Using this script](https://gist.github.com/peterbe/9a6725412ed8361bcecf610d000b6335)