### PR TITLE
subscription api to list subscriptions

### DIFF
--- a/kuma/api/v1/urls.py
+++ b/kuma/api/v1/urls.py
@@ -14,9 +14,5 @@ urlpatterns = [
         views.send_subscriptions_feedback,
         name="api.v1.send_subscriptions_feedback",
     ),
-    re_path(
-        r"^subscriptions/?$",
-        views.create_subscription,
-        name="api.v1.create_subscription",
-    ),
+    re_path(r"^subscriptions/$", views.subscriptions, name="api.v1.subscriptions"),
 ]

--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -146,6 +146,22 @@ def user_client(client, wiki_user):
 
 
 @pytest.fixture
+def stripe_user(wiki_user):
+    wiki_user.stripe_customer_id = "fakeCustomerID123"
+    wiki_user.save()
+    return wiki_user
+
+
+@pytest.fixture
+def stripe_user_client(client, stripe_user):
+    """A test client with wiki_user logged in and with a stripe_customer_id."""
+    stripe_user.set_password("password")
+    stripe_user.save()
+    client.login(username=stripe_user.username, password="password")
+    return client
+
+
+@pytest.fixture
 def editor_client(user_client):
     """A test client with wiki_user logged in for editing."""
     with override_flag("kumaediting", True):

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -16,13 +16,6 @@ class MockSubscription:
     id: str = "sub_123456789"
 
 
-@pytest.fixture
-def stripe_user(wiki_user):
-    wiki_user.stripe_customer_id = "fakeCustomerID123"
-    wiki_user.save()
-    return wiki_user
-
-
 @pytest.mark.django_db
 def test_payments_index(client):
     """Viewing the payments index page doesn't require you to be logged in.

--- a/kuma/users/stripe_utils.py
+++ b/kuma/users/stripe_utils.py
@@ -1,5 +1,8 @@
+from datetime import datetime
+
 import stripe
 from django.conf import settings
+from django.utils import timezone
 
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.templatetags.jinja_helpers import absolutify
@@ -16,6 +19,60 @@ def retrieve_stripe_subscription(customer):
                 return subscription
 
     return None
+
+
+def retrieve_and_synchronize_subscription_info(user):
+    """For the given user, if it has as 'stripe_customer_id' retrieve the info
+    about the subscription if it's there. All packaged in a way that is
+    practical for the stripe_subscription.html template.
+
+    Also, whilst doing this check, we also verify that the UserSubscription record
+    for this user is right. Doing that check is a second-layer check in case
+    our webhooks have failed us.
+    """
+    subscription_info = None
+    stripe_customer = get_stripe_customer(user)
+    if stripe_customer:
+        stripe_subscription_info = get_stripe_subscription_info(stripe_customer)
+        if stripe_subscription_info:
+            source = stripe_customer.default_source
+            if source.object == "card":
+                card = source
+            elif source.object == "source":
+                card = source.card
+            else:
+                raise ValueError(
+                    f"unexpected stripe customer default_source of type {source.object!r}"
+                )
+
+            subscription_info = {
+                "id": stripe_subscription_info.id,
+                "amount": stripe_subscription_info.plan.amount,
+                "brand": card.brand,
+                "expires_at": f"{card.exp_month}/{card.exp_year}",
+                "last4": card.last4,
+                # Cards that are part of a "source" don't have a zip
+                "zip": card.get("address_zip", None),
+                # TODO: Deprecated. Only used in the Edit Profile view
+                "next_payment_at": datetime.fromtimestamp(
+                    stripe_subscription_info.current_period_end
+                ),
+            }
+
+            # To perfect the synchronization, take this opportunity to make sure
+            # we have an up-to-date record of this.
+            UserSubscription.set_active(user, stripe_subscription_info.id)
+        else:
+            # The user has a stripe_customer_id but no active subscription
+            # on the current settings.STRIPE_PLAN_ID! Perhaps it has been cancelled
+            # and not updated in our own records.
+            for user_subscription in UserSubscription.objects.filter(
+                user=user, canceled__isnull=True
+            ):
+                user_subscription.canceled = timezone.now()
+                user_subscription.save()
+
+    return subscription_info
 
 
 def create_stripe_customer_and_subscription_for_user(user, email, stripe_token):

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -27,7 +27,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils import timezone, translation
+from django.utils import translation
 from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_decode
 from django.utils.translation import gettext_lazy as _
@@ -74,8 +74,7 @@ from .models import User, UserBan, UserSubscription
 from .signup import SignupForm
 from .stripe_utils import (
     create_stripe_customer_and_subscription_for_user,
-    get_stripe_customer,
-    get_stripe_subscription_info,
+    retrieve_and_synchronize_subscription_info,
 )
 
 
@@ -486,63 +485,12 @@ def user_edit(request, username):
         "form": UserDeleteForm(username=username),
         "revisions": revisions,
         "attachment_revisions": attachment_revisions,
-        "subscription_info": _retrieve_and_synchronize_subscription_info(edit_user),
+        "subscription_info": retrieve_and_synchronize_subscription_info(edit_user),
         "has_stripe_error": has_stripe_error,
         "next_subscriber_number": User.get_highest_subscriber_number() + 1,
     }
 
     return render(request, "users/user_edit.html", context)
-
-
-def _retrieve_and_synchronize_subscription_info(user):
-    """For the given user, if it has as 'stripe_customer_id' retrieve the info
-    about the subscription if it's there. All packaged in a way that is
-    practical for the stripe_subscription.html template.
-
-    Also, whilst doing this check, we also verify that the UserSubscription record
-    for this user is right. Doing that check is a second-layer check in case
-    our webhooks have failed us.
-    """
-    subscription_info = None
-    stripe_customer = get_stripe_customer(user)
-    if stripe_customer:
-        stripe_subscription_info = get_stripe_subscription_info(stripe_customer)
-        if stripe_subscription_info:
-            source = stripe_customer.default_source
-            if source.object == "card":
-                card = source
-            elif source.object == "source":
-                card = source.card
-            else:
-                raise ValueError(
-                    f"unexpected stripe customer default_source of type {source.object!r}"
-                )
-
-            subscription_info = {
-                "next_payment_at": datetime.fromtimestamp(
-                    stripe_subscription_info.current_period_end
-                ),
-                "brand": card.brand,
-                "expires_at": f"{card.exp_month}/{card.exp_year}",
-                "last4": card.last4,
-                # Cards that are part of a "source" don't have a zip
-                "zip": card.get("address_zip", None),
-            }
-
-            # To perfect the synchronization, take this opportunity to make sure
-            # we have an up-to-date record of this.
-            UserSubscription.set_active(user, stripe_subscription_info.id)
-        else:
-            # The user has a stripe_customer_id but no active subscription
-            # on the current settings.STRIPE_PLAN_ID! Perhaps it has been cancelled
-            # and not updated in our own records.
-            for user_subscription in UserSubscription.objects.filter(
-                user=user, canceled__isnull=True
-            ):
-                user_subscription.canceled = timezone.now()
-                user_subscription.save()
-
-    return subscription_info
 
 
 @redirect_in_maintenance_mode
@@ -937,7 +885,7 @@ def stripe_hooks(request):
 
 def _send_payment_received_email(payment_intent, locale):
     user = get_user_model().objects.get(stripe_customer_id=payment_intent.customer)
-    subscription_info = _retrieve_and_synchronize_subscription_info(user)
+    subscription_info = retrieve_and_synchronize_subscription_info(user)
     locale = locale or settings.WIKI_DEFAULT_LANGUAGE
     context = {
         "payment_date": datetime.fromtimestamp(payment_intent.created),


### PR DESCRIPTION
Part of #6892

Here's how I test it,
I open `payments/pages/index.jsx` and inject these lines:

```jsx
    // TEMPORARY HACKY CODE TO TEST THINGS
    useEffect(() => {
        if (isSubscriber) {
            fetch('/api/v1/subscriptions/').then((r) => {
                console.log('RESPONSE:', r);
                if (r.ok) {
                    r.json().then((data) => {
                        console.log(
                            'SUBSCRIPTION DATA:',
                            JSON.stringify(data, null, 2)
                        );
                    });
                }
            });
        }
    }, [isSubscriber]);
```

But you can also do the same with `curl` if you copy the cURL call from the dev tools Network panel as that will have the `Set-Cookie` in it.

I know the PR looks big. It's not that big. The changes to `kuma/api/v1/views.py` and `kuma/api/v1/urls.py` are the most important and most relevant. Everything else is just refactoring now that these subscription stuff things are spread across `kuma.payments`, `kuma.users`, and `kuma.api.v1`. 

I really hope we can see retire EVERYTHING related to subscriptions from `kuma.users` (including `git mv kuma/users/stripe_utils.py kuma/payments`) when we remove the subscription stuff from the Edit Profile page. 

PS. I'm make it a draft for now to break up the introduction of the `GET /api/v1/subscriptions` from the API stuff for cancelling a subscription. 