### PR TITLE
CI python without coverage

### DIFF
--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -87,12 +87,7 @@ echo "TRAVIS_PULL_REQUEST:"
 echo $TRAVIS_PULL_REQUEST
 
 is_pullrequest_build() {
-    # $TRAVIS_PULL_REQUEST is something like '00123' if this is a pull request.
-    # But just 'false' if not.
-    [[ $TRAVIS_PULL_REQUEST -ne "false" ]]
-
-    # Note! If $TRAVIS_PULL_REQUEST is something like '1234'
-    # the $TRAVIS_BRANCH env var will still be 'master'.
+  [[ ${TRAVIS_PULL_REQUEST-default} != "false" ]]
 }
 has_python_changes() {
     git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py'

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -50,4 +50,13 @@ docker-compose restart ssr
 docker-compose exec -T web ./manage.py migrate
 # This checks that running `./manage.py makemigrations` wasn't forgotten
 docker-compose exec -T web ./manage.py makemigrations --check --dry-run
-docker-compose exec -T web make coveragetest
+
+# The idea here is that coverage analysis on the pytest tests is
+# pretty slow. Still useful but significant slowdown.
+# So can it be skipped if there were no .py changes in the PR.
+git diff --name-only
+
+echo "TRAVIS_PULL_REQUEST:"
+echo $TRAVIS_PULL_REQUEST
+
+docker-compose exec -T web make test

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -61,6 +61,21 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 # git diff --name-only master
 # echo "git diff --name-only master...:"
 # git diff --name-only master...
+
+echo "TRAVIS_COMMIT_RANGE"
+echo $TRAVIS_COMMIT_RANGE
+
+echo "git diff $TRAVIS_COMMIT_RANGE"
+git diff $TRAVIS_COMMIT_RANGE
+
+echo "git diff --name-only $TRAVIS_COMMIT_RANGE"
+git diff --name-only $TRAVIS_COMMIT_RANGE
+
+echo "git diff --name-only HEAD origin/${TRAVIS_BRANCH}"
+git diff --name-only HEAD origin/${TRAVIS_BRANCH}
+
+echo "git diff HEAD...$TRAVIS_BRANCH:"
+git diff HEAD...$TRAVIS_BRANCH
 echo "git diff --name-only HEAD...$TRAVIS_BRANCH:"
 git diff --name-only HEAD...$TRAVIS_BRANCH
 

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -61,16 +61,20 @@ echo "git diff --name-only master:"
 git diff --name-only master
 echo "git diff --name-only master...:"
 git diff --name-only master...
+echo "git diff --name-only HEAD...$TRAVIS_BRANCH:"
+git diff --name-only HEAD...$TRAVIS_BRANCH
+
 
 echo "TRAVIS_PULL_REQUEST:"
 echo $TRAVIS_PULL_REQUEST
-echo "TRAVIS_BRANCH:"
-echo $TRAVIS_BRANCH
 
 is_pullrequest_build() {
     # $TRAVIS_PULL_REQUEST is something like '00123' if this is a pull request.
     # But just 'false' if not.
     [[ $TRAVIS_PULL_REQUEST -ne 'false' ]]
+
+    # Note! If $TRAVIS_PULL_REQUEST is something like '1234'
+    # the $TRAVIS_BRANCH env var will still be 'master'.
 }
 has_python_changes() {
     git diff --name-only master | grep '\.py'

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -55,14 +55,17 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 # The idea here is that coverage analysis on the pytest tests is
 # pretty slow. Still useful but significant slowdown.
 # So can it be skipped if there were no .py changes in the PR.
-echo "git diff master...:"
-git diff master...
-echo "git diff --name-only master:"
-git diff --name-only master
-echo "git diff --name-only master...:"
-git diff --name-only master...
+# echo "git diff master...:"
+# git diff master...
+# echo "git diff --name-only master:"
+# git diff --name-only master
+# echo "git diff --name-only master...:"
+# git diff --name-only master...
 echo "git diff --name-only HEAD...$TRAVIS_BRANCH:"
 git diff --name-only HEAD...$TRAVIS_BRANCH
+
+# echo "git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py':"
+# git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py'
 
 
 echo "TRAVIS_PULL_REQUEST:"
@@ -71,13 +74,13 @@ echo $TRAVIS_PULL_REQUEST
 is_pullrequest_build() {
     # $TRAVIS_PULL_REQUEST is something like '00123' if this is a pull request.
     # But just 'false' if not.
-    [[ $TRAVIS_PULL_REQUEST -ne 'false' ]]
+    [[ $TRAVIS_PULL_REQUEST -ne false ]]
 
     # Note! If $TRAVIS_PULL_REQUEST is something like '1234'
     # the $TRAVIS_BRANCH env var will still be 'master'.
 }
 has_python_changes() {
-    git diff --name-only master | grep '\.py'
+    git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py'
 }
 if is_pullrequest_build && has_python_changes; then echo "IS PR and has Python changes!"; else echo "Regular build, no coverage needed"; fi
 

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -62,41 +62,39 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 # echo "git diff --name-only master...:"
 # git diff --name-only master...
 
-echo "TRAVIS_COMMIT_RANGE"
-echo $TRAVIS_COMMIT_RANGE
+# echo "TRAVIS_COMMIT_RANGE"
+# echo $TRAVIS_COMMIT_RANGE
 
-echo "git diff $TRAVIS_COMMIT_RANGE"
-git diff $TRAVIS_COMMIT_RANGE
+# echo "git diff $TRAVIS_COMMIT_RANGE"
+# git diff $TRAVIS_COMMIT_RANGE
 
 echo "git diff --name-only $TRAVIS_COMMIT_RANGE"
 git diff --name-only $TRAVIS_COMMIT_RANGE
 
-echo "git diff --name-only HEAD origin/${TRAVIS_BRANCH}"
-git diff --name-only HEAD origin/${TRAVIS_BRANCH}
-
-echo "git diff HEAD...$TRAVIS_BRANCH:"
-git diff HEAD...$TRAVIS_BRANCH
-echo "git diff --name-only HEAD...$TRAVIS_BRANCH:"
-git diff --name-only HEAD...$TRAVIS_BRANCH
-
-# echo "git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py':"
-# git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py'
-
-
-echo "TRAVIS_PULL_REQUEST:"
-echo $TRAVIS_PULL_REQUEST
+# echo "git diff --name-only HEAD origin/${TRAVIS_BRANCH}"
+# git diff --name-only HEAD origin/${TRAVIS_BRANCH}
 
 is_pullrequest_build() {
   [[ ${TRAVIS_PULL_REQUEST-default} != "false" ]]
 }
 has_python_changes() {
-    git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py'
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.py'
 }
-if is_pullrequest_build && has_python_changes; then
-    echo "IS PR and has Python changes!"
+if is_pullrequest_build; then
+    echo "IT IS A PULL REQUEST"
 else
-    echo "Regular build, no coverage needed"
+    echo "IT'S NOT A PULL REQUEST"
 fi
+if has_python_changes; then
+    echo "IT HAS PYTHON CHANGES!!"
+else
+    echo "NO PYTHON IN DIFF"
+fi
+# if is_pullrequest_build && has_python_changes; then
+#     echo "IS PR and has Python changes!"
+# else
+#     echo "Regular build, no coverage needed"
+# fi
 
 
 #docker-compose exec -T web make test

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -54,9 +54,13 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 # The idea here is that coverage analysis on the pytest tests is
 # pretty slow. Still useful but significant slowdown.
 # So can it be skipped if there were no .py changes in the PR.
-git diff --name-only
+echo "git diff --name-only master:"
+git diff --name-only master
 
 echo "TRAVIS_PULL_REQUEST:"
 echo $TRAVIS_PULL_REQUEST
+echo "TRAVIS_BRANCH:"
+echo $TRAVIS_BRANCH
 
-docker-compose exec -T web make test
+
+#docker-compose exec -T web make test

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -55,46 +55,16 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 # The idea here is that coverage analysis on the pytest tests is
 # pretty slow. Around 1 minute slower than without.
 # So can it be skipped if there were no .py changes in the PR.
-# echo "git diff master...:"
-# git diff master...
-# echo "git diff --name-only master:"
-# git diff --name-only master
-# echo "git diff --name-only master...:"
-# git diff --name-only master...
-
-# echo "TRAVIS_COMMIT_RANGE"
-# echo $TRAVIS_COMMIT_RANGE
-
-# echo "git diff $TRAVIS_COMMIT_RANGE"
-# git diff $TRAVIS_COMMIT_RANGE
-
-echo "git diff --name-only $TRAVIS_COMMIT_RANGE"
-git diff --name-only $TRAVIS_COMMIT_RANGE
-
-# echo "git diff --name-only HEAD origin/${TRAVIS_BRANCH}"
-# git diff --name-only HEAD origin/${TRAVIS_BRANCH}
-
 is_pullrequest_build() {
   [[ ${TRAVIS_PULL_REQUEST-default} != "false" ]]
 }
 has_python_changes() {
     git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.py'
 }
-if is_pullrequest_build; then
-    echo "IT IS A PULL REQUEST"
+if is_pullrequest_build && has_python_changes; then
+    echo "IS PR and has Python changes!"
+    docker-compose exec -T web make coveragetest
 else
-    echo "IT'S NOT A PULL REQUEST"
+    echo "Regular build, no coverage needed"
+    docker-compose exec -T web make test
 fi
-if has_python_changes; then
-    echo "IT HAS PYTHON CHANGES!!"
-else
-    echo "NO PYTHON IN DIFF"
-fi
-# if is_pullrequest_build && has_python_changes; then
-#     echo "IS PR and has Python changes!"
-# else
-#     echo "Regular build, no coverage needed"
-# fi
-
-
-#docker-compose exec -T web make test

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -53,7 +53,7 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 
 
 # The idea here is that coverage analysis on the pytest tests is
-# pretty slow. Still useful but significant slowdown.
+# pretty slow. Around 1 minute slower than without.
 # So can it be skipped if there were no .py changes in the PR.
 # echo "git diff master...:"
 # git diff master...
@@ -74,7 +74,7 @@ echo $TRAVIS_PULL_REQUEST
 is_pullrequest_build() {
     # $TRAVIS_PULL_REQUEST is something like '00123' if this is a pull request.
     # But just 'false' if not.
-    [[ $TRAVIS_PULL_REQUEST -ne false ]]
+    [[ $TRAVIS_PULL_REQUEST -ne "false" ]]
 
     # Note! If $TRAVIS_PULL_REQUEST is something like '1234'
     # the $TRAVIS_BRANCH env var will still be 'master'.
@@ -82,7 +82,11 @@ is_pullrequest_build() {
 has_python_changes() {
     git diff --name-only HEAD...$TRAVIS_BRANCH | grep '\.py'
 }
-if is_pullrequest_build && has_python_changes; then echo "IS PR and has Python changes!"; else echo "Regular build, no coverage needed"; fi
+if is_pullrequest_build && has_python_changes; then
+    echo "IS PR and has Python changes!"
+else
+    echo "Regular build, no coverage needed"
+fi
 
 
 #docker-compose exec -T web make test

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -55,8 +55,12 @@ docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 # The idea here is that coverage analysis on the pytest tests is
 # pretty slow. Still useful but significant slowdown.
 # So can it be skipped if there were no .py changes in the PR.
+echo "git diff master...:"
+git diff master...
 echo "git diff --name-only master:"
 git diff --name-only master
+echo "git diff --name-only master...:"
+git diff --name-only master...
 
 echo "TRAVIS_PULL_REQUEST:"
 echo $TRAVIS_PULL_REQUEST

--- a/scripts/ci-python
+++ b/scripts/ci-python
@@ -51,6 +51,7 @@ docker-compose exec -T web ./manage.py migrate
 # This checks that running `./manage.py makemigrations` wasn't forgotten
 docker-compose exec -T web ./manage.py makemigrations --check --dry-run
 
+
 # The idea here is that coverage analysis on the pytest tests is
 # pretty slow. Still useful but significant slowdown.
 # So can it be skipped if there were no .py changes in the PR.
@@ -61,6 +62,16 @@ echo "TRAVIS_PULL_REQUEST:"
 echo $TRAVIS_PULL_REQUEST
 echo "TRAVIS_BRANCH:"
 echo $TRAVIS_BRANCH
+
+is_pullrequest_build() {
+    # $TRAVIS_PULL_REQUEST is something like '00123' if this is a pull request.
+    # But just 'false' if not.
+    [[ $TRAVIS_PULL_REQUEST -ne 'false' ]]
+}
+has_python_changes() {
+    git diff --name-only master | grep '\.py'
+}
+if is_pullrequest_build && has_python_changes; then echo "IS PR and has Python changes!"; else echo "Regular build, no coverage needed"; fi
 
 
 #docker-compose exec -T web make test


### PR DESCRIPTION
This makes it so that coverage tests are only used if the PR build is a PR and has any changes to `.py` files. 

See comment below about the potential (hint: 1min faster builds)