### PR TITLE
codecov submission with retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ jobs:
         - scripts/ci-localerefresh
         # - bash <(curl -s https://codecov.io/bash)
         - curl --version
-        - script/ci-codecovsubmit
+        - scripts/ci-codecovsubmit

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,6 @@ jobs:
         - scripts/ci-python
         - scripts/ci-jest
         - scripts/ci-localerefresh
-        - bash <(curl -s https://codecov.io/bash)
+        # - bash <(curl -s https://codecov.io/bash)
+        - curl --version
+        - script/ci-codecovsubmit

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,4 @@ jobs:
         - scripts/ci-python
         - scripts/ci-jest
         - scripts/ci-localerefresh
-        # - bash <(curl -s https://codecov.io/bash)
-        - curl --version
         - scripts/ci-codecovsubmit

--- a/scripts/ci-codecovsubmit
+++ b/scripts/ci-codecovsubmit
@@ -5,4 +5,4 @@ set -u  # Treat unset variables as an error
 # FYI, as of April 2020, you get version 7.47.0 of curl
 # and `--retry-connrefused` was added in curl 7.52.0 :(
 
-bash <(curl -s --retry 3 --retry-connrefused https://codecov.io/bash)
+bash <(curl -s --retry 3 https://codecov.io/bash)

--- a/scripts/ci-codecovsubmit
+++ b/scripts/ci-codecovsubmit
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e  # Exit on non-zero status
+set -u  # Treat unset variables as an error
+
+bash <(curl -s --retry 3 --retry-connrefused https://codecov.io/bash)

--- a/scripts/ci-codecovsubmit
+++ b/scripts/ci-codecovsubmit
@@ -2,4 +2,7 @@
 set -e  # Exit on non-zero status
 set -u  # Treat unset variables as an error
 
+# FYI, as of April 2020, you get version 7.47.0 of curl
+# and `--retry-connrefused` was added in curl 7.52.0 :(
+
 bash <(curl -s --retry 3 --retry-connrefused https://codecov.io/bash)


### PR DESCRIPTION
Unfortunately, it sometimes happen that we get an error submitting this due to connection errors. 
Thankfully modern versions of `curl` allow the `--retry-connrefused` param. 
So I thought I'd add that. But it turns out we don't have a modern version of `curl` in TravisCI. 
Anyway, at least this uses the `--retry` which intelligently retries on bad HTTP error codes. And now it's a bash script instead. 