### PR TITLE
Fix "Technologies" dropdown UI bug

### DIFF
--- a/kuma/static/styles/components/wiki/_toc.scss
+++ b/kuma/static/styles/components/wiki/_toc.scss
@@ -181,7 +181,7 @@ On This Page component
         border: 2px solid $blue;
         width: calc(100% - 40px);
         list-style: none;
-        z-index: 99;
+        z-index: 94;
 
         @media #{$mq-small-desktop-and-up} {
             @include bidi(((padding-left, 20px, padding-right, 0),));


### PR DESCRIPTION
Changes:
- Lower z-index of Table of Contents so it appears below Technologies dropdown 

To test: 
- Visit any page with a table of contents, like http://localhost.org:8000/en-US/docs/Web/CSS. 
- Hover over "Technologies" and ensure that it shows up above TOC

Before:
<img width="485" alt="Screen Shot 2020-04-27 at 10 50 32 AM" src="https://user-images.githubusercontent.com/650/80386143-f79bfb00-8874-11ea-80fa-9dd215f7f02b.png">

After: 
<img width="586" alt="Screen Shot 2020-04-27 at 10 46 30 AM" src="https://user-images.githubusercontent.com/650/80386047-ddfab380-8874-11ea-8973-a4049e91e25f.png">


Closes #6942 