### PR TITLE
Make breadcrumbs mobile and tablet-friendly

### DIFF
--- a/kuma/javascript/src/breadcrumbs.jsx
+++ b/kuma/javascript/src/breadcrumbs.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { useContext } from 'react';
-
+import { gettext } from './l10n.js';
 import GAProvider from './ga-provider.jsx';
 
 import type { DocumentData } from './document.jsx';
@@ -54,6 +54,9 @@ export default function Breadcrumbs({ document }: DocumentProps) {
                             onClick={sendBreadcrumbItemClick}
                             onContextMenu={sendBreadcrumbItemClick}
                         >
+                            <span className="pre-text">
+                                {gettext('See')}&nbsp;
+                            </span>
                             <span property="name">{p.title}</span>
                         </a>
                         <meta property="position" content={i + 1} />

--- a/kuma/javascript/src/breadcrumbs.jsx
+++ b/kuma/javascript/src/breadcrumbs.jsx
@@ -36,7 +36,7 @@ export default function Breadcrumbs({ document }: DocumentProps) {
                 vocab="https://schema.org/"
                 aria-label="breadcrumbs"
             >
-                {document.parents.map((p, i) => (
+                {document.parents.map((p, i, { length }) => (
                     <li
                         key={p.url}
                         property="itemListElement"
@@ -44,7 +44,11 @@ export default function Breadcrumbs({ document }: DocumentProps) {
                     >
                         <a
                             href={p.url}
-                            className="breadcrumb-chevron"
+                            className={
+                                i === length - 1
+                                    ? 'breadcrumb-previous'
+                                    : 'breadcrumb-chevron'
+                            }
                             property="item"
                             typeof="WebPage"
                             onClick={sendBreadcrumbItemClick}

--- a/kuma/javascript/src/breadcrumbs.test.jsx
+++ b/kuma/javascript/src/breadcrumbs.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import {
+    toBeInTheDocument,
+    toHaveClass,
+} from '@testing-library/jest-dom/matchers';
+import GAProvider from './ga-provider.jsx';
+import Breadcrumbs from './breadcrumbs.jsx';
+
+expect.extend({ toBeInTheDocument, toHaveClass });
+
+describe('Breadcrumbs', () => {
+    const mockDocumentData = {
+        // url needs a # to get around a JSDOM error:
+        // Error: Not implemented: navigation (except hash changes)
+        absoluteURL: '#main-url',
+        title: 'main crumb',
+        parents: [
+            {
+                title: 'crumb 1',
+                url: '/url-1',
+            },
+            {
+                title: 'crumb 2',
+                url: '/url-2',
+            },
+            {
+                title: 'crumb 3',
+                url: '/url-3',
+            },
+        ],
+    };
+
+    it('renders correct number of crumbs (parents + current page)', () => {
+        const expected = mockDocumentData.parents.length + 1;
+        const { queryAllByText } = render(
+            <Breadcrumbs document={mockDocumentData} />
+        );
+        const items = queryAllByText(/crumb/);
+        expect(items).toHaveLength(expected);
+    });
+
+    it('gives the last parent a different class name, so we can style it differently for small screens', () => {
+        const expected = 'breadcrumb-chevron';
+        const firstParent = mockDocumentData.parents[0];
+        const lastParent =
+            mockDocumentData.parents[mockDocumentData.parents.length - 1];
+        const { queryByText } = render(
+            <Breadcrumbs document={mockDocumentData} />
+        );
+        const firstElement = queryByText(firstParent.title).closest('a');
+        const lastElement = queryByText(lastParent.title).closest('a');
+
+        expect(firstElement).toHaveClass(expected);
+        expect(lastElement).not.toHaveClass(expected);
+    });
+
+    it('logs GA event for every crumb click', () => {
+        const mockGA = jest.fn();
+        const { queryByText } = render(
+            <GAProvider.context.Provider value={mockGA}>
+                <Breadcrumbs document={mockDocumentData} />
+            </GAProvider.context.Provider>
+        );
+        const link = queryByText(mockDocumentData.title).closest('a');
+
+        // click on current crumb
+        fireEvent.click(link);
+
+        // check that our GA event was called
+        expect(mockGA).toHaveBeenCalledWith('send', {
+            eventAction: 'Crumbs',
+            eventCategory: 'Wiki',
+            eventLabel: `${location.href}${mockDocumentData.absoluteURL}`,
+            hitType: 'event',
+        });
+    });
+});

--- a/kuma/javascript/src/breadcrumbs.test.jsx
+++ b/kuma/javascript/src/breadcrumbs.test.jsx
@@ -62,10 +62,9 @@ describe('Breadcrumbs', () => {
                 <Breadcrumbs document={mockDocumentData} />
             </GAProvider.context.Provider>
         );
-        const link = queryByText(mockDocumentData.title).closest('a');
 
         // click on current crumb
-        fireEvent.click(link);
+        fireEvent.click(queryByText(mockDocumentData.title).closest('a'));
 
         // check that our GA event was called
         expect(mockGA).toHaveBeenCalledWith('send', {

--- a/kuma/javascript/src/breadcrumbs.test.jsx
+++ b/kuma/javascript/src/breadcrumbs.test.jsx
@@ -11,8 +11,8 @@ expect.extend({ toBeInTheDocument, toHaveClass });
 
 describe('Breadcrumbs', () => {
     const mockDocumentData = {
-        // url needs a # to get around a JSDOM error:
-        // Error: Not implemented: navigation (except hash changes)
+        // url needs a # to trick it into thinking it's a hash change:
+        // JSDOM error - `Not implemented: navigation (except hash changes)`
         absoluteURL: '#main-url',
         title: 'main crumb',
         parents: [

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -100,13 +100,15 @@ function DocumentPage({ document }: DocumentProps) {
             <A11yNav />
             <Header document={document} />
             <main role="main">
-                <Titlebar title={document.title} document={document} />
-                <div className="full-width-row-container">
-                    <div className="max-content-width-container">
-                        <Breadcrumbs document={document} />
-                        <LanguageMenu document={document} />
+                <header>
+                    <Titlebar title={document.title} document={document} />
+                    <div className="full-width-row-container">
+                        <div className="max-content-width-container">
+                            <Breadcrumbs document={document} />
+                            <LanguageMenu document={document} />
+                        </div>
                     </div>
-                </div>
+                </header>
                 <ContentErrorBoundary>
                     <Content document={document} />
                 </ContentErrorBoundary>

--- a/kuma/javascript/src/document.test.js
+++ b/kuma/javascript/src/document.test.js
@@ -87,7 +87,7 @@ describe('Document component renders all of its parts', () => {
             let parent = fakeDocumentData.parents[i];
             let link = links[i];
             expect(link.props.href).toBe(parent.url);
-            expect(link.children[0].children[0]).toBe(parent.title);
+            expect(link.children[1].children[0]).toBe(parent.title);
         }
     });
 

--- a/kuma/static/styles/base/elements/_sectioning.scss
+++ b/kuma/static/styles/base/elements/_sectioning.scss
@@ -22,6 +22,17 @@ aside {
 main {
     background: #fff;
     min-height: 200px;
+
+    > header {
+        display: flex;
+
+        // arrange breadcrumbs above title bar for mobile
+        // and below title bar for desktop
+        flex-direction: column-reverse;
+        @media #{$mq-small-desktop-and-up} {
+            flex-direction: column;
+        }
+    }
 }
 
 details {

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -23,7 +23,7 @@
             &::before {
                 display: inline-block;
                 content: '‹';
-                margin: 0 5px;
+                margin: 0 5px 0 0;
                 font-size: 1rem;
                 font-weight: bold;
             }

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -1,3 +1,5 @@
+@import '../utils/utility-mixins.scss';
+
 .breadcrumbs {
     flex: 1 1;
 
@@ -17,17 +19,68 @@
             }
         }
 
-        .breadcrumb-chevron:after {
-            display: inline-block;
-            content: '›';
-            color: $grey-vdark;
-            margin: 0 5px;
-            font-size: 1rem;
-            font-weight: bold;
+        .breadcrumb-previous {
+            &::before {
+                display: inline-block;
+                content: '‹';
+                margin: 0 5px;
+                font-size: 1rem;
+                font-weight: bold;
+            }
+            span::before {
+                display: inline-block;
+                content: 'See\00a0';
+            }
+            &:hover {
+                span {
+                    &::before {
+                        text-decoration: underline;
+                    }
+                }
+            }
         }
 
-        :last-child .breadcrumb-chevron:after {
-            display: none;
+        &:first-child > [class*='crumb-current-page'] {
+            @include reset-visually-hidden();
+        }
+
+        // only show immediate parent on mobile and tablet
+        .crumb-current-page,
+        .breadcrumb-chevron {
+            @include visually-hidden();
+        }
+    }
+}
+
+@media #{$mq-small-desktop-and-up} {
+    .breadcrumbs {
+        li {
+            // reveal other breadcrumbs on Desktop
+            .breadcrumb-chevron,
+            .crumb-current-page {
+                @include reset-visually-hidden();
+            }
+
+            .breadcrumb-previous {
+                &::before {
+                    display: none;
+                }
+                span::before {
+                    display: none;
+                }
+            }
+
+            .breadcrumb-previous,
+            .breadcrumb-chevron {
+                &::after {
+                    display: inline-block;
+                    content: '›';
+                    color: $grey-vdark;
+                    margin: 0 5px;
+                    font-size: 1rem;
+                    font-weight: bold;
+                }
+            }
         }
     }
 }

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -26,17 +26,6 @@
                 position: relative;
                 top: -1px;
             }
-            span::before {
-                display: inline-block;
-                content: 'See\00a0';
-            }
-            &:hover {
-                span {
-                    &::before {
-                        text-decoration: underline;
-                    }
-                }
-            }
         }
 
         &:first-child > [class*='crumb-current-page'] {
@@ -78,6 +67,9 @@
                     top: -1px;
                 }
             }
+        }
+        .pre-text {
+            @include visually-hidden();
         }
     }
 }

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -21,11 +21,10 @@
 
         .breadcrumb-previous {
             &::before {
-                display: inline-block;
-                content: '‹';
-                margin: 0 5px 0 0;
-                font-size: 1rem;
-                font-weight: bold;
+                @include caret-arrow($blue, 6px, left);
+                margin: 0 10px 0 0;
+                position: relative;
+                top: -1px;
             }
             span::before {
                 display: inline-block;
@@ -73,12 +72,10 @@
             .breadcrumb-previous,
             .breadcrumb-chevron {
                 &::after {
-                    display: inline-block;
-                    content: '›';
-                    color: $grey-vdark;
-                    margin: 0 5px;
-                    font-size: 1rem;
-                    font-weight: bold;
+                    @include caret-arrow($grey-vdark, 6px, right);
+                    margin: 0 8px 0 5px;
+                    position: relative;
+                    top: -1px;
                 }
             }
         }

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -28,14 +28,15 @@
             }
         }
 
-        &:first-child > [class*='crumb-current-page'] {
-            @include reset-visually-hidden();
-        }
-
         // only show immediate parent on mobile and tablet
         .crumb-current-page,
         .breadcrumb-chevron {
             @include visually-hidden();
+        }
+
+        // if there are no crumb parents, reveal the current page crumb
+        &:first-child > [class*='crumb-current-page'] {
+            @include reset-visually-hidden();
         }
     }
 }
@@ -68,6 +69,7 @@
                 }
             }
         }
+
         .pre-text {
             @include visually-hidden();
         }

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -21,7 +21,7 @@
 
         .breadcrumb-previous {
             &::before {
-                @include caret-arrow($blue, 6px, left);
+                @include caret-arrow($blue, left);
                 margin: 0 10px 0 0;
                 position: relative;
                 top: -1px;
@@ -72,7 +72,7 @@
             .breadcrumb-previous,
             .breadcrumb-chevron {
                 &::after {
-                    @include caret-arrow($grey-vdark, 6px, right);
+                    @include caret-arrow($grey-vdark);
                     margin: 0 8px 0 5px;
                     position: relative;
                     top: -1px;

--- a/kuma/static/styles/minimalist/utils/_utility-mixins.scss
+++ b/kuma/static/styles/minimalist/utils/_utility-mixins.scss
@@ -12,17 +12,17 @@
 }
 
 @mixin reset-visually-hidden {
-    border: initial;
-    clip: initial;
-    height: initial;
-    margin: initial;
-    overflow: initial;
-    padding: initial;
-    position: initial !important; /* stylelint-disable-line declaration-no-important */
-    width: initial;
+    border: inherit;
+    clip: inherit;
+    height: inherit;
+    margin: inherit;
+    overflow: inherit;
+    padding: inherit;
+    position: inherit !important; /* stylelint-disable-line declaration-no-important */
+    width: inherit;
 }
 
-@mixin caret-arrow($color, $size, $direction: right, $thickness: 2px) {
+@mixin caret-arrow($color, $direction: right, $size: 6px, $thickness: 2px) {
     content: '';
     border: solid $color;
     border-width: 0 $thickness $thickness 0;

--- a/kuma/static/styles/minimalist/utils/_utility-mixins.scss
+++ b/kuma/static/styles/minimalist/utils/_utility-mixins.scss
@@ -10,3 +10,14 @@
     position: absolute !important; /* stylelint-disable-line declaration-no-important */
     width: 1px;
 }
+
+@mixin reset-visually-hidden {
+    border: initial;
+    clip: initial;
+    height: initial;
+    margin: initial;
+    overflow: initial;
+    padding: initial;
+    position: initial !important; /* stylelint-disable-line declaration-no-important */
+    width: initial;
+}

--- a/kuma/static/styles/minimalist/utils/_utility-mixins.scss
+++ b/kuma/static/styles/minimalist/utils/_utility-mixins.scss
@@ -21,3 +21,23 @@
     position: initial !important; /* stylelint-disable-line declaration-no-important */
     width: initial;
 }
+
+@mixin caret-arrow($color, $size, $direction: right, $thickness: 2px) {
+    content: '';
+    border: solid $color;
+    border-width: 0 $thickness $thickness 0;
+    display: inline-block;
+    width: $size;
+    height: $size;
+
+    /* stylelint-disable block-closing-brace-newline-after */
+    @if ($direction == up) {
+        transform: rotate(-135deg);
+    } @else if ($direction == left) {
+        transform: rotate(135deg);
+    } @else if ($direction == down) {
+        transform: rotate(45deg);
+    } @else if ($direction == right) {
+        transform: rotate(-45deg);
+    }
+}


### PR DESCRIPTION
**Changes**
- On mobile and tablet screens, hide all but the immediate parent crumb 
- On mobile and tablet screens, breadcrumbs appear above title
- New arrow styles between breadcrumbs
- Add Sass mixin for caret-like arrows 

**To test**
Go to http://localhost.org:8000/en-US/docs/Web/HTML/Element/article and view breadcrumbs on various screen sizes.

**Before:**
_Desktop_
<img width="1195" alt="before-desktop" src="https://user-images.githubusercontent.com/650/80426994-e1ae2a80-88b4-11ea-8184-dc1cf24a9a6a.png">

_Mobile_
<img width="417" alt="before-mobile" src="https://user-images.githubusercontent.com/650/80426996-e246c100-88b4-11ea-9738-6c65c962f016.png">


**After:** 
_Desktop_
<img width="1137" alt="after-desktop" src="https://user-images.githubusercontent.com/650/80427009-e672de80-88b4-11ea-8f12-d55e6ea61af7.png">

_Mobile_
<img width="493" alt="after-mobile" src="https://user-images.githubusercontent.com/650/80427011-e70b7500-88b4-11ea-9c67-b30849b31f87.png">


Closes #6822 