### PR TITLE
Retrieve any stripe subscription, not just for the current plan

### DIFF
--- a/kuma/users/stripe_utils.py
+++ b/kuma/users/stripe_utils.py
@@ -11,14 +11,20 @@ from .models import UserSubscription
 
 
 def retrieve_stripe_subscription(customer):
+    """
+    Returns the first subscription it finds matching the configured stripe
+    plan or, if there's none, just the first it finds.
+    """
+    first_subscription = None
     for subscription in customer.subscriptions.list().auto_paging_iter():
         # We have to use array indexing syntax, as stripe uses dicts to
         # represent its objects (dicts come with an .items method)
         for item in subscription["items"].auto_paging_iter():
             if item.plan.id == settings.STRIPE_PLAN_ID:
                 return subscription
-
-    return None
+            elif first_subscription is None:
+                first_subscription = subscription
+    return first_subscription
 
 
 def retrieve_and_synchronize_subscription_info(user):

--- a/kuma/users/stripe_utils.py
+++ b/kuma/users/stripe_utils.py
@@ -16,14 +16,19 @@ def retrieve_stripe_subscription(customer):
     plan or, if there's none, just the first it finds.
     """
     first_subscription = None
+
     for subscription in customer.subscriptions.list().auto_paging_iter():
+        if first_subscription is None:
+            first_subscription = subscription
+
         # We have to use array indexing syntax, as stripe uses dicts to
         # represent its objects (dicts come with an .items method)
         for item in subscription["items"].auto_paging_iter():
             if item.plan.id == settings.STRIPE_PLAN_ID:
+                # If we find a subscription matching the selected plan we
+                # return that instead of whatever we found first
                 return subscription
-            elif first_subscription is None:
-                first_subscription = subscription
+
     return first_subscription
 
 


### PR DESCRIPTION
Fixes #6846 

## What it does
Surprisingly little. It changes subscription retrieval to return the first subscription it finds, if there's none for the currently configured plan. Which means we'll also save subscriptions from other (old) plans to our caching table.
I honestly thought there would be more to do here, but I couldn't find any other unwanted interactions this change was creating 🤔 

## How to test
1. Make sure you have an enabled webhook for the payment_suceeded event (https://dashboard.stripe.com/test/webhooks)
1. Subscribe to MDN in your local install
1. Create a new stripe subscription plan. For a test account you'll have to create it under a new product (https://dashboard.stripe.com/test/subscriptions/products).
1. Set the new plan in .env
1. Clear the users_usersubscription table
1. Restart docker
1. Start ngrok, configure the enabled webhook to use it
1. resend the last payment_suceeded event (which should be for the plan you currently have not selected)
1. Verify that it 200s