### PR TITLE
Read subscription invoice total from stripe object

### DIFF
--- a/kuma/users/tests/test_stripe_subscription.py
+++ b/kuma/users/tests/test_stripe_subscription.py
@@ -172,6 +172,7 @@ def test_stripe_payment_succeeded_sends_invoice_mail(
         data=SimpleNamespace(
             object=SimpleNamespace(
                 number="test_invoice_001",
+                total=700,
                 customer="cus_mock_testuser",
                 created=1583842724,
                 invoice_pdf="https://developer.mozilla.org/mock-invoice-pdf-url",
@@ -199,7 +200,7 @@ def test_stripe_payment_succeeded_sends_invoice_mail(
     assert payment_email.to == [testuser.email]
     assert "Receipt" in payment_email.subject
     assert "Invoice number: test_invoice_001" in payment_email.body
-    assert "You supported MDN with a $4.99 monthly subscription" in payment_email.body
+    assert "You supported MDN with a $7.00 monthly subscription" in payment_email.body
     assert "manage monthly subscriptions" in payment_email.body
 
 


### PR DESCRIPTION
Fixes #6874 

## What it does
Changes the invoice amount for the invoice email to be dynamic, based on what was actually paid. E.g. for my configured plan:
```
Thank you.

You supported MDN with a $23.00 monthly subscription.

Amount paid: $23.00
Payment method: Visa

Invoice number: 6DAEC331-0022
Date of issue: April 28, 2020
Date due: April 28, 2020

Your next payment of $23.00 (monthly) occurs on May 28, 2020.

Cancel any time. To cancel your subscription, please go to the manage monthly subscriptions page (http://localhost.org:8000/en-US/payments/recurring/management/). If you have quest
ions, please read the FAQ (http://localhost.org:8000/en-US/payments/) or you can also contact support (mdn-support@mozilla.com).
```

I also renamed `payment_intent` to `invoice` as the former was a misnomer, making it hard to find the correct docs (my bad). Unfortunately I have to divide a money amount by 100, which is a no-no but the currency formatting lib we use unfortunately operates on dollars instead of cents. I don't think it's a biggie in this case as it's only for display purpose and we're not a bank.

## How to test it
Create a subscription plan with a non 5 USD amount, do the ngrok dance, subscribe to MDN and check that you've received an email with the correct amount.