### PR TITLE
fix robots and endpoints headless integration tests

### DIFF
--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -208,18 +208,7 @@ def test_hreflang_basic(site_url):
 @pytest.mark.parametrize(
     "uri,expected_keys",
     [
-        (
-            "/api/v1/whoami",
-            (
-                "username",
-                "is_staff",
-                "is_authenticated",
-                "timezone",
-                "is_beta_tester",
-                "avatar_url",
-                "is_superuser",
-            ),
-        ),
+        ("/api/v1/whoami", (("waffle", ("flags", "switches", "samples")),),),
         (
             "/api/v1/doc/en-US/Web/CSS",
             (

--- a/tests/headless/test_robots.py
+++ b/tests/headless/test_robots.py
@@ -9,7 +9,7 @@ from . import INDEXED_ATTACHMENT_DOMAINS, INDEXED_WEB_DOMAINS, WIKI_HOST
 @pytest.mark.smoke
 @pytest.mark.headless
 @pytest.mark.nondestructive
-def test_robots(any_host_url, wiki_host):
+def test_robots(any_host_url):
     url = any_host_url + "/robots.txt"
     response = requests.get(url)
     assert response.status_code == 200
@@ -24,6 +24,7 @@ def test_robots(any_host_url, wiki_host):
             assert "Disallow:\n" in response.text
             assert "Disallow: /" not in response.text
         else:
-            assert "Disallow: /admin/\n" in response.text
+            assert "Disallow:\n" not in response.text
+            assert "Disallow: /" in response.text
     else:
         assert "Disallow: /\n" in response.text


### PR DESCRIPTION
Fixes https://github.com/mdn/kuma/issues/6918

Already tested against stage and prod using:
```python
docker-compose exec web pytest --base-url https://developer.allizom.org tests
docker-compose exec web pytest --base-url https://developer.mozilla.org tests
```
so with this PR all integration tests pass again.