### PR TITLE
Add command for exporting subscribers to sendinblue

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-issue.md
+++ b/.github/ISSUE_TEMPLATE/content-issue.md
@@ -1,3 +1,13 @@
+---
+name: Content request
+about: Suggest a change to MDN Content
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+
 # Content Issue
 <!-- Select the appropriate option -->
 - [x] Please close this issue, I accidentally submitted it without adding any details

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -317,6 +317,16 @@ https://dashboard.stripe.com/test/webhooks
 Note that with the free tier a restart of ngrok gives you a new hostname, so you'll have to change the config
 again and restart the server (or manually change the webhook in Stripe's dashboard).
 
+Enable Sendinblue email integration
+===================================
+#. Create a Sendinblue account over at https://www.sendinblue.com (you can skip a lot of the profile set-up,
+   look for skip in the upper right).
+#. Get your v3 API key at https://account.sendinblue.com/advanced/api
+#. Create two lists at https://my.sendinblue.com/lists/new/parent_id/1 - one for paying and one for non-paying
+   users and remember their IDs
+#. Add the sendinblue config keys to your .env, the keynames are ``SENDINBLUE_API_KEY``,
+   ``SENDINBLUE_PAYING_LIST_ID`` and ``SENDINBLUE_NOT_PAYING_LIST_ID``
+
 Interact with the Docker containers
 ===================================
 The current directory is mounted as the ``/app`` folder in the web and worker

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1845,4 +1845,6 @@ STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
 # into lists of paying and not paying users
 SENDINBLUE_API_KEY = config("SENDINBLUE_API_KEY", default=None)
 SENDINBLUE_PAYING_LIST_ID = config("SENDINBLUE_PAYING_LIST_ID", cast=int, default=None)
-SENDINBLUE_NOT_PAYING_LIST_ID = config("SENDINBLUE_NOT_PAYING_LIST_ID", cast=int, default=None)
+SENDINBLUE_NOT_PAYING_LIST_ID = config(
+    "SENDINBLUE_NOT_PAYING_LIST_ID", cast=int, default=None
+)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1844,5 +1844,5 @@ STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
 # We use sendinblue.com to send marketing emails and are subdividing users
 # into lists of paying and not paying users
 SENDINBLUE_API_KEY = config("SENDINBLUE_API_KEY", default=None)
-SENDINBLUE_PAYING_LIST_ID = config("SENDINBLUE_PAYING_LIST_ID", cast=int)
-SENDINBLUE_NOT_PAYING_LIST_ID = config("SENDINBLUE_NOT_PAYING_LIST_ID", cast=int)
+SENDINBLUE_PAYING_LIST_ID = config("SENDINBLUE_PAYING_LIST_ID", cast=int, default=None)
+SENDINBLUE_NOT_PAYING_LIST_ID = config("SENDINBLUE_NOT_PAYING_LIST_ID", cast=int, default=None)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1844,7 +1844,5 @@ STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
 # We use sendinblue.com to send marketing emails and are subdividing users
 # into lists of paying and not paying users
 SENDINBLUE_API_KEY = config("SENDINBLUE_API_KEY", default=None)
-SENDINBLUE_PAYING_LIST_ID = config("SENDINBLUE_PAYING_LIST_ID", cast=int, default=None)
-SENDINBLUE_NOT_PAYING_LIST_ID = config(
-    "SENDINBLUE_NOT_PAYING_LIST_ID", cast=int, default=None
-)
+SENDINBLUE_PAYING_LIST_ID = config("SENDINBLUE_PAYING_LIST_ID", default=None)
+SENDINBLUE_NOT_PAYING_LIST_ID = config("SENDINBLUE_NOT_PAYING_LIST_ID", default=None)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1840,3 +1840,9 @@ INDEX_CSS_CLASSNAMES = config("INDEX_CSS_CLASSNAMES", cast=bool, default=not DEB
 # For local development you might want to set this to a hostname provided to
 # you by a tunneling service such as ngrok.
 STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
+
+# We use sendinblue.com to send marketing emails and are subdividing users
+# into lists of paying and not paying users
+SENDINBLUE_API_KEY = config("SENDINBLUE_API_KEY", default=None)
+SENDINBLUE_PAYING_LIST_ID = config("SENDINBLUE_PAYING_LIST_ID", cast=int)
+SENDINBLUE_NOT_PAYING_LIST_ID = config("SENDINBLUE_NOT_PAYING_LIST_ID", cast=int)

--- a/kuma/users/apps.py
+++ b/kuma/users/apps.py
@@ -18,9 +18,10 @@ class UserConfig(AuthConfig):
         # Connect signal handlers
         from . import signal_handlers  # noqa
 
-        from kuma.users.checks import stripe_check
+        from kuma.users.checks import stripe_check, sendinblue_check
 
         register(stripe_check)
+        register(sendinblue_check)
 
         # Configure global 'stripe' module
         if settings.STRIPE_SECRET_KEY:

--- a/kuma/users/checks.py
+++ b/kuma/users/checks.py
@@ -2,10 +2,13 @@ import stripe
 from django.conf import settings
 from django.core.checks import Error
 
+from . import sendinblue
 from .stripe_utils import create_missing_stripe_webhook
 
 STRIPE_PLAN_ERROR = "kuma.users.E001"
 STRIPE_PLAN_INACTIVE_ERROR = "kuma.users.E002"
+
+SENDINBLUE_LIST_ERROR = "kuma.users.E003"
 
 
 def stripe_check(app_configs, **kwargs):
@@ -23,20 +26,44 @@ def stripe_check(app_configs, **kwargs):
         if not plan.active:
             errors.append(
                 Error(
-                    f"{settings.STRIPE_PLAN_ID} points to an inactive Strip plan",
+                    f"{settings.STRIPE_PLAN_ID} points to an inactive Stripe plan",
                     id=STRIPE_PLAN_INACTIVE_ERROR,
                 )
             )
     except stripe.error.StripeError as error:
         errors.append(
-            Error(f"unable to retrieve stripe plan: {error}", id=STRIPE_PLAN_ERROR)
+            Error(f"unable to retrieve Stripe plan: {error}", id=STRIPE_PLAN_ERROR)
         )
 
     try:
         create_missing_stripe_webhook()
     except stripe.error.StripeError as error:
         errors.append(
-            Error(f"unable get or create strip webhooks: {error}", id=STRIPE_PLAN_ERROR)
+            Error(
+                f"unable get or create Stripe webhooks: {error}", id=STRIPE_PLAN_ERROR
+            )
         )
+
+    return errors
+
+
+def sendinblue_check(app_configs, **kwargs):
+    errors = []
+
+    if not settings.SENDINBLUE_API_KEY:
+        return errors
+
+    for id in [
+        settings.SENDINBLUE_PAYING_LIST_ID,
+        settings.SENDINBLUE_NOT_PAYING_LIST_ID,
+    ]:
+        response = sendinblue.request("GET", f"contacts/lists/{id}")
+        if not response.ok:
+            errors.append(
+                Error(
+                    f"Error when checking sendinblue list #{id}: {response.json()['message']}",
+                    id=SENDINBLUE_LIST_ERROR,
+                )
+            )
 
     return errors

--- a/kuma/users/management/commands/export_to_sendinblue.py
+++ b/kuma/users/management/commands/export_to_sendinblue.py
@@ -28,14 +28,15 @@ class Command(BaseCommand):
         non_paying_users = []
         for user in users.only("email", "first_name", "last_name"):
             is_paying = user.id in active_subscriber_user_ids
-            list = paying_users if is_paying else non_paying_users
-            list.append(
-                {
-                    "EMAIL": user.email,
-                    "FIRSTNAME": user.first_name,
-                    "LASTNAME": user.last_name,
-                }
-            )
+            row = {
+                "EMAIL": user.email,
+                "FIRSTNAME": user.first_name,
+                "LASTNAME": user.last_name,
+            }
+            if is_paying:
+                paying_users.append(row)
+            else:
+                non_paying_users.append(row)
 
         def export_users(users, list_id):
             csv_out = StringIO()
@@ -58,7 +59,9 @@ class Command(BaseCommand):
                 "content-type": "application/json",
             }
 
-            response = requests_retry_session().request("POST", URL, json=payload, headers=headers)
+            response = requests_retry_session().request(
+                "POST", URL, json=payload, headers=headers
+            )
             response.raise_for_status()
 
         print(f"Exporting {len(paying_users)} paying user(s)")

--- a/kuma/users/management/commands/export_to_sendinblue.py
+++ b/kuma/users/management/commands/export_to_sendinblue.py
@@ -12,7 +12,7 @@ from kuma.users.models import User, UserSubscription
 class Command(BaseCommand):
     help = "Exports newsletter subscribed users to sendinblue"
 
-    def handle(self):
+    def handle(self, **options):
         if not settings.SENDINBLUE_API_KEY:
             raise CommandError("SENDINBLUE_API_KEY config not set")
 
@@ -48,7 +48,7 @@ class Command(BaseCommand):
 
             payload = {
                 "fileBody": csv_out.getvalue(),
-                "listIds": [list_id],
+                "listIds": [int(list_id)],
                 "updateExistingContacts": True,
                 "emptyContactsAttributes": True,
             }

--- a/kuma/users/management/commands/export_to_sendinblue.py
+++ b/kuma/users/management/commands/export_to_sendinblue.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                 non_paying_users.append(row)
 
         def export_users(users, list_id):
-             print(f"Exporting {len(paying_users):,} on list ${list_id}")
+            print(f"Exporting {len(users):,} on list {list_id}")
             csv_out = StringIO()
             writer = csv.DictWriter(
                 csv_out, fieldnames=["EMAIL", "FIRSTNAME", "LASTNAME"]
@@ -65,7 +65,5 @@ class Command(BaseCommand):
             )
             response.raise_for_status()
 
-        print(f"Exporting {len(paying_users)} paying user(s)")
         export_users(paying_users, options["paying_users_list_id"])
-        print(f"Exporting {len(non_paying_users)} non-paying users")
         export_users(non_paying_users, options["non_paying_users_list_id"])

--- a/kuma/users/management/commands/export_to_sendinblue.py
+++ b/kuma/users/management/commands/export_to_sendinblue.py
@@ -1,0 +1,89 @@
+import csv
+import json
+from io import StringIO
+
+import requests
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+URL = "https://api.sendinblue.com/v3/contacts/import"
+
+
+def _dictfetchall(cursor):
+    "Returns all rows from a cursor as a dict. source: https://stackoverflow.com/a/14294314"
+    desc = cursor.description
+    return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
+
+
+class Command(BaseCommand):
+    help = "Exports newsletter subscribed users to sendinblue"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--api-key")
+        parser.add_argument("--paying-users-list-id", type=int)
+        parser.add_argument("--non-paying-users-list-id", type=int)
+
+    def handle(self, **options):
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            SELECT
+                email,
+                first_name,
+                last_name,
+                EXISTS(
+                    SELECT 1
+                    FROM users_usersubscription
+                    WHERE user_id = auth_user.id AND canceled IS NULL
+                ) AS is_paying
+            FROM auth_user
+            WHERE email <> '' AND is_newsletter_subscribed
+        """
+        )
+        rows = _dictfetchall(cursor)
+
+        paying_users = []
+        non_paying_users = []
+        for row in rows:
+            if row["is_paying"]:
+                paying_users.append(row)
+            else:
+                non_paying_users.append(row)
+
+        def export_users(users, list_id):
+            csv_out = StringIO()
+            writer = csv.DictWriter(
+                csv_out, fieldnames=["EMAIL", "FIRSTNAME", "LASTNAME"]
+            )
+            writer.writeheader()
+            for user in users:
+                writer.writerow(
+                    {
+                        "EMAIL": user["email"],
+                        "FIRSTNAME": user["first_name"],
+                        "LASTNAME": user["last_name"],
+                    }
+                )
+
+            payload = json.dumps(
+                {
+                    "fileBody": csv_out.getvalue(),
+                    "listIds": [list_id],
+                    "updateExistingContacts": True,
+                    "emptyContactsAttributes": True,
+                },
+                separators=(",", ":"),
+            )
+            headers = {
+                "api-key": options["api_key"],
+                "accept": "application/json",
+                "content-type": "application/json",
+            }
+
+            response = requests.request("POST", URL, data=payload, headers=headers)
+            response.raise_for_status()
+
+        print(f"Exporting {len(paying_users)} paying user(s)")
+        export_users(paying_users, options["paying_users_list_id"])
+        print(f"Exporting {len(non_paying_users)} non-paying user(s)")
+        export_users(non_paying_users, options["non_paying_users_list_id"])

--- a/kuma/users/management/commands/export_to_sendinblue.py
+++ b/kuma/users/management/commands/export_to_sendinblue.py
@@ -10,12 +10,6 @@ from kuma.users.models import User, UserSubscription
 URL = "https://api.sendinblue.com/v3/contacts/import"
 
 
-def _dictfetchall(cursor):
-    "Returns all rows from a cursor as a dict. source: https://stackoverflow.com/a/14294314"
-    desc = cursor.description
-    return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
-
-
 class Command(BaseCommand):
     help = "Exports newsletter subscribed users to sendinblue"
 

--- a/kuma/users/management/commands/export_to_sendinblue.py
+++ b/kuma/users/management/commands/export_to_sendinblue.py
@@ -85,5 +85,5 @@ class Command(BaseCommand):
 
         print(f"Exporting {len(paying_users)} paying user(s)")
         export_users(paying_users, options["paying_users_list_id"])
-        print(f"Exporting {len(non_paying_users)} non-paying user(s)")
+        print(f"Exporting {len(non_paying_users)} non-paying users")
         export_users(non_paying_users, options["non_paying_users_list_id"])

--- a/kuma/users/sendinblue.py
+++ b/kuma/users/sendinblue.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+
+from kuma.core.utils import requests_retry_session
+
+
+API_URL = "https://api.sendinblue.com/v3/"
+
+
+def request(method, path, **kwargs):
+    headers = {
+        "api-key": settings.SENDINBLUE_API_KEY,
+        "accept": "application/json",
+        "content-type": "application/json",
+    }
+
+    return requests_retry_session().request(
+        method, API_URL + path, headers=headers, **kwargs
+    )

--- a/kuma/users/sendinblue.py
+++ b/kuma/users/sendinblue.py
@@ -10,6 +10,6 @@ def request(method, path, **kwargs):
     return requests_retry_session().request(
         method,
         API_URL + path,
-        headers={"api-key": settings.SENDINBLUE_API_KEY, "accept": "application/json",},
+        headers={"api-key": settings.SENDINBLUE_API_KEY, "accept": "application/json"},
         **kwargs,
     )

--- a/kuma/users/sendinblue.py
+++ b/kuma/users/sendinblue.py
@@ -7,12 +7,9 @@ API_URL = "https://api.sendinblue.com/v3/"
 
 
 def request(method, path, **kwargs):
-    headers = {
-        "api-key": settings.SENDINBLUE_API_KEY,
-        "accept": "application/json",
-        "content-type": "application/json",
-    }
-
     return requests_retry_session().request(
-        method, API_URL + path, headers=headers, **kwargs
+        method,
+        API_URL + path,
+        headers={"api-key": settings.SENDINBLUE_API_KEY, "accept": "application/json",},
+        **kwargs,
     )


### PR DESCRIPTION
Fixes #6933 

## What it does
Adds a command to export users who've opted-in to the "new" newsletter signup checkbox into sendinblue. It's currently done in two requests, since we want to bucket users into paying and non-paying lists. The docs for the API used are here: https://developers.sendinblue.com/reference#importcontacts-1

~I chose to not add the API key to our config files it yet, as we're still in the early testing phase of this. So in the future this command might have no arguments, but for now it has three (more below).~

Also there's a limit to the import CSV string size, which is ~8MB. My napkin math says we'll reach that once we try to import 400k users at once. Currently we're only importing the once who've checkedthe fairly new (signup-only) opt-in. So I opted for not complicating the code for the 400k case. My expectation is that we'll have proper syncing set-up before reach that.

~Oh and I went with raw SQL since I spent half an hour reading docs trying to find out how to do what I already knew how to do in SQL. Frustrated I gave up and just went raw. Happy to do the Django thing if anyone prefers that (and has some guidance for me).~

## How to test it
1. Create a sendinblue account over at https://www.sendinblue.com (you can skip a lot of the profile set-up, look for skip in the upper right)
1. Get your v3 API key at https://account.sendinblue.com/advanced/api
1. Create two lists at https://my.sendinblue.com/lists/new/parent_id/1 - one for paying and one for non-paying users
1. Add the sendinblue config keys to your .env (see below for key naming)
1. Run the following and check after that you receive emails informing you about successful imports (might take a min)
https://github.com/mdn/kuma/blob/fa26f1861e0d089b3c2ba6a7c3195e17d0d8761e/kuma/settings/common.py#L1844-L1848
```bash
docker-compose exec web ./manage.py export_to_sendinblue
```