### PR TITLE
Fix Jest error in user-provider test

### DIFF
--- a/kuma/javascript/src/user-provider.test.js
+++ b/kuma/javascript/src/user-provider.test.js
@@ -6,9 +6,6 @@ import { render, waitFor } from '@testing-library/react';
 import GAProvider from './ga-provider.jsx';
 import UserProvider from './user-provider.jsx';
 
-// This can be removed once https://github.com/mdn/kuma/pull/6940 lands
-require('regenerator-runtime/runtime');
-
 describe('UserProvider', () => {
     test('context works', () => {
         const P = UserProvider.context.Provider;


### PR DESCRIPTION
**Issue:** 
Running `jest` gives you this error in `user-provider.test.js`: 
```
  console.error node_modules/react-test-renderer/cjs/react-test-renderer.development.js:120
    Warning: An update to UserProvider inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in UserProvider
        in GAProvider
```

**Changes:**
Update test so it does not cause this error.

**To test:**
Run `jest` and ensure that no `console.errors` are logged and tests pass. 