### PR TITLE
footer and .contentinfo

### DIFF
--- a/kuma/javascript/src/footer.jsx
+++ b/kuma/javascript/src/footer.jsx
@@ -104,10 +104,7 @@ export default function Footer() {
                 <div id="license" className="contentinfo">
                     <p>
                         &copy; 2005-{new Date().getFullYear()} Mozilla and
-                        individual contributors.
-                    </p>
-                    <p>
-                        Content is available under{' '}
+                        individual contributors. Content is available under{' '}
                         <a href="/docs/MDN/About#Copyrights_and_licenses">
                             these licenses
                         </a>


### PR DESCRIPTION
Fixes #6971

To test: Go to 
http://localhost.org:8000/en-US/docs/Web

Before: 
<img width="607" alt="Screen Shot 2020-04-30 at 12 49 35 PM" src="https://user-images.githubusercontent.com/26739/80737127-11da1100-8ae1-11ea-96f1-e1841133e228.png">

After:
<img width="753" alt="Screen Shot 2020-04-30 at 12 48 47 PM" src="https://user-images.githubusercontent.com/26739/80737065-fbcc5080-8ae0-11ea-8653-f7f809c7345d.png">


We're still maintaining two footers :(