### PR TITLE
Fix icon size and pluralization on Payments Management page

### DIFF
--- a/kuma/javascript/src/payments/pages/management.jsx
+++ b/kuma/javascript/src/payments/pages/management.jsx
@@ -75,7 +75,7 @@ const ManagementPage = ({ locale }: Props): React.Node => {
         <div className="active-subscriptions">
             <Interpolated
                 id={gettext(
-                    'You have no active subscriptions. Why not <signupLink />?'
+                    'You have no active subscription. Why not <signupLink />?'
                 )}
                 signupLink={
                     <a href={`/${locale}/payments/`}>{gettext('set one up')}</a>
@@ -181,7 +181,7 @@ const ManagementPage = ({ locale }: Props): React.Node => {
             >
                 <section>
                     <div className="column-8">
-                        <h2>{gettext('Subscriptions')}</h2>
+                        <h2>{gettext('Subscription')}</h2>
                         {renderContent()}
                         {status === 'success' && renderSuccess()}
                     </div>

--- a/kuma/javascript/src/payments/pages/management.test.jsx
+++ b/kuma/javascript/src/payments/pages/management.test.jsx
@@ -59,7 +59,7 @@ describe('Payments Management Page', () => {
     it('shows no subscriptions message if not a subscriber', () => {
         const mockUserData = { isAuthenticated: true };
         const { getByText } = setup(mockUserData);
-        expect(getByText(/no active subscriptions/i)).toBeInTheDocument();
+        expect(getByText(/no active subscription/i)).toBeInTheDocument();
     });
 
     it('shows error message if cannot retrieve subscriptions', async () => {
@@ -150,7 +150,7 @@ describe('Payments Management Page', () => {
         // Success message and no subscriptions message should show
         await waitFor(() => {
             expect(getByText(successMsg)).toBeInTheDocument();
-            expect(getByText(/no active subscriptions/i)).toBeInTheDocument();
+            expect(getByText(/no active subscription/i)).toBeInTheDocument();
         });
 
         window.fetch.mockReset();

--- a/kuma/static/styles/components/payments/_page.scss
+++ b/kuma/static/styles/components/payments/_page.scss
@@ -225,12 +225,12 @@
                 padding-left: 30px;
 
                 &.amount {
-                    background: url('/static/img/subscriptions/money.svg') 0 50% no-repeat;
+                    background: url('/static/img/subscriptions/money.svg') 0 50% / 23px 16px no-repeat;
                 }
 
                 &.credit-card {
                     background: url('/static/img/subscriptions/credit-card.svg')
-                        0 50% no-repeat;
+                        0 50% / 21px 16px no-repeat;
                 }
                 &::after {
                     content: ': ';


### PR DESCRIPTION
Must've had cached SVG files or something-- I did not notice this on the last review. 

Before:
<img width="632" alt="Screen Shot 2020-04-30 at 3 39 34 PM" src="https://user-images.githubusercontent.com/650/80752012-d3505080-8af8-11ea-9118-7f2d921480c2.png">

After:
<img width="635" alt="Screen Shot 2020-04-30 at 3 39 13 PM" src="https://user-images.githubusercontent.com/650/80752024-d8150480-8af8-11ea-8d50-6f1d1537aefd.png">
