### PR TITLE
First iteration of responsive header improvements

### DIFF
--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -18,9 +18,13 @@ exports[`Login component when user is logged in 1`] = `
       <img
         alt="test-username"
         className="avatar"
-        src="/static/img/avatar.png"
-        srcSet="test-url 200w, test-url 50w"
+        src="test-url"
       />
+      <span
+        className="username"
+      >
+        test-username
+      </span>
     </button>
     <ul
       className="dropdown-menu-items right"

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -29,10 +29,7 @@ export default function Login(): React.Node {
         let label = (
             <>
                 <img
-                    srcSet={`${userData.avatarUrl || ''} 200w, ${
-                        userData.avatarUrl || ''
-                    } 50w`}
-                    src={'/static/img/avatar.png'}
+                    src={userData.avatarUrl || '/static/img/avatar.png'}
                     className="avatar"
                     alt={userData.username}
                 />

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -27,14 +27,17 @@ export default function Login(): React.Node {
         // profile pic, defaulting to the dino head if the avatar
         // URL doesn't work.
         let label = (
-            <img
-                srcSet={`${userData.avatarUrl || ''} 200w, ${
-                    userData.avatarUrl || ''
-                } 50w`}
-                src={'/static/img/avatar.png'}
-                className="avatar"
-                alt={userData.username}
-            />
+            <>
+                <img
+                    srcSet={`${userData.avatarUrl || ''} 200w, ${
+                        userData.avatarUrl || ''
+                    } 50w`}
+                    src={'/static/img/avatar.png'}
+                    className="avatar"
+                    alt={userData.username}
+                />
+                <span className="username">{userData.username}</span>
+            </>
         );
         let viewProfileLink = `/${locale}/profiles/${userData.username}`;
         let editProfileLink = `${viewProfileLink}/edit`;

--- a/kuma/javascript/src/header/login.test.js
+++ b/kuma/javascript/src/header/login.test.js
@@ -43,12 +43,12 @@ test('Login component when user is logged in', () => {
     // Expect a Dropdown element
     let root = login.root;
     let dropdown = root.findByType(Dropdown);
+    let dropDownLabelProps = dropdown.props.label.props.children[0].props;
     expect(dropdown).toBeDefined();
 
     // Whose label prop is an image with the expected src and alt attributes
-    expect(dropdown.props.label.props.srcSet).toContain('test-url 50w');
-    expect(dropdown.props.label.props.srcSet).toContain('test-url 200w');
-    expect(dropdown.props.label.props.alt).toEqual('test-username');
+    expect(dropDownLabelProps.src).toContain('test-url');
+    expect(dropDownLabelProps.alt).toEqual('test-username');
 
     let string = JSON.stringify(login.toJSON());
     expect(string).toContain('View profile');

--- a/kuma/static/styles/minimalist/components/_dropdown.scss
+++ b/kuma/static/styles/minimalist/components/_dropdown.scss
@@ -14,11 +14,15 @@
         flex-direction: row;
         align-items: center;
         color: $text-color;
-        padding: 0 5px 5px;
+        padding-left: 5px;
         border: none;
         white-space: nowrap;
         font-size: $tiny-font-size;
         font-weight: bold;
+
+        @media #{$mq-tablet-and-up} {
+            padding: 0 5px 5px;
+        }
     }
 
     .dropdown-menu-items {

--- a/kuma/static/styles/minimalist/components/_login.scss
+++ b/kuma/static/styles/minimalist/components/_login.scss
@@ -3,8 +3,18 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    justify-self: center;
 
+    @media #{$mq-tablet-and-up} {
+        justify-self: center;
+    }
+
+    .username {
+        margin-left: 5px;
+
+        @media #{$mq-tablet-and-up} {
+            display: none;
+        }
+    }
     /* Buttons (in the dropdown labels) don't seem to inherit font sizes
         so we need to make this explicit. */
     button {
@@ -29,12 +39,15 @@
 .signin-link {
     display: flex;
     align-items: center;
-    justify-self: center;
+    color: $text-color;
     font-size: 1rem;
     font-weight: bold;
-    color: $text-color;
-    margin-left: 24px;
     text-decoration: none;
+
+    @media #{$mq-tablet-and-up} {
+        justify-self: center;
+        margin-left: 24px;
+    }
 
     &:hover {
         text-decoration: none;

--- a/kuma/static/styles/minimalist/components/_main-nav.scss
+++ b/kuma/static/styles/minimalist/components/_main-nav.scss
@@ -81,9 +81,10 @@
             border: none;
             width: 100%;
             text-align: left;
-            padding: 10px;
+            padding: 10px 10px 15px 0;
 
             @media #{$mq-tablet-and-up} {
+                padding-left: 10px;
                 width: unset;
             }
         }

--- a/kuma/static/styles/minimalist/components/_main-nav.scss
+++ b/kuma/static/styles/minimalist/components/_main-nav.scss
@@ -84,7 +84,7 @@
             padding: 10px 10px 15px 0;
 
             @media #{$mq-tablet-and-up} {
-                padding-left: 10px;
+                padding: 10px;
                 width: unset;
             }
         }

--- a/kuma/static/styles/minimalist/components/_page-header.scss
+++ b/kuma/static/styles/minimalist/components/_page-header.scss
@@ -15,6 +15,7 @@
     @media #{$mq-small-desktop-and-up} {
         grid-template-columns: 221px 5fr minmax(250px, 2fr) minmax(90px, auto);
         grid-template-areas: 'I M S L';
+        padding: 0 16px;
         height: 68px;
         font-size: 16px;
     }

--- a/kuma/static/styles/minimalist/components/_page-header.scss
+++ b/kuma/static/styles/minimalist/components/_page-header.scss
@@ -1,12 +1,12 @@
 .page-header {
     display: grid;
-    margin: 0 16px;
-    align-items: center;
-    font-size: 10px;
-    grid-template-columns: repeat(4, 1fr);
-    grid-template-areas: 'I I L L' 'S S S S' 'M M M M';
+    padding: 20px;
+    gap: 20px;
+    grid-template-columns: 1fr;
+    grid-template-areas: 'I' 'L' 'M' 'S';
 
     @media #{$mq-tablet-and-up} {
+        align-items: center;
         grid-template-columns: minmax(206px, 1fr) 300px minmax(90px, auto);
         grid-template-areas: 'I S L' 'R R R' 'M M M';
         height: 122px;


### PR DESCRIPTION
I am breaking down the work on the optimized header as I have found a few things over and above the "actual" work that needs attention. So, instead of holding out for one *big* PR, I am thinking many small pull requests that progressively improve things ;)

## Header on mobile post this PR (not signed in)

![Screenshot 2020-05-04 at 06 43 02](https://user-images.githubusercontent.com/10350960/80941579-148b7d80-8de3-11ea-9b1c-1ab97dcd2002.png)

## Header on mobile post this PR (signed in)

![Screenshot 2020-05-04 at 06 42 47](https://user-images.githubusercontent.com/10350960/80941591-1fdea900-8de3-11ea-8ded-dfee50d802fd.png)

@Gregoor r?