### PR TITLE
Fix BCD table row headings

### DIFF
--- a/kuma/static/styles/components/compat-tables/_bc-table.scss
+++ b/kuma/static/styles/components/compat-tables/_bc-table.scss
@@ -17,8 +17,10 @@ table.bc-table {
     border-spacing: 0;
     @include rgba-fallback('background-color', $table-blue, .5);
 
-    th {
-        text-align: center;
+    thead {
+        th {
+            text-align: center;
+        }
     }
 }
 
@@ -127,6 +129,7 @@ table.bc-table {
     @include bidi(((border-right, solid, 0), ));
     @include bidi(((border-left, 0, solid), ));
     text-align: left;
+    vertical-align: top;
 }
 
 /* td


### PR DESCRIPTION
Changes:
- Align table body row headings to top-left of cell 

To test:
- Visit any page with a BCD table that has notes, such as http://localhost.org:8000/en-US/docs/Web/CSS/@media#Accessibility_concerns. 
- Toggle arrow and ensure that table row heading is still visible 

Before: 
<img width="1015" alt="Screen Shot 2020-05-04 at 6 39 52 PM" src="https://user-images.githubusercontent.com/650/81020369-abcdf080-8e36-11ea-9e22-3adaf66be8cf.png">


After: 
<img width="1013" alt="Screen Shot 2020-05-04 at 6 39 28 PM" src="https://user-images.githubusercontent.com/650/81020385-b092a480-8e36-11ea-9976-bca36090ba3b.png">


Closes #6845 