### PR TITLE
Replaced IRC mentions with Matrix equivalents.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ the [MDN "Getting Involved" page][get-involved]. There are interesting
 they may be harder to find. If you have questions about what to work on, you
 can ask:
 
-* In the #mdndev [IRC channel on irc.mozilla.org][irc-howto].
+* In the #mdn [Matrix room on chat.mozilla.org][matrix-howto].
 * In the [MDN Topic][discourse] in Discourse.
 
 [get-involved]: https://wiki.mozilla.org/Webdev/GetInvolved/developer.mozilla.org#Mentored_Bugs
-[irc-howto]: https://wiki.mozilla.org/Irc
+[matrix-howto]: https://wiki.mozilla.org/Matrix
 [mdn-projects]: https://github.com/mdn
 
 How to submit code
@@ -274,8 +274,7 @@ merge after fixing minor issues.
 
 Deployment and Closing Bugs
 ---------------------------
-MDN staff deploy new code one to three times a week. Deployments are announced
-in the #mdndev IRC channel. Currently deployed code can be seen on the
+MDN staff deploy new code one to three times a week. Currently deployed code can be seen on the
 [What's Deployed?](https://whatsdeployed.io/s-HC0) page.
 
 Once a bug fix is in production, the bug can be marked as RESOLVED:FIXED.

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Development
 :Dev Docs:      https://kuma.readthedocs.io/en/latest/installation.html
 :CI Server:     https://travis-ci.com/mdn/kuma
 :Forum:         https://discourse.mozilla.org/c/mdn
-:IRC:           irc://irc.mozilla.org/mdndev
+:Matrix:        `#mdn room`_
 :Servers:       `What's Deployed on MDN?`_
 
                 https://developer.allizom.org/ (stage)
@@ -50,6 +50,7 @@ Development
 .. _`Pull Request Queues`: http://prs.mozilla.io/mdn:kuma,kumascript,infra,mdn-fiori
 .. _`What's Deployed on MDN?`: https://whatsdeployed.io/s/HC0/mdn/kuma
 .. _sprint: https://wiki.mozilla.org/Engagement/MDN_Durable_Team/Processes#Planning_Sprints
+.. _`#mdn room`: https://chat.mozilla.org/#/room/#mdn:mozilla.org
 
 
 Getting started

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -195,7 +195,7 @@ pushing to production.
   on homepage and article pages. Try to verify features in the newly pushed
   code. Check the `functional tests`_.
 
-* Announce in Matrix (#mdn) that staging looks good, and you are pushing to production.
+* Announce in Slack (#mdn-dev) that staging looks good, and you are pushing to production.
 
 .. _Jenkins: https://ci.us-west-2.mdn.mozit.cloud
 .. _`What's Deployed on KumaScript`: https://whatsdeployed.io/s-SWJ
@@ -254,4 +254,3 @@ the AWS US West datacenter.
     git merge --ff-only origin/master
     git push
     cd ..
-

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -179,13 +179,8 @@ pushing to production.
 
   * Look at the changes to be pushed (`What's Deployed on Kuma`_, and
     `What's deployed on KumaScript`_). To enlist the help of pull request
-    authors and others, you can report bug numbers and PRs in IRC.
-    ``firebot`` will give handy links to Bugzilla.
+    authors and others, you can report bug numbers and PRs in Matrix.
   * Think about manual tests to confirm the code changes work without errors.
-  * Monitor the push in the ``#mdndev`` IRC channel. The final messages
-    (one for kuma, one for kumascript) look like::
-
-        🎉 SUCCESS: Check Rollout Status: Branch stage-push build #104:
 
 * Merge and push to the ``stage-integration-tests`` branch::
 
@@ -200,7 +195,7 @@ pushing to production.
   on homepage and article pages. Try to verify features in the newly pushed
   code. Check the `functional tests`_.
 
-* Announce in IRC that staging looks good, and you are pushing to production.
+* Announce in Matrix (#mdn) that staging looks good, and you are pushing to production.
 
 .. _Jenkins: https://ci.us-west-2.mdn.mozit.cloud
 .. _`What's Deployed on KumaScript`: https://whatsdeployed.io/s-SWJ
@@ -212,7 +207,7 @@ Deploy to Production
 The production site is located at https://developer.mozilla.org. It is
 monitored by the development team and MozMEAO.
 
-* Pick a push song on https://www.youtube.com. Post link to IRC.
+* Pick a push song on https://www.youtube.com. Post link to Matrix.
 
 * Start the production push::
 
@@ -226,12 +221,6 @@ monitored by the development team and MozMEAO.
     git merge --ff-only origin/master
     git push
     cd ..
-
-* Monitor the push in the ``#mdndev`` IRC channel. The final messages (one
-  for kuma, one for kumascript) are something like::
-
-    🎉 SUCCESS: Check Rollout Status: Branch prod-push build #7
-
 
 * For the next 30-60 minutes,
 
@@ -266,7 +255,3 @@ the AWS US West datacenter.
     git push
     cd ..
 
-* Monitor the push in the ``#mdndev`` IRC channel. The final messages (one
-  for kuma, one for kumascript) are something like::
-
-    🎉 SUCCESS: Check Rollout Status: Branch standby-push build #7

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,7 +29,7 @@ transitioning to Docker containers for deployment as well.
   tests using Docker.
 * We are documenting tips and tricks on the
   :doc:`Troubleshooting page <troubleshooting>`.
-* Feel free to ask for help on IRC at ``#mdndev`` or on `discourse`_.
+* Feel free to ask for help on Matrix at ``#mdn`` or on `discourse`_.
 
 .. _`Docker for Mac`: https://docs.docker.com/docker-for-mac/
 .. _`Docker's Ubuntu packages`: https://docs.docker.com/engine/installation/linux/ubuntulinux/
@@ -148,8 +148,8 @@ Pontoon_. If there is an error, the output will end with the error, such as::
     ./az/LC_MESSAGES/django.po:263: 'msgid' and 'msgstr' entries do not both end with '\n'
     msgfmt: found 1 fatal error
 
-These need to be fixed by a Kuma developer. Notify them in the #mdndev IRC
-channel or open a bug. You can continue with installation, but non-English
+These need to be fixed by a Kuma developer. Notify them in the #mdn Matrix
+room or open a bug. You can continue with installation, but non-English
 locales will not be localized.
 
 .. _Pontoon: https://pontoon.mozilla.org/projects/mdn/

--- a/kuma/users/jinja2/users/email/welcome/html.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/html.ltxt
@@ -36,10 +36,10 @@
             </li>
             <li>
               {% trans
-                channel_link='irc://irc.mozilla.org/mdn',
-                irc_link=add_utm('https://wiki.mozilla.org/IRC', 'welcome')
+                room_link='https://chat.mozilla.org/#/room/#mdn:mozilla.org',
+                matrix_link=add_utm('https://wiki.mozilla.org/Matrix', 'welcome')
               %}
-                Real-time chat: <a href="{{ channel_link }}">#mdn channel on irc.mozilla.org</a>.  (Get more info about <a href="{{ irc_link }}">IRC</a>.) You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jswisher), MDN's community manager.
+                Real-time chat: <a href="{{ room_link }}">#mdn room on chat.mozilla.org</a>.  (Get more info about <a href="{{ matrix_link }}">Matrix</a>.) You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (cmills), and me (jswisher), MDN's community manager.
               {% endtrans %}
             </li>
         </ul>

--- a/kuma/users/jinja2/users/email/welcome/plain.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/plain.ltxt
@@ -36,10 +36,10 @@
     {{ _("Join to tell us about what you're interested in on MDN and ask questions about the site.") }}
 
 {# L10n: This is an email. Whitespace matters! #}
-* {{ _('Real-time chat: #mdn channel on irc.mozilla.org') }}
+* {{ _('Real-time chat: #mdn room on chat.mozilla.org') }}
 
 {# L10n: This is an email. Whitespace matters! #}
-    ({{ _('See %(irc_link)s for more info about IRC.', irc_link=add_utm('https://wiki.mozilla.org/IRC', 'welcome')) }})
+    ({{ _('See %(matrix_link)s for more info about Matrix.', matrix_link=add_utm('https://wiki.mozilla.org/Matrix', 'welcome')) }})
 
 {# L10n: This is an email. Whitespace matters! #}
     {{ _("You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jswisher), MDN's community manager.") }}


### PR DESCRIPTION
After a rightful comment of Kairo's on Matrix, I have updated files where IRC was mentioned.

This includes both welcome emails and code contribution docs to kuma.
@jmswisher: not a big deal but I would appreciate your review on kuma/users/jinja2/users/email/welcome/html.ltxt / kuma/users/jinja2/users/email/welcome/plain.ltxt

@escattone / @peterbe / @schalkneethling: I have removed some #mdn-dev IRC mentions and replaced some of them with #mdn when I found it relevant. Please tell me if `deploy.rst` (and `troubleshooting.rst` not touched in this PR) should be treated differently.
 