### PR TITLE
Remove speedcurve from wiki

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -42,10 +42,6 @@
     {% include "includes/google_analytics.html" %}
   {% endblock %}
 
-  {% block speedcurve_lux %}
-    {% include "includes/speedcurve-lux.html" %}
-  {% endblock %}
-
   {% block perfhead %}{% endblock %}
 
   {%- if not untrusted %}


### PR DESCRIPTION
Fixes #7046

Steps to tests:

1. Open http://wiki.localhost.org:8000 - no speedcurve in HTML source
1. Open http://wiki.localhost.org:8000/en-US/docs/Web - no speedcurve in HTML source
1. Open http://localhost.org:8000 - speedcurve still in HTML source
1. Open http://localhost.org:8000/en-US/docs/Web - speedcurve still in HTML source