### PR TITLE
Fix typo on /payments

### DIFF
--- a/kuma/javascript/src/payments/components/incentives.jsx
+++ b/kuma/javascript/src/payments/components/incentives.jsx
@@ -14,7 +14,7 @@ export const nonSubscriberInvitationCopy = gettext(
     'Get invited to attend special events and conferences.'
 );
 const subscriberDiscountCopy = gettext(
-    'Get 20% of the <merchStoreLink /> with discount code MDNMEMBER20.'
+    'Get 20% off at the <merchStoreLink /> with discount code MDNMEMBER20.'
 );
 export const subscriberInvitationCopy = gettext(
     'Check back for invitations to attend special events and conferences.'

--- a/kuma/javascript/src/payments/components/incentives.jsx
+++ b/kuma/javascript/src/payments/components/incentives.jsx
@@ -21,8 +21,7 @@ export const subscriberInvitationCopy = gettext(
 );
 
 const Incentives = ({ isSubscriber = false }: Props) => {
-    const merchStoreURL =
-        'https://shop.spreadshirt.com/mozilla-developer-network/';
+    const merchStoreURL = 'https://shop.spreadshirt.com/mdn-store/';
     return (
         <div className="subscriptions-incentive">
             <h3>{gettext('Enjoy exclusive member perks')}</h3>


### PR DESCRIPTION
**Changes** 
- Update copy on /payments to "20% _off at_ the MDN Merch Store"

**To test**
- Go to /payments and ensure text says "20% off at": 
<img width="418" alt="Screen Shot 2020-05-12 at 3 37 09 PM" src="https://user-images.githubusercontent.com/650/81738024-008cef00-9467-11ea-841c-7e0f320cdb63.png">

Closes #7028