### PR TITLE
Add ability to push to multiple clusters

### DIFF
--- a/Jenkinsfiles/standby-push.groovy
+++ b/Jenkinsfiles/standby-push.groovy
@@ -31,8 +31,8 @@ stage('Push') {
 }
 
 stage('Push EKS') {
-    def current_revision_hash = utils.get_revision_hash('prod.eks.mm')
     dir('infra/apps/mdn/mdn-aws/k8s') {
+        def current_revision_hash = utils.get_revision_hash('prod.eks.mm')
         withEnv(["TO_REVISION_HASH=${env.GIT_COMMIT}",
                  "FROM_REVISION_HASH=${current_revision_hash}"]) {
             utils.migrate_db('prod.eks.mm')

--- a/Jenkinsfiles/standby-push.groovy
+++ b/Jenkinsfiles/standby-push.groovy
@@ -1,0 +1,47 @@
+stage("Announce") {
+    utils.announce_push()
+}
+
+stage("Check Pull") {
+    // Check that the image can be successfully pulled from the registry.
+    utils.ensure_pull()
+}
+
+stage("Prepare Infra") {
+    // Checkout the "mdn/infra" repo's "master" branch into the
+    // "infra" sub-directory of the current working directory.
+    utils.checkout_repo('https://github.com/mdn/infra', 'master', 'infra')
+}
+
+stage('Push') {
+    dir('infra/apps/mdn/mdn-aws/k8s') {
+        def current_revision_hash = utils.get_revision_hash()
+        withEnv(["TO_REVISION_HASH=${env.GIT_COMMIT}",
+                 "FROM_REVISION_HASH=${current_revision_hash}"]) {
+            // Run the database migrations.
+            utils.migrate_db()
+            // Start a rolling update of the Kuma-based deployments.
+            utils.rollout()
+            // Monitor the rollout until it has completed.
+            utils.monitor_rollout()
+            // Record the rollout in external services like New-Relic.
+            utils.record_rollout()
+        }
+    }
+}
+
+stage('Push EKS') {
+    def current_revision_hash = utils.get_revision_hash('prod.eks.mm')
+    dir('infra/apps/mdn/mdn-aws/k8s') {
+        withEnv(["TO_REVISION_HASH=${env.GIT_COMMIT}",
+                 "FROM_REVISION_HASH=${current_revision_hash}"]) {
+            utils.migrate_db('prod.eks.mm')
+            // Start a rolling update of the Kuma-based deployments.
+            utils.rollout('prod.eks.mm')
+            // Monitor the rollout until it has completed.
+            utils.monitor_rollout('prod.eks.mm')
+            // Record the rollout in external services like New-Relic.
+            utils.record_rollout('prod.eks.mm')
+        }
+    }
+}

--- a/Jenkinsfiles/standby-push.yml
+++ b/Jenkinsfiles/standby-push.yml
@@ -1,3 +1,3 @@
 pipeline:
   enabled: true
-  script: "push"
+  script: "standby-push"

--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -27,7 +27,10 @@ def get_target_name() {
     )
 }
 
-def get_target_script() {
+def get_target_script(target='') {
+    if (target != null && !target.trim().isEmpty()) {
+        return target
+    }
     if (env.BRANCH_NAME == PROD_BRANCH_NAME) {
         return 'prod'
     }
@@ -111,9 +114,9 @@ def sh_with_notify(cmd, display, notify_on_success=false) {
     }
 }
 
-def get_revision_hash() {
+def get_revision_hash(target='') {
     def region = get_region()
-    def target = get_target_script()
+    def target = get_target_script(target)
     def repo_name = get_repo_name()
     return sh(
         returnStdout: true,
@@ -140,8 +143,8 @@ def ensure_pull() {
     )
 }
 
-def make(cmd, display, notify_on_success=false) {
-    def target = get_target_script()
+def make(cmd, display, notify_on_success=false, target='') {
+    def target = get_target_script(target)
     def region = get_region()
     def tag = get_commit_tag()
     def repo_upper = get_repo_name().toUpperCase()
@@ -166,37 +169,37 @@ def is_read_only_db() {
     }
 }
 
-def migrate_db() {
+def migrate_db(target='') {
     /*
      * Migrate the database (only for kuma and writeable databases).
      */
     if ((get_repo_name() == 'kuma') && !is_read_only_db()) {
-        make('k8s-db-migration-job', 'Migrate Database')
+        make('k8s-db-migration-job', 'Migrate Database', target)
     }
 }
 
-def rollout() {
+def rollout(target='') {
     /*
      * Start a rolling update.
      */
     def repo = get_repo_name()
-    make("k8s-${repo}-deployments", 'Start Rollout')
+    make("k8s-${repo}-deployments", 'Start Rollout', target)
 }
 
-def monitor_rollout() {
+def monitor_rollout(target='') {
     /*
      * Monitor the rolling update until it succeeds or fails.
      */
     def repo = get_repo_name()
-    make("k8s-${repo}-rollout-status", 'Check Rollout Status', true)
+    make("k8s-${repo}-rollout-status", 'Check Rollout Status', true, target)
 }
 
-def record_rollout() {
+def record_rollout(target='') {
     /*
      * Record the rollout in external services like New Relic and SpeedCurve.
      */
     def repo = get_repo_name()
-    make("k8s-${repo}-record-deployment-job", 'Record Rollout', true)
+    make("k8s-${repo}-record-deployment-job", 'Record Rollout', true, target)
 }
 
 def announce_push() {

--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -155,9 +155,9 @@ def make(cmd, display, notify_on_success=false, target='') {
     sh_with_notify(cmds, display, notify_on_success)
 }
 
-def is_read_only_db() {
+def is_read_only_db(target='') {
     def region = get_region()
-    def target = get_target_script()
+    def target = get_target_script(target)
     try {
         sh """
             . regions/${region}/${target}.sh
@@ -173,7 +173,7 @@ def migrate_db(target='') {
     /*
      * Migrate the database (only for kuma and writeable databases).
      */
-    if ((get_repo_name() == 'kuma') && !is_read_only_db()) {
+    if ((get_repo_name() == 'kuma') && !is_read_only_db(target)) {
         make('k8s-db-migration-job', 'Migrate Database', target)
     }
 }


### PR DESCRIPTION
Add ability to push to multiple cluster for just the `eu-central-1` region, the `get_target_script` function in `utils.groovy` needed to be updated to be able to accept an argument. This allows the function to be able to use the  appropriate config file during deployments.

This goes hand in hand with mdn/infra#404 and this PR resolves #7049 