### PR TITLE
remove doc api calls from integration tests

### DIFF
--- a/tests/headless/test_cdn.py
+++ b/tests/headless/test_cdn.py
@@ -153,7 +153,6 @@ def test_not_cached(site_url, is_behind_cdn, slug, status):
         ("/@api/deki/files/3613/=hut.jpg", 301),
         ("/diagrams/workflow/workflow.svg", 200),
         ("/presentations/microsummaries/index.html", 200),
-        ("/api/v1/doc/en-US/Web/CSS", 200),
         ("/en-US/search/xml", 200),
         ("/en-US/docs.json?slug=Web/HTML", 200),
         ("/en-US/Firefox", 302),

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -207,35 +207,8 @@ def test_hreflang_basic(site_url):
 @pytest.mark.nondestructive
 @pytest.mark.parametrize(
     "uri,expected_keys",
-    [
-        ("/api/v1/whoami", (("waffle", ("flags", "switches", "samples")),),),
-        (
-            "/api/v1/doc/en-US/Web/CSS",
-            (
-                (
-                    "documentData",
-                    (
-                        "locale",
-                        "title",
-                        "slug",
-                        "tocHTML",
-                        "bodyHTML",
-                        "id",
-                        "quickLinksHTML",
-                        "parents",
-                        "translations",
-                        "wikiURL",
-                        "summary",
-                        "language",
-                        "lastModified",
-                        "absoluteURL",
-                    ),
-                ),
-                "redirectURL",
-            ),
-        ),
-    ],
-    ids=("whoami", "doc"),
+    [["/api/v1/whoami", [("waffle", ("flags", "switches", "samples"))]]],
+    ids=("whoami",),
 )
 def test_api_basic(site_url, uri, expected_keys):
     """Basic test of site's api endpoints."""


### PR DESCRIPTION
Removes two integration tests that we missed removing in https://github.com/mdn/kuma/pull/7045, and so fixes the integration tests such that they pass again. Has already been tested against https://developer.mozilla.org.