### PR TITLE
SMTPServerDisconnected sending confirmation email

### DIFF
--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -598,7 +598,8 @@ class EmailMultiAlternativesRetrying(EmailMultiAlternatives):
         retry_options = retry_options or {
             "retry_exceptions": (SMTPServerDisconnected,),
             # The default in redo is 60 seconds. Let's tone that down.
-            "sleeptime": 3,
+            "sleeptime": 10,
+            "attempts": 10,
         }
 
         parent_method = super(EmailMultiAlternativesRetrying, self).send

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -598,7 +598,7 @@ class EmailMultiAlternativesRetrying(EmailMultiAlternatives):
         retry_options = retry_options or {
             "retry_exceptions": (SMTPServerDisconnected,),
             # The default in redo is 60 seconds. Let's tone that down.
-            "sleeptime": 10,
+            "sleeptime": 3,
             "attempts": 10,
         }
 


### PR DESCRIPTION
Fixes #6737

We actually already have retry on the welcome email. But I increased the retry'ing there a bit. 
The most important change is in the sending of verification emails. 

To test; set in your `.env` this:
```
EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
EMAIL_HOST=anything.for.testing
```
and then go to http://localhost.org:8000/en-US/users/account/email and try to trigger the sending of a verification email. It'll just sit there for ~30 seconds and eventually fail (because `anything.for.testing` won't actually work)