### PR TITLE
Create hook to fetch subscription data

### DIFF
--- a/kuma/javascript/src/hooks/useSubscriptionData.js
+++ b/kuma/javascript/src/hooks/useSubscriptionData.js
@@ -1,0 +1,34 @@
+// @flow
+import { useEffect, useState } from 'react';
+import { getSubscriptions } from '../payments/api.js';
+import { type UserData } from '../user-provider.jsx';
+
+export type SubscriptionData = {
+    id: string,
+    amount: number,
+    brand: string,
+    expires_at: string,
+    last4: string,
+    zip: string,
+    next_payment_at: string,
+};
+
+function useSubscriptionData(userData: ?UserData) {
+    const [subscription, setSubscription] = useState<?SubscriptionData>(null);
+    const [error, setError] = useState<?string>(null);
+
+    useEffect(() => {
+        if (userData && userData.isSubscriber) {
+            const handleSuccess = (data) => {
+                const [subscription] = data.subscriptions;
+                setSubscription(subscription);
+            };
+            const handleError = (error) => setError(error);
+            getSubscriptions(handleSuccess, handleError);
+        }
+    }, [userData]);
+
+    return { subscription, error };
+}
+
+export default useSubscriptionData;


### PR DESCRIPTION
Subscription data is also needed on the account settings Subscriptions component, so rather than duplicate the code, create a hook that both of them can use. The data needed is for this view:

<img width="462" alt="Screen Shot 2020-05-26 at 10 29 46 AM" src="https://user-images.githubusercontent.com/650/82913573-79e31200-9f3c-11ea-92be-8c165ccf1b6c.png">


Changes:
- Move code that fetches subscription data into a custom hook 

To test:
- Management page should work just as it used to
- Tests in `payments/pages/management.test.jsx` should still pass 

Part of #7076 