### PR TITLE
fix legacy samples files

### DIFF
--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -112,6 +112,7 @@ def test_status(client, settings, mock_status_externals):
         "ALLOWED_HOSTS": ["*"],
         "ATTACHMENT_HOST": "demos:8000",
         "ATTACHMENT_ORIGIN": "demos:8000",
+        "ATTACHMENTS_AWS_S3_CUSTOM_URL": "https://media.prod.mdn.mozit.cloud",
         "DEBUG": False,
         "INTERACTIVE_EXAMPLES_BASE": "https://interactive-examples.mdn.mozilla.net",
         "MAINTENANCE_MODE": False,

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -82,6 +82,7 @@ def status(request):
             "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
             "ATTACHMENT_HOST": settings.ATTACHMENT_HOST,
             "ATTACHMENT_ORIGIN": settings.ATTACHMENT_ORIGIN,
+            "ATTACHMENTS_AWS_S3_CUSTOM_URL": settings.ATTACHMENTS_AWS_S3_CUSTOM_URL,
             "DEBUG": settings.DEBUG,
             "INTERACTIVE_EXAMPLES_BASE": settings.INTERACTIVE_EXAMPLES_BASE,
             "MAINTENANCE_MODE": settings.MAINTENANCE_MODE,

--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from django.conf import settings
 from redirect_urls import redirect as lib_redirect
 
 from kuma.core.decorators import shared_cache_control
@@ -704,6 +705,14 @@ scl3_redirectpatterns = [
         "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
         re_flags="i",
         permanent=True,
+    ),
+    # All of the remaining "samples/" URL's are redirected to the
+    # the media domain (ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN).
+    redirect(
+        r"^samples/(?P<sample_path>.*)$",
+        f"{settings.ATTACHMENTS_AWS_S3_CUSTOM_URL}/samples/{{sample_path}}",
+        re_flags="i",
+        permanent=False,
     ),
     # Bug 887428 - Misprinted URL in promo materials
     # RewriteRule ^Firefox_OS/Security$ docs/Mozilla/Firefox_OS/Security

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -336,10 +336,6 @@ STATIC_ROOT = path("static")
 
 SERVE_MEDIA = False
 
-# Serve diagrams, presentations, and samples from 2005-2012
-SERVE_LEGACY = config("SERVE_LEGACY", default=False, cast=bool)
-LEGACY_ROOT = config("LEGACY_ROOT", default=None)
-
 # Paths that don't require a locale prefix.
 LANGUAGE_URL_IGNORED_PATHS = (
     "healthz",
@@ -1829,6 +1825,7 @@ ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN = config(
 ATTACHMENTS_AWS_S3_SECURE_URLS = config(
     "ATTACHMENTS_AWS_S3_SECURE_URLS", default=True, cast=bool
 )  # Does the custom domain use TLS
+ATTACHMENTS_AWS_S3_CUSTOM_URL = f"{'https' if ATTACHMENTS_AWS_S3_SECURE_URLS else 'http'}://{ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN}"
 
 ATTACHMENTS_AWS_S3_REGION_NAME = config(
     "ATTACHMENTS_AWS_S3_REGION_NAME", default="us-east-1"

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -5,7 +5,6 @@ from django.shortcuts import render
 from django.urls import include, re_path, reverse_lazy
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
-from django.views.static import serve
 
 from kuma.attachments import views as attachment_views
 from kuma.core import views as core_views
@@ -148,15 +147,6 @@ urlpatterns += [
     # We use our own views for setting language in cookies. But to just align with django, set it like this.
     re_path(r"^i18n/setlang/", core_views.set_language, name="set-language-cookie"),
 ]
-
-if settings.SERVE_LEGACY and settings.LEGACY_ROOT:
-    urlpatterns.append(
-        re_path(
-            r"^(?P<path>(diagrams|presentations|samples)/.+)$",
-            shared_cache_control(s_maxage=MONTH)(serve),
-            {"document_root": settings.LEGACY_ROOT},
-        )
-    )
 
 if getattr(settings, "DEBUG_TOOLBAR_INSTALLED", False):
     import debug_toolbar

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,3 +119,8 @@ def site_url(kuma_status):
 @pytest.fixture(scope="session")
 def wiki_site_url(kuma_status):
     return kuma_status["settings"]["WIKI_SITE_URL"]
+
+
+@pytest.fixture(scope="session")
+def media_url(kuma_status):
+    return kuma_status["settings"]["ATTACHMENTS_AWS_S3_CUSTOM_URL"]

--- a/tests/headless/map_301.py
+++ b/tests/headless/map_301.py
@@ -517,6 +517,13 @@ MOZILLADEMOS_URLS = list(
     )
 )
 
+# These are the remaining "samples/*" URL's, the ones that haven't been redirected
+# by any of the special cases, which we expect to be redirected to the media CDN.
+DEFAULT_SAMPLES_URLS = [
+    url_test("/samples/cssref/background.html", status_code=302,),
+    url_test("/samples/html/progress.html", status_code=302,),
+]
+
 # Converted from SCL3 Apache files - MindTouch / old hosted files
 LEGACY_URLS = list(
     flatten(

--- a/tests/headless/test_redirects.py
+++ b/tests/headless/test_redirects.py
@@ -3,6 +3,7 @@ import pytest
 from utils.urls import assert_valid_url
 
 from .map_301 import (
+    DEFAULT_SAMPLES_URLS,
     GITHUB_IO_URLS,
     LEGACY_URLS,
     MARIONETTE_URLS,
@@ -45,6 +46,20 @@ def test_github_redirects(url, base_url):
 def test_mozillademos_redirects(url, base_url):
     url["base_url"] = base_url
     assert_valid_url(**url)
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+@pytest.mark.parametrize(
+    "url", DEFAULT_SAMPLES_URLS, ids=[item["url"] for item in DEFAULT_SAMPLES_URLS]
+)
+def test_default_samples_redirects(url, base_url, media_url):
+    url["base_url"] = base_url
+    url["location"] = f"{media_url}{url['url']}"
+    assert_valid_url(**url)
+    print(url["url"])
+    print(url["location"])
+    assert False
 
 
 @pytest.mark.headless


### PR DESCRIPTION
This PR updates the way we handle "legacy" files, all of the really old, rarely accessed files under `/diagrams/*`, `/presentations/*`, and `/samples/*`. However, this PR is really the second step.

The first step, which is already in place, is that all of the files under `/diagrams/*`, `/presentations/*`, and `/samples/*` have been moved to the stage and production media S3 buckets and made available via `https://media.prod.mdn.mozit.cloud` and `https://media.stage.mdn.mozit.cloud`, but the files are exactly the same between stage and production, and always will be since the legacy files are frozen. Also, we've added two new behaviors to the primary stage and production CDN's that serve traffic intended for `/diagrams/*` and `/presentations/*` directly from the appropriate S3 bucket. **You will notice that there is no CDN behavior for `/samples/*`.** This is because many of the `/samples/*` URL's are redirected by Django -- some to specific documents, some to `http://mdn.github.io`, and some to specific file attachments at `https://mdn.mozillademos.org/files/*` -- so all of the traffic for `/samples/*` has to first be routed to Django and then redirected from there.

So now that this first step is understood, we can better talk about what this PR does. It basically does three things:
- Adds a catch-all redirect for `/samples/*`, after all of the previous special cases, that simply redirects to `https://media.prod.mdn.mozit.cloud/samples/*`. I think it's fine to always redirect to the production media domain for samples because they are frozen, and will always be the same between stage and production, so there's no need to distinguish between the stage and production media domains. This is already how the special-case samples redirects work, for example `/samples/canvas-tutorial/images/backdrop.png` always redirects to `https://mdn.mozillademos.org/files/5395/backdrop.png`, which is the production domain (the stage domain is `https://files-stage.mdn.mozit.cloud/files/5395/backdrop.png`).
- Removes the code related to serving legacy files, since Django does not do that any longer.
- Adds a few new headless integration tests.