### PR TITLE
Fix styling and position of previous and next buttons

### DIFF
--- a/kuma/static/styles/base/_icons.scss
+++ b/kuma/static/styles/base/_icons.scss
@@ -59,6 +59,14 @@ label #{$selector-icon}:first-child {
 
 /* icons used by PreviousMenuNext macro */
 .prevnext {
+    $arrow-icon-width: 20px;
+
+    // svg has 5px of whitespace around the arrow, so we have to offset the
+    // arrow's position to get the content truly centered within the button
+    $arrow-icon-offset: 5px;
+
+    // spacing between text and arrow
+    $arrow-icon-spacing: 5px;
     .icon-arrow-left {
         @include set-icon('../arrows/arrow-left.svg');
         vertical-align: sub;

--- a/kuma/static/styles/components/home/_base.scss
+++ b/kuma/static/styles/components/home/_base.scss
@@ -37,10 +37,3 @@
         }
     }
 }
-
-/* right to left */
-html[dir='rtl'] #home {
-    .icon-arrow-right:before {
-        content: '\f060';
-    }
-}

--- a/kuma/static/styles/components/wiki/_customcss.scss
+++ b/kuma/static/styles/components/wiki/_customcss.scss
@@ -10,7 +10,7 @@ In a perfect world we go through the contents of this file and integrate it with
 eventually emptying this file.
 
 ********************************************************************** */
-
+@import '../../minimalist/vars/vars-color-palette.scss';
 
 .prevnext {
     @include restrict-line-length();


### PR DESCRIPTION
**Desktop changes**
<img width="883" alt="desktop-changes" src="https://user-images.githubusercontent.com/650/83200201-d434cc00-a110-11ea-8b0f-45eff4df352b.png">

**Mobile changes**
<img width="881" alt="mobile-changes" src="https://user-images.githubusercontent.com/650/83200308-09d9b500-a111-11ea-998a-6affcde19898.png">


To test: 
Visit http://localhost.org:8000/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website and use prev and next buttons at top

Closes #6913 