### PR TITLE
add ability to save/serve sitemaps to/from S3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ATTACHMENTS_USE_S3=${ATTACHMENTS_USE_S3:-True}
       - ATTACHMENTS_AWS_ACCESS_KEY_ID=${ATTACHMENTS_AWS_ACCESS_KEY_ID:-minio}
       - ATTACHMENTS_AWS_SECRET_ACCESS_KEY=${ATTACHMENTS_AWS_SECRET_ACCESS_KEY:-minio123}
-      - ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN=${ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN:-localhost:9000/mdn-attachments}
+      - ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN=${ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN:-localhost:9000/media}
       - ATTACHMENTS_AWS_S3_SECURE_URLS=${ATTACHMENTS_AWS_S3_SECURE_URLS:-False}
       - ATTACHMENTS_AWS_S3_ENDPOINT_URL=${ATTACHMENTS_AWS_S3_ENDPOINT_URL:-http://minio:9000}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
@@ -41,6 +41,7 @@ services:
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
       - SITE_URL=${SITE_URL:-http://localhost:8000}
+      - SITEMAP_USE_S3=${SITEMAP_USE_S3:-True}
       - STATIC_URL=${STATIC_URL:-http://localhost:8000/static/}
       - WAFFLE_COOKIE_SECURE=False
       # Other environment overrides
@@ -144,7 +145,7 @@ services:
     environment:
       MC_HOST_minio: "http://${MINIO_ACCESS_KEY:-minio}:${MINIO_SECRET_KEY:-minio123}@minio:9000"
     entrypoint: ""
-    command: /bin/sh -c "for BUCKET in 'test' 'mdn-attachments'; do mc mb -p minio/$$BUCKET && mc policy set download minio/$$BUCKET; done"
+    command: /bin/sh -c "for BUCKET in 'test' 'media'; do mc mb -p minio/$$BUCKET && mc policy set download minio/$$BUCKET; done"
 
   mockga:
     build:

--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -12,6 +12,7 @@ from waffle.testutils import override_flag
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.constants import REDIRECT_CONTENT
 from kuma.wiki.models import Document, Revision
+from kuma.wiki.tasks import sitemap_storage as real_sitemap_storage
 
 
 @pytest.fixture(autouse=True)
@@ -235,3 +236,12 @@ def redirect_doc(wiki_user, root_doc):
 def mock_requests():
     with requests_mock.Mocker() as mocker:
         yield mocker
+
+
+@pytest.fixture
+def sitemap_storage(settings):
+    """A well-behaved sitemap_storage that cleans-up before and after itself."""
+    settings.ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN = "localhost:9000/test"
+    real_sitemap_storage.s3_clear()
+    yield real_sitemap_storage
+    real_sitemap_storage.s3_clear()

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1885,4 +1885,4 @@ STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
 SENDINBLUE_API_KEY = config("SENDINBLUE_API_KEY", default=None)
 SENDINBLUE_LIST_ID = config("SENDINBLUE_LIST_ID", default=None)
 
-SITEMAP_USE_S3 = config("SITEMAP_USE_S3", cast=bool, default=False)
+SITEMAP_USE_S3 = config("SITEMAP_USE_S3", cast=bool, default=True)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1827,7 +1827,7 @@ ATTACHMENTS_AWS_SECRET_ACCESS_KEY = config(
     "ATTACHMENTS_AWS_SECRET_ACCESS_KEY", default=None
 )
 ATTACHMENTS_AWS_STORAGE_BUCKET_NAME = config(
-    "ATTACHMENTS_AWS_STORAGE_BUCKET_NAME", default="mdn-attachments"
+    "ATTACHMENTS_AWS_STORAGE_BUCKET_NAME", default="media"
 )
 
 ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN = config(
@@ -1884,3 +1884,5 @@ STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
 # into lists of paying and not paying users
 SENDINBLUE_API_KEY = config("SENDINBLUE_API_KEY", default=None)
 SENDINBLUE_LIST_ID = config("SENDINBLUE_LIST_ID", default=None)
+
+SITEMAP_USE_S3 = config("SITEMAP_USE_S3", cast=bool, default=False)

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -22,7 +22,7 @@ from kuma.search.urls import (
     lang_urlpatterns as search_lang_urlpatterns,
 )
 from kuma.users.urls import lang_urlpatterns as users_lang_urlpatterns
-from kuma.views import serve_from_media_root
+from kuma.views import serve_sitemap
 from kuma.wiki.admin import purge_view
 from kuma.wiki.urls import lang_urlpatterns as wiki_lang_urlpatterns
 from kuma.wiki.views.document import as_json as document_as_json
@@ -139,10 +139,8 @@ urlpatterns += [
     re_path("^api/", include("kuma.api.urls")),
     re_path("", include("kuma.version.urls")),
     # Serve sitemap files.
-    re_path(
-        r"^sitemap.xml$", serve_from_media_root, {"path": "sitemap.xml"}, name="sitemap"
-    ),
-    re_path(r"^(?P<path>sitemaps/.+)$", serve_from_media_root, name="sitemaps"),
+    re_path(r"^sitemap.xml$", serve_sitemap, {"path": "sitemap.xml"}, name="sitemap"),
+    re_path(r"^(?P<path>sitemaps/.+)$", serve_sitemap, name="sitemaps"),
     re_path(r"^humans.txt$", core_views.humans_txt, name="humans_txt"),
     re_path(
         r"^miel$",

--- a/kuma/views.py
+++ b/kuma/views.py
@@ -1,14 +1,30 @@
 from django.conf import settings
+from django.http import HttpResponse
 from django.views.decorators.http import require_safe
 from django.views.static import serve
 
 from kuma.core.decorators import shared_cache_control
+from kuma.wiki.tasks import sitemap_storage
 
 
 @shared_cache_control(s_maxage=60 * 60)
 @require_safe
-def serve_from_media_root(request, path):
+def serve_sitemap(request, path):
     """
-    A convenience view for serving files from the media root directory.
+    A convenience view for serving sitemap files.
+
+    NOTE: This will only be used for local development. For the stage
+          and production sites, all of the sitemap requests will be
+          served from S3 via the CDN.
+
+    TODO: After we're using S3 in both stage and production for the
+          sitemap files, settings.SITEMAP_USE_S3 will always be true
+          (it could be removed) and this function collapses to just
+          that case, and will only be used for local development.
     """
+    if settings.SITEMAP_USE_S3:
+        with sitemap_storage.open(path, "rb") as sitemap_file:
+            return HttpResponse(
+                sitemap_file.read(), content_type="application/xml; charset=utf-8"
+            )
     return serve(request, path, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This PR provides and enables the ability to save the sitemap files to S3. When enabled, it also serves the sitemap files from S3, but for stage and production, those requests will never reach Django but instead be routed (by the primary CDN) directly to S3. This is the last step in eliminating our reliance on EFS. Here are the steps forward regarding EFS:
- [x] review this PR
- [x] test on stage
- [x] merge this PR
- [ ] create and merge an https://github.com/mdn/infra PR that removes EFS from our K8s resources

This is related to our work on https://github.com/mdn/kuma/issues/7034 because that effort to move to EKS was intended to not only reduce the cluster-management burden but also to eliminate the common problem of "stuck" cluster nodes, which we've discovered to be related to our use of EFS.