### PR TITLE
Add contributions linkto usernav

### DIFF
--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -37,6 +37,7 @@ export default function Login(): React.Node {
             </>
         );
         let viewProfileLink = `/${locale}/profiles/${userData.username}`;
+        let contributionsLink = `/${locale}/dashboards/revisions?user=${userData.username}`;
         let editProfileLink = `${viewProfileLink}/edit`;
 
         return (
@@ -47,6 +48,11 @@ export default function Login(): React.Node {
                     right={true}
                     hideArrow={true}
                 >
+                    <li>
+                        <a href={contributionsLink}>
+                            {gettext('Contributions')}
+                        </a>
+                    </li>
                     <li>
                         <a href={viewProfileLink}>{gettext('View profile')}</a>
                     </li>


### PR DESCRIPTION
"It will be simple they said..." 😄 

So, adding the link to the usernav is indeed simple, quick, and easy. But...

The page this links to is `http://wiki.localhost.org:8000/en-US/dashboards/revisions?user=username` - Note that `wiki` portion.

This page does not use the new header and as such, all links will from hereon out keep you on the wiki. This is probably not what we want.

What we probably want to do is to update the template this page uses to use the new header but, do we also want to prevent this from going to the `wiki.` domain? Is there a different option here?

Would love your thoughts @peterbe and @atopal 

/cc @tobinmori 

fix #7077