### PR TITLE
tell google translate to avoid pre tags

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -193,6 +193,7 @@ def clean_content(content):
     parsed.injectSectionIDs()
     if not settings.ALLOW_ALL_IFRAMES:
         parsed.filterIframeHosts(settings.ALLOWED_IFRAME_PATTERNS)
+    parsed.annotatePreTags()
     return parsed.serialize()
 
 
@@ -365,6 +366,11 @@ class ContentSectionTool(object):
     @newrelic.agent.function_trace()
     def annotateLinks(self, base_url):
         self.stream = LinkAnnotationFilter(self.stream, base_url)
+        return self
+
+    @newrelic.agent.function_trace()
+    def annotatePreTags(self):
+        self.stream = PreNotranslateClassFilter(self.stream)
         return self
 
     @newrelic.agent.function_trace()
@@ -553,6 +559,27 @@ class LinkAnnotationFilter(html5lib_Filter):
 
                         add_to_attr("class", links[href]["classes"])
                         add_to_attr("rel", links[href]["rel"])
+
+                token["data"] = attrs
+
+            yield token
+
+
+class PreNotranslateClassFilter(html5lib_Filter):
+    """
+    Filter which annotates <pre> tags with the 'notranslate' class.
+    """
+
+    def __iter__(self):
+        input = html5lib_Filter.__iter__(self)
+        for token in input:
+            if token["type"] == "StartTag" and token["name"] == "pre":
+                attrs = dict(token["data"]) or {(None, "class"): ""}
+                for (namespace, name), value in attrs.copy().items():
+                    if name == "class" and "notranslate" not in value:
+                        before = attrs.get((namespace, "class")) or ""
+                        after = f"{before} notranslate".strip()
+                        attrs[(namespace, "class")] = after
 
                 token["data"] = attrs
 

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -576,7 +576,7 @@ class PreNotranslateClassFilter(html5lib_Filter):
             if token["type"] == "StartTag" and token["name"] == "pre":
                 attrs = dict(token["data"]) or {(None, "class"): ""}
                 for (namespace, name), value in attrs.copy().items():
-                    if name == "class" and "notranslate" not in value.lower().split():
+                    if name == "class" and "notranslate" not in value.split():
                         before = attrs.get((namespace, "class")) or ""
                         after = f"{before} notranslate".strip()
                         attrs[(namespace, "class")] = after

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -576,7 +576,7 @@ class PreNotranslateClassFilter(html5lib_Filter):
             if token["type"] == "StartTag" and token["name"] == "pre":
                 attrs = dict(token["data"]) or {(None, "class"): ""}
                 for (namespace, name), value in attrs.copy().items():
-                    if name == "class" and "notranslate" not in value:
+                    if name == "class" and "notranslate" not in value.lower().split():
                         before = attrs.get((namespace, "class")) or ""
                         after = f"{before} notranslate".strip()
                         attrs[(namespace, "class")] = after

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1015,7 +1015,7 @@ def test_annotate_links_external_link():
         ],
         [
             '<pre class="NOTranslate">h1 { color:brown }</pre>',
-            '<pre class="NOTranslate">h1 { color:brown }</pre>',
+            '<pre class="NOTranslate notranslate">h1 { color:brown }</pre>',
         ],
         # Present as a string but not really right
         [

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -994,6 +994,35 @@ def test_annotate_links_external_link():
     assert normalize_html(actual_raw) == expected
 
 
+@pytest.mark.parametrize(
+    "code",
+    (
+        # Simple existing class value
+        [
+            '<pre class="syntaxbox">h1 { color:brown }</pre>',
+            '<pre class="syntaxbox notranslate">h1 { color:brown }</pre>',
+        ],
+        # No class attribute at all
+        [
+            "<pre>h1 { color:pink }</pre>",
+            '<pre class="notranslate">h1 { color:pink }</pre>',
+        ],
+        # 'notranslate' already set
+        [
+            '<pre class="notranslate brush:js">h1 { color:brown }</pre>',
+            # Note, no difference!
+            '<pre class="notranslate brush:js">h1 { color:brown }</pre>',
+        ],
+    ),
+)
+def test_annotate_pre_tags(code):
+    """pre tags should get a 'notranslate' class added"""
+    html, expected_html = code
+    actual_raw = parse(html).annotatePreTags().serialize()
+    expected = normalize_html(expected_html)
+    assert normalize_html(actual_raw) == expected
+
+
 class FilterEditorSafetyTests(TestCase):
     def test_editor_safety_filter(self):
         """Markup that's hazardous for editing should be stripped"""

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1013,7 +1013,17 @@ def test_annotate_links_external_link():
             # Note, no difference!
             '<pre class="notranslate brush:js">h1 { color:brown }</pre>',
         ],
+        [
+            '<pre class="NOTranslate">h1 { color:brown }</pre>',
+            '<pre class="NOTranslate">h1 { color:brown }</pre>',
+        ],
+        # Present as a string but not really right
+        [
+            '<pre class="syntaxbox">h1 { color:brown }</pre>',
+            '<pre class="syntaxbox notranslate">h1 { color:brown }</pre>',
+        ],
     ),
+    ids=("simple", "empty", "already", "already-case-insensitive", "tricky"),
 )
 def test_annotate_pre_tags(code):
     """pre tags should get a 'notranslate' class added"""

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -359,7 +359,7 @@ class RevisionFormEditTests(RevisionFormViewTests):
             " specifies the type of rendering box used for an element.</p>\n"
             "<p>{{cssinfo}}</p>\n"
             '<h2 id="Syntax">Syntax</h2>\n'
-            '<pre class="brush:css">'
+            '<pre class="brush:css notranslate">'
             "display: none;\n"
             "</pre>"
         ),
@@ -377,7 +377,7 @@ class RevisionFormEditTests(RevisionFormViewTests):
             "<p>{{cssinfo}} and my changes.</p>\n"
             '<h2 id="Syntax">Syntax</h2>\n'
             '<p><a href="http://spam.example.com">Buy my product!</a></p>\n'
-            '<pre class="brush:css">display: none;</pre>\n'
+            '<pre class="brush:css notranslate">display: none;</pre>\n'
         ),
         "comment": "Comment",
         "days": "0",
@@ -447,7 +447,7 @@ class RevisionFormEditTests(RevisionFormViewTests):
         expected_content = (
             "<p>{{cssinfo}} and my changes.</p>\n"
             '<p><a href="http://spam.example.com">Buy my product!</a></p>\n'
-            '<pre class="brush:css">display: none;</pre>\n'
+            '<pre class="brush:css notranslate">display: none;</pre>\n'
             "Comment"
         )
         assert parameters["comment_content"] == expected_content
@@ -476,7 +476,7 @@ class RevisionFormEditTests(RevisionFormViewTests):
         expected_content = (
             "<p>{{cssinfo}} and my changes.</p>\n"
             '<p><a href="http://spam.example.com">Buy my product!</a></p>\n'
-            '<pre class="brush:css">display: none;</pre>\n'
+            '<pre class="brush:css notranslate">display: none;</pre>\n'
             "Comment\n"
             "CSS Positioning"
         )
@@ -507,7 +507,7 @@ class RevisionFormEditTests(RevisionFormViewTests):
         expected_content = (
             "The CSS property display\n" + "<p>{{cssinfo}} and my changes.</p>\n"
             '<p><a href="http://spam.example.com">Buy my product!</a></p>\n'
-            '<pre class="brush:css">display: none;</pre>\n'
+            '<pre class="brush:css notranslate">display: none;</pre>\n'
             "Updated\n"
             "CSS display, hidden"
         )
@@ -528,7 +528,7 @@ class RevisionFormEditTests(RevisionFormViewTests):
         expected_content = (
             "<p>{{cssinfo}} and my changes.</p>\n"
             '<p><a href="http://spam.example.com">Buy my product!</a></p>\n'
-            '<pre class="brush:css">display: none;</pre>\n'
+            '<pre class="brush:css notranslate">display: none;</pre>\n'
             "Comment\n"
             "CSS\n"
             "CSS Property\n"


### PR DESCRIPTION
Fixes #7101

I've tested this quite extensively using the Chrome extension and using https://translate.google.com and it works. Very satisfying. 
But what to be tested is the HTML our Python code produces. You can either sacrifice one of your Wiki docs in your docker-compose and just paste HTML snippets into it and hit save and see what it produces. Basically, these:
```html
<pre>something</pre>
<pre class="syntaxbox">something</pre>
```
...should become:
```html
<pre class="notranslate>something</pre>
<pre class="syntaxbox notranslate">something</pre>
```
Arguably, you can't argue with the unit test I wrote :)

What's important to observe is if the `pre` tags still look right. I.e. this new class doesn't interfere with Prism. 