### PR TITLE
Clash between soapbox and new mobile header

### DIFF
--- a/kuma/static/styles/components/structure/_global-notice.scss
+++ b/kuma/static/styles/components/structure/_global-notice.scss
@@ -6,6 +6,7 @@ global notices (via soapbox)
     position: relative;
     margin: 0 0 -1px;
     background: $light-background-color;
+    z-index: 9;
 
     .wrap {
         @include set-smaller-font-size();

--- a/kuma/static/styles/minimalist/components/_search-widget.scss
+++ b/kuma/static/styles/minimalist/components/_search-widget.scss
@@ -107,7 +107,7 @@
     }
 
     &.show-form {
-        position: fixed;
+        position: absolute;
         right: 0;
         z-index: 1;
 
@@ -125,8 +125,6 @@
         }
 
         .toggle-form {
-            top: 0;
-
             .close-icon {
                 transform: translateY(0);
             }


### PR DESCRIPTION
This solves the clash we had between the soapbox message and the new header on mobile. This works predictably with the soapbox on, and off.

@peterbe r?

fix #7219