### PR TITLE
right current url in report a content problem

### DIFF
--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -329,7 +329,7 @@ exports[`Header snapshot 1`] = `
             role="menuitem"
           >
             <a
-              href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&projects=mdn/sprints/2&labels=user-report&title=%2Fen-US"
+              href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&projects=mdn/sprints/2&labels=user-report&title=http://localhost/[fake%20absolute%20url]"
               onClick={[Function]}
               onContextMenu={[Function]}
               rel="noopener noreferrer"

--- a/kuma/javascript/src/header/header.jsx
+++ b/kuma/javascript/src/header/header.jsx
@@ -26,7 +26,7 @@ export default function Header(props: Props): React.Node {
             >
                 <Logo />
             </a>
-            <MainMenu document={props.document} locale={locale} />
+            <MainMenu documentData={props.document} locale={locale} />
             <Search initialQuery={props.searchQuery || ''} />
             <Login />
         </header>

--- a/kuma/javascript/src/header/main-menu.jsx
+++ b/kuma/javascript/src/header/main-menu.jsx
@@ -8,7 +8,7 @@ import { gettext } from '../l10n.js';
 import type { DocumentData } from '../document.jsx';
 
 type Props = {
-    documentData?: ?DocumentData,
+    documentData: ?DocumentData,
     locale: string,
 };
 
@@ -191,9 +191,12 @@ const _MainMenu = ({ documentData, locale }: Props) => {
 
     // One of the menu items has a URL that we need to substitute
     // the current document path into. Compute that now.
-    let path = encodeURIComponent(
-        `/${locale}` + (documentData ? `/docs/${documentData.slug}` : '')
+    const [currentAbsoluteUrl, setCurrentAbsoluteUrl] = useState(
+        documentData ? documentData.absoluteURL : ''
     );
+    useEffect(() => {
+        setCurrentAbsoluteUrl(window.location.href);
+    }, []);
 
     return (
         <nav className="main-nav" aria-label="Main menu">
@@ -248,7 +251,7 @@ const _MainMenu = ({ documentData, locale }: Props) => {
                                             rel="noopener noreferrer"
                                             href={item.url.replace(
                                                 '{{PATH}}',
-                                                path
+                                                currentAbsoluteUrl
                                             )}
                                             onClick={sendMenuItemInteraction}
                                             onContextMenu={

--- a/kuma/javascript/src/header/main-menu.jsx
+++ b/kuma/javascript/src/header/main-menu.jsx
@@ -190,7 +190,9 @@ const _MainMenu = ({ documentData, locale }: Props) => {
     );
 
     // One of the menu items has a URL that we need to substitute
-    // the current document path into. Compute that now.
+    // the current document path into. Compute that now, if possible.
+    // In SPAs (e.g. the home page) there is no `documentData` but the
+    // useEffect below will take care of it anyway.
     const [currentAbsoluteUrl, setCurrentAbsoluteUrl] = useState(
         documentData ? documentData.absoluteURL : ''
     );

--- a/kuma/wiki/templatetags/ssr.py
+++ b/kuma/wiki/templatetags/ssr.py
@@ -41,7 +41,6 @@ def render_react(component_name, locale, url, document_data, ssr=True):
         "url": url,
         "documentData": document_data,
     }
-    print("IN render_react:", repr(url))
     if ssr:
         return server_side_render(component_name, data)
     else:

--- a/kuma/wiki/templatetags/ssr.py
+++ b/kuma/wiki/templatetags/ssr.py
@@ -41,7 +41,7 @@ def render_react(component_name, locale, url, document_data, ssr=True):
         "url": url,
         "documentData": document_data,
     }
-
+    print("IN render_react:", repr(url))
     if ssr:
         return server_side_render(component_name, data)
     else:


### PR DESCRIPTION
Fixes #7235

[@Gregoor is right](https://github.com/mdn/kuma/issues/7235#issuecomment-645530001). We can use a `useEffect` to override whatever happens on the server. 
It occurred to me that this value doesn't actually have to be correct in the server. Because it only ever purposes of that link to click it. 