### PR TITLE
Sendinblue unsubscribe webhook

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -310,7 +310,7 @@ If you're using Stripe in testing mode you can also get test numbers from this s
 https://stripe.com/docs/testing#cards
 
 Testing Stripe's hooks locally requires setting up a tunneling service, like ngrok (https://ngrok.com).
-You should then set ``STRIPE_WEBHOOK_HOSTNAME`` to the hostname you get from your tunneling service, e.g. for
+You should then set ``CUSTOM_WEBHOOK_HOSTNAME`` to the hostname you get from your tunneling service, e.g. for
 ngrok it might be https://203ebfab.ngrok.io
 After kuma has started you will have a webhook configured in stripe. You can view it on Stripe's dashboard:
 https://dashboard.stripe.com/test/webhooks

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -633,7 +633,7 @@ def test_sendinblue_unsubscribe(mock_check_sendinblue, client):
 
     email = "testuser@example.com"
 
-    create_user(
+    user = create_user(
         save=True, username="testuser", email=email, is_newsletter_subscribed=True,
     )
 
@@ -644,4 +644,5 @@ def test_sendinblue_unsubscribe(mock_check_sendinblue, client):
     )
     assert response.status_code == 200
 
-    assert not User.objects.get(email=email).is_newsletter_subscribed
+    user.refresh_from_db()
+    assert not user.is_newsletter_subscribed

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
-
 from django.conf import settings
 from django.core import mail
 from django.test import Client
@@ -20,7 +19,7 @@ from kuma.core.ga_tracking import (
 from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.search.tests import ElasticTestCase
-from kuma.users.models import User, UserSubscription
+from kuma.users.models import UserSubscription
 from kuma.users.tests import create_user
 from kuma.wiki.models import BCSignal
 

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -21,7 +21,7 @@ from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.search.tests import ElasticTestCase
 from kuma.users.models import User, UserSubscription
-from kuma.users.tests import user
+from kuma.users.tests import create_user
 from kuma.wiki.models import BCSignal
 
 
@@ -483,7 +483,7 @@ def test_stripe_payment_succeeded_sends_invoice_mail(
     }
     download_url.return_value = bytes("totally not a pdf", "utf-8")
 
-    testuser = user(
+    testuser = create_user(
         save=True,
         username="testuser",
         email="testuser@example.com",
@@ -512,7 +512,7 @@ def test_stripe_subscription_canceled(mock1, client):
         ),
     )
 
-    testuser = user(
+    testuser = create_user(
         save=True,
         username="testuser",
         email="testuser@example.com",
@@ -579,7 +579,7 @@ def test_stripe_payment_succeeded_sends_ga_tracking(
             )
         ),
     )
-    user(
+    create_user(
         save=True,
         username="testuser",
         email="testuser@example.com",
@@ -610,7 +610,7 @@ def test_stripe_subscription_canceled_sends_ga_tracking(
         ),
     )
 
-    user(
+    create_user(
         save=True,
         username="testuser",
         email="testuser@example.com",
@@ -633,7 +633,7 @@ def test_sendinblue_unsubscribe(mock_check_sendinblue, client):
 
     email = "testuser@example.com"
 
-    user(
+    create_user(
         save=True, username="testuser", email=email, is_newsletter_subscribed=True,
     )
 

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -634,10 +634,7 @@ def test_sendinblue_unsubscribe(mock_check_sendinblue, client):
     email = "testuser@example.com"
 
     user(
-        save=True,
-        username="testuser",
-        email=email,
-        is_newsletter_subscribed=True,
+        save=True, username="testuser", email=email, is_newsletter_subscribed=True,
     )
 
     response = client.post(

--- a/kuma/api/v1/urls.py
+++ b/kuma/api/v1/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     ),
     path("subscriptions/", views.subscriptions, name="api.v1.subscriptions"),
     path("stripe_hooks/", views.stripe_hooks, name="api.v1.stripe_hooks"),
+    path("sendinblue_hooks/", views.sendinblue_hooks, name="api.v1.sendinblue_hooks"),
 ]

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -295,10 +295,17 @@ def sendinblue_hooks(request):
     # are different from the Stripe ones, in that they treat the event as a notification
     # of a _potential_ change, while still needing to contact sendinblue to verify that
     # it actually happened.
-    event = json.loads(request.body)
+    try:
+        payload = json.loads(request.body)
+        event = payload["event"]
+        email = payload["email"]
+    except (json.decoder.JSONDecodeError, KeyError) as exception:
+        return HttpResponseBadRequest(
+            f"{exception.__class__.__name__} on {request.body}"
+        )
 
-    if event["event"] == "unsubscribe":
-        refresh_is_user_newsletter_subscribed(event["email"])
+    if event == "unsubscribe":
+        refresh_is_user_newsletter_subscribed(email)
         return HttpResponse()
     else:
         return HttpResponseBadRequest(

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -45,6 +45,7 @@ from kuma.search.filters import (
 )
 from kuma.search.search import SearchView
 from kuma.users.models import User, UserSubscription
+from kuma.users.newsletter.utils import refresh_is_user_newsletter_subscribed
 from kuma.users.stripe_utils import (
     cancel_stripe_customer_subscriptions,
     create_stripe_customer_and_subscription_for_user,
@@ -284,3 +285,22 @@ def _download_from_url(url):
     pdf_download = requests_retry_session().get(url)
     pdf_download.raise_for_status()
     return pdf_download.content
+
+
+@csrf_exempt
+@require_POST
+@never_cache
+def sendinblue_hooks(request):
+    # Sendinblue does not sign its webhook requests, hence the event handlers following
+    # are different from the Stripe ones, in that they treat the event as a notification
+    # of a _potential_ change, while still needing to contact sendinblue to verify that
+    # it actually happened.
+    event = json.loads(request.body)
+
+    if event["event"] == "unsubscribe":
+        refresh_is_user_newsletter_subscribed(event["email"])
+        return HttpResponse()
+    else:
+        return HttpResponseBadRequest(
+            f"We did not expect a Sendinblue webhook of type {event['event']!r}"
+        )

--- a/kuma/attachments/tests/test_models.py
+++ b/kuma/attachments/tests/test_models.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db.utils import IntegrityError
 
-from kuma.users.tests import user, UserTestCase
+from kuma.users.tests import create_user, UserTestCase
 from kuma.wiki.models import DocumentAttachment
 from kuma.wiki.tests import document
 
@@ -146,42 +146,42 @@ class AttachmentModelTests(UserTestCase):
         g2.save()
 
         # User with no explicit permission is allowed
-        u2 = user(username="test_user2", save=True)
+        u2 = create_user(username="test_user2", save=True)
         self.assertTrue(allow_add_attachment_by(u2))
 
         # User in group with negative permission is disallowed
-        u3 = user(username="test_user3", save=True)
+        u3 = create_user(username="test_user3", save=True)
         u3.groups.set([g1])
         u3.save()
         self.assertTrue(not allow_add_attachment_by(u3))
 
         # Superusers can do anything, despite group perms
-        u1 = user(username="test_super", is_superuser=True, save=True)
+        u1 = create_user(username="test_super", is_superuser=True, save=True)
         u1.groups.set([g1])
         u1.save()
         self.assertTrue(allow_add_attachment_by(u1))
 
         # User with negative permission is disallowed
-        u4 = user(username="test_user4", save=True)
+        u4 = create_user(username="test_user4", save=True)
         u4.user_permissions.add(p1)
         u4.save()
         self.assertTrue(not allow_add_attachment_by(u4))
 
         # User with positive permission overrides group
-        u5 = user(username="test_user5", save=True)
+        u5 = create_user(username="test_user5", save=True)
         u5.groups.set([g1])
         u5.user_permissions.add(p2)
         u5.save()
         self.assertTrue(allow_add_attachment_by(u5))
 
         # Group with positive permission takes priority
-        u6 = user(username="test_user6", save=True)
+        u6 = create_user(username="test_user6", save=True)
         u6.groups.set([g1, g2])
         u6.save()
         self.assertTrue(allow_add_attachment_by(u6))
 
         # positive permission takes priority, period.
-        u7 = user(username="test_user7", save=True)
+        u7 = create_user(username="test_user7", save=True)
         u7.user_permissions.add(p1)
         u7.user_permissions.add(p2)
         u7.save()

--- a/kuma/authkeys/tests/conftest.py
+++ b/kuma/authkeys/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kuma.users.tests import user
+from kuma.users.tests import create_user
 
 from ..models import Key
 
@@ -14,7 +14,7 @@ class Object(object):
 @pytest.fixture
 @pytest.mark.django_db
 def user_auth_key():
-    u = user(username="test23", email="test23@example.com", save=True)
+    u = create_user(username="test23", email="test23@example.com", save=True)
     key = Key(user=u)
     secret = key.generate_secret()
     key.save()

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -26,7 +26,9 @@ class KeyViewsTest(RefetchingUserTestCase):
         password = "trustno1"
         email = "tester23@example.com"
 
-        self.user = create_user(username=username, email=email, password=password, save=True)
+        self.user = create_user(
+            username=username, email=email, password=password, save=True
+        )
         self.client.login(username=username, password=password)
 
         # Give self.user (tester23) keys permissions
@@ -169,7 +171,9 @@ class KeyViewsPermissionTest(RefetchingUserTestCase):
         password = "trustno1"
         email = "tester23@example.com"
 
-        self.user = create_user(username=username, email=email, password=password, save=True)
+        self.user = create_user(
+            username=username, email=email, password=password, save=True
+        )
         self.client.login(username=username, password=password)
 
     def test_new_key_requires_permission(self):

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -7,7 +7,7 @@ from pyquery import PyQuery as pq
 
 from kuma.core.tests import assert_no_cache_header, assert_redirect_to_wiki
 from kuma.core.urlresolvers import reverse
-from kuma.users.tests import user
+from kuma.users.tests import create_user
 
 from ..models import Key
 from ..views import ITEMS_PER_PAGE
@@ -26,7 +26,7 @@ class KeyViewsTest(RefetchingUserTestCase):
         password = "trustno1"
         email = "tester23@example.com"
 
-        self.user = user(username=username, email=email, password=password, save=True)
+        self.user = create_user(username=username, email=email, password=password, save=True)
         self.client.login(username=username, password=password)
 
         # Give self.user (tester23) keys permissions
@@ -41,7 +41,7 @@ class KeyViewsTest(RefetchingUserTestCase):
         password2 = "somepass"
         email2 = "someone@example.com"
 
-        self.user2 = user(
+        self.user2 = create_user(
             username=username2, email=email2, password=password2, save=True
         )
 
@@ -169,7 +169,7 @@ class KeyViewsPermissionTest(RefetchingUserTestCase):
         password = "trustno1"
         email = "tester23@example.com"
 
-        self.user = user(username=username, email=email, password=password, save=True)
+        self.user = create_user(username=username, email=email, password=password, save=True)
         self.client.login(username=username, password=password)
 
     def test_new_key_requires_permission(self):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1884,7 +1884,7 @@ INDEX_CSS_CLASSNAMES = config("INDEX_CSS_CLASSNAMES", cast=bool, default=not DEB
 
 # For local development you might want to set this to a hostname provided to
 # you by a tunneling service such as ngrok.
-STRIPE_WEBHOOK_HOSTNAME = config("STRIPE_WEBHOOK_HOSTNAME", default=None)
+CUSTOM_WEBHOOK_HOSTNAME = config("CUSTOM_WEBHOOK_HOSTNAME", default=None)
 
 # We use sendinblue.com to send marketing emails and are subdividing users
 # into lists of paying and not paying users

--- a/kuma/users/newsletter/checks.py
+++ b/kuma/users/newsletter/checks.py
@@ -1,21 +1,21 @@
 from django.conf import settings
 from django.core.checks import Error
 
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.templatetags.jinja_helpers import absolutify
+
 from . import sendinblue
 
-SENDINBLUE_ERROR = "kuma.users.sendinblue.E001"
+SENDINBLUE_API_ERROR = "kuma.users.sendinblue.E001"
 
 
-def sendinblue_check(app_configs, **kwargs):
-    if not settings.SENDINBLUE_API_KEY:
-        return []
-
+def create_sendinblue_attributes():
     response = sendinblue.request("GET", "contacts/attributes")
     if not response.ok:
         return [
             Error(
                 f"Error getting sendinblue attributes: {response.status_code}",
-                id=SENDINBLUE_ERROR,
+                id=SENDINBLUE_API_ERROR,
             )
         ]
 
@@ -29,8 +29,62 @@ def sendinblue_check(app_configs, **kwargs):
             return [
                 Error(
                     f"Error when creating sendinblue attribute: {response.json()['message']}",
-                    id=SENDINBLUE_ERROR,
+                    id=SENDINBLUE_API_ERROR,
                 )
             ]
 
     return []
+
+
+# We're using sendinblue for marketing emails. Another possible use-case is "transactional"
+# But as we're not using it that way, we don't have to check for that.
+EMAIL_TYPE = "marketing"
+
+
+def create_sendinblue_unsubscribe_webhook():
+    url_path = reverse("api.v1.sendinblue_hooks")
+    url = (
+        "https://" + settings.CUSTOM_WEBHOOK_HOSTNAME + url_path
+        if settings.CUSTOM_WEBHOOK_HOSTNAME
+        else absolutify(url_path)
+    )
+
+    # From https://developers.sendinblue.com/reference#createwebhook
+    # "Occurs whenever a user unsubscribes through an email's subscription management link."
+    events = ("unsubscribed",)
+
+    response = sendinblue.request("GET", "webhooks", params={"type": EMAIL_TYPE})
+
+    no_webhooks_found = response.status_code == 404
+    if not response.ok and not no_webhooks_found:
+        return [
+            Error(
+                f"Error getting sendinblue webhooks: {response.status_code}",
+                id=SENDINBLUE_API_ERROR,
+            )
+        ]
+
+    if not no_webhooks_found:
+        for webhook in response.json()["webhooks"]:
+            if webhook["url"] == url and set(events) == set(webhook["events"]):
+                return []
+
+    response = sendinblue.request(
+        "POST", "webhooks", json={"url": url, "events": events, "type": EMAIL_TYPE}
+    )
+    if not response.ok:
+        return [
+            Error(
+                f"Error creating sendinblue webhook: {response.status_code}",
+                id=SENDINBLUE_API_ERROR,
+            )
+        ]
+
+    return []
+
+
+def sendinblue_check(app_configs, **kwargs):
+    if not settings.SENDINBLUE_API_KEY:
+        return []
+
+    return create_sendinblue_attributes() + create_sendinblue_unsubscribe_webhook()

--- a/kuma/users/newsletter/utils.py
+++ b/kuma/users/newsletter/utils.py
@@ -1,0 +1,23 @@
+from urllib.parse import quote
+
+from django.conf import settings
+
+from kuma.users.models import User
+
+from . import sendinblue
+
+
+def check_is_in_sendinblue_list(email):
+    response = sendinblue.request("GET", f"contacts/email/{quote(email)}")
+    if response.ok:
+        return settings.SENDINBLUE_LIST_ID in response.json()["listIds"]
+    elif response.status_code == 404:
+        return False
+    else:
+        response.raise_for_status()
+
+
+def refresh_is_user_newsletter_subscribed(email):
+    User.objects.filter(email=email).update(
+        is_newsletter_subscribed=check_is_in_sendinblue_list(email)
+    )

--- a/kuma/users/stripe_utils.py
+++ b/kuma/users/stripe_utils.py
@@ -138,8 +138,8 @@ def get_stripe_subscription_info(stripe_customer):
 def create_missing_stripe_webhook():
     url_path = reverse("api.v1.stripe_hooks")
     url = (
-        "https://" + settings.STRIPE_WEBHOOK_HOSTNAME + url_path
-        if settings.STRIPE_WEBHOOK_HOSTNAME
+        "https://" + settings.CUSTOM_WEBHOOK_HOSTNAME + url_path
+        if settings.CUSTOM_WEBHOOK_HOSTNAME
         else absolutify(url_path)
     )
 

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -31,7 +31,7 @@ class UserTestCase(UserTestMixin, KumaTestCase):
     pass
 
 
-def user(save=False, **kwargs):
+def create_user(save=False, **kwargs):
     if "username" not in kwargs:
         kwargs["username"] = get_random_string(length=15)
     password = kwargs.pop("password", "password")

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -7,7 +7,7 @@ from django.test import RequestFactory
 
 from kuma.core.tests import call_on_commit_immediately, KumaTestCase
 
-from . import user
+from . import create_user
 from ..adapters import KumaAccountAdapter, USERNAME_CHARACTERS, USERNAME_EMAIL
 from ..forms import UserEditForm, UserRecoveryEmailForm
 from ..models import User
@@ -16,7 +16,7 @@ from ..models import User
 class TestUserEditForm(KumaTestCase):
     def test_username(self):
         """bug 753563: Support username changes"""
-        test_user = user(save=True)
+        test_user = create_user(save=True)
         data = {
             "username": test_user.username,
         }
@@ -24,19 +24,19 @@ class TestUserEditForm(KumaTestCase):
         assert form.is_valid()
 
         # let's try this with the username above
-        test_user2 = user(save=True)
+        test_user2 = create_user(save=True)
         form = UserEditForm(data, instance=test_user2)
         assert not form.is_valid()
 
     def test_can_keep_legacy_username(self):
-        test_user = user(username="legacy@example.com", save=True)
+        test_user = create_user(username="legacy@example.com", save=True)
         assert test_user.has_legacy_username
         data = {"username": "legacy@example.com"}
         form = UserEditForm(data, instance=test_user)
         assert form.is_valid(), repr(form.errors)
 
     def test_cannot_change_legacy_username(self):
-        test_user = user(username="legacy@example.com", save=True)
+        test_user = create_user(username="legacy@example.com", save=True)
         assert test_user.has_legacy_username
         data = {"username": "mr.legacy@example.com"}
         form = UserEditForm(data, instance=test_user)
@@ -44,7 +44,7 @@ class TestUserEditForm(KumaTestCase):
         assert {"username": [USERNAME_CHARACTERS]} == form.errors
 
     def test_cannot_change_to_legacy_username(self):
-        test_user = user(save=True)
+        test_user = create_user(save=True)
         assert not test_user.has_legacy_username
         data = {"username": "mr.legacy@example.com"}
         form = UserEditForm(data, instance=test_user)
@@ -52,7 +52,7 @@ class TestUserEditForm(KumaTestCase):
         assert {"username": [USERNAME_CHARACTERS]} == form.errors
 
     def test_blank_username_invalid(self):
-        test_user = user(save=True)
+        test_user = create_user(save=True)
         data = {
             "username": "",
         }
@@ -93,7 +93,7 @@ class TestUserEditForm(KumaTestCase):
         self._assert_protos_and_sites(protos, sites)
 
     def _assert_protos_and_sites(self, protos, sites):
-        edit_user = user(save=True)
+        edit_user = create_user(save=True)
         for proto, expected_valid in protos:
             for name, site in sites:
                 url = "%s%s" % (proto, site)

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -11,12 +11,12 @@ from kuma.core.tests import assert_no_cache_header, call_on_commit_immediately
 from kuma.core.urlresolvers import reverse
 from kuma.users.tasks import send_recovery_email, send_welcome_email
 
-from . import user, UserTestCase
+from . import create_user, UserTestCase
 
 
 class SendRecoveryEmailTests(TestCase):
     def test_send_email(self):
-        testuser = user(username="legacy", email="legacy@example.com")
+        testuser = create_user(username="legacy", email="legacy@example.com")
         testuser.set_unusable_password()
         testuser.save()
         send_recovery_email(testuser.pk, email="actual@example.com")
@@ -64,7 +64,7 @@ class TestWelcomeEmails(UserTestCase):
     @override_switch("welcome_email", True)
     @call_on_commit_immediately
     def test_welcome_mail_for_verified_email(self):
-        testuser = user(
+        testuser = create_user(
             username="welcome",
             email="welcome@tester.com",
             password="welcome",
@@ -93,7 +93,7 @@ class TestWelcomeEmails(UserTestCase):
     @override_switch("welcome_email", True)
     @call_on_commit_immediately
     def test_welcome_mail_for_unverified_email(self):
-        testuser = user(
+        testuser = create_user(
             username="welcome2",
             email="welcome2@tester.com",
             password="welcome2",

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -47,7 +47,7 @@ from kuma.wiki.models import (
 from kuma.wiki.templatetags.jinja_helpers import absolutify
 from kuma.wiki.tests import document as create_document
 
-from . import SampleRevisionsMixin, SocialTestMixin, user, UserTestCase
+from . import create_user, SampleRevisionsMixin, SocialTestMixin, UserTestCase
 from ..models import User, UserBan, UserSubscription
 from ..views import delete_document, revert_document
 
@@ -1423,7 +1423,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
 
     def test_account_tokens(self):
         testemail = "account_token@acme.com"
-        testuser = user(
+        testuser = create_user(
             username="user", is_active=True, email=testemail, password="test", save=True
         )
         EmailAddress.objects.create(
@@ -1451,7 +1451,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         """
         # Setup a user with a token and refresh token
         testemail = "account_token@acme.com"
-        testuser = user(
+        testuser = create_user(
             username="user", is_active=True, email=testemail, password="test", save=True
         )
         EmailAddress.objects.create(
@@ -1539,7 +1539,7 @@ class KumaGoogleTests(UserTestCase, SocialTestMixin):
         whose email address, when `email.split('@')[0]` would become the same
         as the existing GitHub user.
         """
-        user(username="octocat", save=True)
+        create_user(username="octocat", save=True)
         self.google_login(
             profile_data=dict(self.google_profile_data, email="octocat@gmail.com",)
         )
@@ -1553,7 +1553,7 @@ class KumaGoogleTests(UserTestCase, SocialTestMixin):
         Tests that GA tracking events are sent for errors in the username
         field submitted when signing-up with a new account.
         """
-        user(username="octocat", save=True)
+        create_user(username="octocat", save=True)
         with self.settings(
             GOOGLE_ANALYTICS_ACCOUNT="UA-XXXX-1",
             GOOGLE_ANALYTICS_TRACKING_RAISE_ERRORS=True,


### PR DESCRIPTION
Fixes #7171 

## What it does
- renames `STRIPE_WEBHOOK_HOSTNAME` to `CUSTOM_WEBHOOK_HOSTNAME`, to make it reusable with other webhooks
- adds a system check which creates a sendinblue webhook, listening to the `unsubscribe` event (analogous to what we did for Stripe)
- adds an associated view route for handling the webhook
  - it differs from stripe in that sendinblue doesn't offer signing of the events, so we only interpret the hook being (correctly) called as a nudge, which we then use to contact sendinblue and check whether something did change
  - currently we only do that for checking whether a given email is still in the system (and in the correct sendinblue list) and then set the associated user's `is_newsletter_subscribed` toggle accordingly

## How to test it
- start ngrok (proxiying to whatever port you run kuma on)
- add your custom hostname to your .env (`CUSTOM_WEBHOOK_HOSTNAME`)
- start kuma
- 🔍 after it says something like "system checks found no problems", check https://my.sendinblue.com/advanced/webhook whether a new webhook was created (assuming you've already configured sendinblue)

and then
- have a user in your db with `is_newsletter_subscribed` set to **true** and their email to `example@example.com`
  - you can set the former through the UI, but doing the latter through the UI will lead to that email being in sendinblue, which defeats the purpose of what you're about to test (the webhook event will lead to a refresh, which finds a user still in the system, hence no change)
- go back to https://my.sendinblue.com/advanced/webhook, click Actions and then "send a test"
- 🔎 check your DB / user profile whether the user is now marked as not subscribed