### PR TITLE
fix(compat‑tables): Update platform borders and merge selector lists

### DIFF
--- a/kuma/static/styles/components/compat-tables/_bc-table.scss
+++ b/kuma/static/styles/components/compat-tables/_bc-table.scss
@@ -82,13 +82,23 @@ table.bc-table {
 }
 
 /* thicker border between platforms */
+$bc-table-border-selectors: ();
+
 @each $type, $config in $table-types {
     @each $border in map-get($config, platform-border) {
-        .bc-table-#{$type} th:nth-child(#{$border}),
-        .bc-table-#{$type} td:nth-child(#{$border}) {
-            border-left: $bc-border-width-thick solid $bc-border-color;
-        }
+        $bc-table-border-selectors: join(
+            $bc-table-border-selectors,
+            (
+                '.bc-table-#{$type} th:nth-child(#{$border})',
+                '.bc-table-#{$type} td:nth-child(#{$border})',
+            ),
+            $separator: comma,
+        );
     }
+}
+
+#{$bc-table-border-selectors} {
+    border-left: $bc-border-width-thick solid $bc-border-color;
 }
 
 /* th
@@ -289,13 +299,8 @@ mobile display
     }
 
     /* thicker border between platforms */
-    @each $type, $config in $table-types {
-        @each $border in map-get($config, platform-border) {
-            .bc-table-#{$type} th:nth-child(#{$border}),
-            .bc-table-#{$type} td:nth-child(#{$border}) {
-                border-top: $bc-border-width-thick solid $bc-border-color;
-                border-left: none;
-            }
-        }
+    #{$bc-table-border-selectors} {
+        border-top: $bc-border-width-thick solid $bc-border-color;
+        border-left: none;
     }
 }

--- a/kuma/static/styles/components/compat-tables/_vars.scss
+++ b/kuma/static/styles/components/compat-tables/_vars.scss
@@ -50,11 +50,11 @@ $table-types: (
 	js: (
 		size: 13,
 		feature-name-width: 200px,
-		platform-border: (8, 15)
+		platform-border: (8, 14)
 	),
 	ext: (
 		size: 5,
 		feature-name-width: 300px,
-		platform-border: (6)
+		platform-border: (7)
 	)
 );


### PR DESCRIPTION
The **JavaScript** platform borders became outdated when **IE Mobile** was removed, and the **WebExtension** platform borders became outdated when **Safari 14** added support for **WebExtensions**.

I also merged the selector lists of the border declarations.

---

Fixes <https://github.com/mdn/kuma/issues/7274>