### PR TITLE
user_details v1 api

### DIFF
--- a/kuma/api/v1/serializers.py
+++ b/kuma/api/v1/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import exceptions
 from rest_framework import serializers
 
+from kuma.users.models import User
 from kuma.wiki.models import BCSignal, Document
 
 
@@ -26,3 +27,9 @@ class BCSignalSerializer(serializers.Serializer):
         if document:
             return BCSignal.objects.create(document=document, **validated_data)
         raise exceptions.ValidationError("Document not found")
+
+
+class UserDetailsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("username", "fullname", "is_newsletter_subscribed", "locale")

--- a/kuma/api/v1/urls.py
+++ b/kuma/api/v1/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     ),
     path("subscriptions/", views.subscriptions, name="api.v1.subscriptions"),
     path("stripe_hooks/", views.stripe_hooks, name="api.v1.stripe_hooks"),
+    path("user_details/", views.user_details, name="api.v1.user_details"),
 ]

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -47,11 +47,8 @@ from kuma.search.filters import (
 )
 from kuma.search.search import SearchView
 from kuma.users.models import User, UserSubscription
-<<<<<<< HEAD
-from kuma.users.signals import newsletter_subscribed, newsletter_unsubscribed
-=======
 from kuma.users.newsletter.utils import refresh_is_user_newsletter_subscribed
->>>>>>> master
+from kuma.users.signals import newsletter_subscribed, newsletter_unsubscribed
 from kuma.users.stripe_utils import (
     cancel_stripe_customer_subscriptions,
     create_stripe_customer_and_subscription_for_user,

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -19,13 +19,15 @@ from ratelimit.decorators import ratelimit
 from raven.contrib.django.models import client as raven_client
 from rest_framework import serializers, status
 from rest_framework.decorators import api_view
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from waffle import flag_is_active
 from waffle.decorators import waffle_flag
 from waffle.models import Flag, Sample, Switch
 
-from kuma.api.v1.serializers import BCSignalSerializer
+from kuma.api.v1.serializers import BCSignalSerializer, UserDetailsSerializer
 from kuma.core.email_utils import render_email
 from kuma.core.ga_tracking import (
     ACTION_SUBSCRIPTION_CANCELED,
@@ -45,6 +47,7 @@ from kuma.search.filters import (
 )
 from kuma.search.search import SearchView
 from kuma.users.models import User, UserSubscription
+from kuma.users.signals import newsletter_subscribed, newsletter_unsubscribed
 from kuma.users.stripe_utils import (
     cancel_stripe_customer_subscriptions,
     create_stripe_customer_and_subscription_for_user,
@@ -284,3 +287,33 @@ def _download_from_url(url):
     pdf_download = requests_retry_session().get(url)
     pdf_download.raise_for_status()
     return pdf_download.content
+
+
+class APIUserDetailsView(APIView):
+    http_method_names = ["get", "put"]
+    serializer_class = UserDetailsSerializer
+    renderer_classes = [JSONRenderer]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, format=None):
+        assert request.user.is_authenticated
+        serializer = UserDetailsSerializer(request.user, many=False)
+        return Response(serializer.data)
+
+    def put(self, request, format=None):
+        user = request.user
+        serializer = UserDetailsSerializer(instance=user, data=request.data)
+        if serializer.is_valid():
+            was_subscribed = user.is_newsletter_subscribed
+            serializer.save(user=user)
+
+            if not was_subscribed and user.is_newsletter_subscribed:
+                newsletter_subscribed.send(None, user=user)
+            if was_subscribed and not user.is_newsletter_subscribed:
+                newsletter_unsubscribed.send(None, user=user)
+
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+user_details = never_cache(APIUserDetailsView.as_view())


### PR DESCRIPTION
Fixes #7246

Hopefully the "unit tests" speak for themselves. But what I did, to sanity check that it would work was this quick hack to user-details.jsx:

```diff
diff --git a/kuma/javascript/src/accountsettings/components/user-details.jsx b/kuma/javascript/src/accountsettings/components/user-details.jsx
index 72309db8a..1b5a908e8 100644
--- a/kuma/javascript/src/accountsettings/components/user-details.jsx
+++ b/kuma/javascript/src/accountsettings/components/user-details.jsx
@@ -1,7 +1,9 @@
 // @flow
 import * as React from 'react';
+import { useEffect } from 'react';
 
 import { gettext } from '../../l10n.js';
+import { getCookie } from '../../utils';
 import LanguageSelect from './language-select.jsx';
 
 type Props = {
@@ -13,6 +15,32 @@ type Props = {
 const UserDetails = ({ locale, userData, sortedLanguages }: Props) => {
     const { email, username } = userData;
 
+    useEffect(() => {
+        let dismounted = false;
+        fetch('/api/v1/user_details/')
+            .then((response) => response.json())
+            .then((data) => {
+                console.log('DATA:', data);
+                // data['fullname'] += ' new';
+                fetch('/api/v1/user_details/', {
+                    method: 'PUT',
+                    body: JSON.stringify(data),
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken'),
+                        'Content-Type': 'application/json',
+                    },
+                })
+                    .then((response) => response.json())
+                    .then((r) => {
+                        console.log('PUTTED:', r);
+                    });
+            });
+
+        return () => {
+            dismounted = true;
+        };
+    }, []);
+
     return (
         <form
             name="user-details"
```

And it works. I don't think you need to apply that diff but if you skim it you can see what's possible and to be done in the React world once this endpoint is in place. 