### PR TITLE
next_url jinja helper to respect ADDITIONAL_NEXT_URL_ALLOWED_HOSTS

### DIFF
--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -62,6 +62,19 @@ def next_url(request):
     def inner():
         if hasattr(request, "path"):
             if request.GET.get("next"):
+                # Make a special exception for 'next' URLs that are absolute but
+                # who's host is in a known list.
+                if (
+                    "://" in request.GET["next"]
+                    and settings.DEBUG
+                    and settings.ADDITIONAL_NEXT_URL_ALLOWED_HOSTS
+                    and settings.ADDITIONAL_NEXT_URL_ALLOWED_HOSTS
+                    in request.GET["next"]
+                ):
+                    # The reason we don't need to make a much more elaborate
+                    # comparison of the host and the 'ADDITIONAL_NEXT_URL_ALLOWED_HOSTS'
+                    # setting is because this will only ever happen in DEBUG anyway.
+                    return request.GET["next"]
                 if "://" not in request.GET["next"]:
                     return request.GET["next"]
             elif reverse(settings.LOGIN_URL) != request.get_full_path():


### PR DESCRIPTION
(Not tying this to an issue because it's not production-important enough and it's a change that confidently only matters for local development for select few)

Easy to test:

1. Go to http://localhost.org:8000/en-US/users/account/signup-landing?next=http%3A%2F%2Flocalhost.org%3A3000%2F
2. Note that when you hover over GitHub and Google (inside the Sign-in box on the left) that the `?next=...` link is gone

Now, add `ADDITIONAL_NEXT_URL_ALLOWED_HOSTS=localhost.org:3000` to your `.env` and stop/start `docker-compose`. And check out the branch too (obviously 😉)

Now you'll get links like: http://localhost.org:8000/users/github/login/?next=http%3A%2F%2Flocalhost.org%3A3000%2F 

PS. Make sure that links like http://localhost.org:8000/en-US/users/account/signup-landing?next=/en-US/docs/Web/JavaScript still work. 
And make sure that http://localhost.org:8000/en-US/users/account/signup-landing?next=http%3A%2F%2Fsomeotherdomain.org%3A3000%2F "doesn't". 