### PR TITLE
search input broken due to main menu focus management

### DIFF
--- a/kuma/javascript/src/header/main-menu.jsx
+++ b/kuma/javascript/src/header/main-menu.jsx
@@ -39,9 +39,6 @@ const _MainMenu = ({ documentData, locale }: Props) => {
 
     function hideSubMenuIfVisible() {
         if (showSubMenu) {
-            if (previousActiveElementRef.current) {
-                previousActiveElementRef.current.focus();
-            }
             setShowSubMenu(false);
         }
     }
@@ -81,6 +78,9 @@ const _MainMenu = ({ documentData, locale }: Props) => {
         document.addEventListener('keyup', (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 hideSubMenuIfVisible();
+                if (previousActiveElementRef.current) {
+                    previousActiveElementRef.current.focus();
+                }
             }
         });
 


### PR DESCRIPTION
Only restore focus to the previous active element when a user
is using the keyboard as method of input.

fix #7423