### PR TITLE
Fix search widget's border being cut off by input white background

### DIFF
--- a/kuma/static/styles/minimalist/components/_search-widget.scss
+++ b/kuma/static/styles/minimalist/components/_search-widget.scss
@@ -64,6 +64,7 @@
         color: $text-color;
         border-width: 0;
         min-width: 60px;
+        background: transparent;
 
         &:focus,
         &:invalid {


### PR DESCRIPTION
# Current visual

Tested on Chromium 84.0.4147.135 (Official Build) Arch Linux (64-bit)

![20200825195208](https://user-images.githubusercontent.com/62244135/91235769-a1e53b80-e70c-11ea-971f-d3f4328c1d28.png)

(notice the border)

# The fix

This PR changes the search widget's input background to transparent, but it's safe because the parent `.header-search form` has a `#fff` background as well.