### PR TITLE
run js lints when yarn.lock gets upgraded

### DIFF
--- a/.github/workflows/js-lints.yml
+++ b/.github/workflows/js-lints.yml
@@ -21,6 +21,9 @@ jobs:
             .jsx
             .scss
           PREFIX_FILTER: kuma
+          FILES: |
+            package.json
+            yarn.lock
 
       - name: Setup Node.js environment
         if: steps.git_diff_content.outputs.diff


### PR DESCRIPTION
If a PR comes in that edits any `kuma/**/*.(js|jsx|scss)` the "JavaScript and SASS Lints" workflow kicks in. 
But if Dependabot upgrades something like `prettier` or `eslint` in the `yarn.lock` we wouldn't notice if our code is compatible with this. This change hopefully fixes it. 

I learned about this technique here: https://github.com/technote-space/get-diff-action/issues/111#issuecomment-681387855