### PR TITLE
Add GA to browser compat CTA

### DIFF
--- a/kuma/javascript/src/active-banner.jsx
+++ b/kuma/javascript/src/active-banner.jsx
@@ -194,6 +194,8 @@ export const DEVELOPER_NEEDS_ID = 'developer_needs';
 export const SUBSCRIPTION_ID = 'subscription_banner';
 
 function MDNBrowserCompatReportBanner() {
+    const ga = useContext(GAProvider.context);
+
     return (
         <Banner
             id={MDN_BROWSER_COMPAT_REPORT_ID}
@@ -216,6 +218,14 @@ function MDNBrowserCompatReportBanner() {
             url={
                 'https://mdn-web-dna.s3-us-west-2.amazonaws.com/MDN-Browser-Compatibility-Report-2020.pdf'
             }
+            onCTAClick={() => {
+                ga('send', {
+                    hitType: 'event',
+                    eventCategory: MDN_BROWSER_COMPAT_REPORT_ID,
+                    eventAction: 'Browser Compat Report CTA clicked',
+                    eventLabel: 'banner',
+                });
+            }}
             newWindow
         />
     );

--- a/kuma/javascript/src/active-banner.jsx
+++ b/kuma/javascript/src/active-banner.jsx
@@ -222,7 +222,7 @@ function MDNBrowserCompatReportBanner() {
                 ga('send', {
                     hitType: 'event',
                     eventCategory: MDN_BROWSER_COMPAT_REPORT_ID,
-                    eventAction: 'Browser Compat Report CTA clicked',
+                    eventAction: 'Browser Compat Report 2020 CTA clicked',
                     eventLabel: 'banner',
                 });
             }}


### PR DESCRIPTION
This adds a call to GA when CTA button to download the report PDF is clicked. Confirmed with GA testing that the following will be sent on click:

```
Running command: ga("send", {hitType: "event", eventCategory: "mdn_browser_compat_report", eventAction: "Browser Compat Report CTA clicked", eventLabel: "banner"})
```

@peterbe r?

fix #7516 