### PR TITLE
menu not usable on mobile

### DIFF
--- a/kuma/static/styles/minimalist/components/_main-nav.scss
+++ b/kuma/static/styles/minimalist/components/_main-nav.scss
@@ -1,6 +1,6 @@
 @import '../vars/vars-color-palette';
 
-$menu-zindex: 100;
+$menu-zindex: 500;
 $menu-box-shadow: 0 2px 8px 0 $neutral-400;
 $menu-border: solid 1px $neutral-400;
 $menu-border-radius: 4px;


### PR DESCRIPTION
Fix `z-index` for menu on mobile to ensure it is infront of page overlay

fix #7534