### PR TITLE
Disable the payments endpoint

### DIFF
--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -17,6 +17,15 @@ def test_payments_index(client, settings):
 
 
 @pytest.mark.django_db
+def test_payments_index_disabled(client, settings):
+    """Viewing the payments index page doesn't require you to be logged in.
+    Payments page shows support email and header."""
+    settings.ENABLE_SUBSCRIPTIONS = False
+    response = client.get(reverse("payments_index"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_payments_url_fixes(client):
     """These tests just make sure that the use of trailing slashes are correct."""
     url = reverse("payments_index")

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.conf import settings
+from django.http import Http404
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from waffle.decorators import waffle_flag
@@ -12,6 +14,8 @@ log = logging.getLogger("kuma.payments.views")
 
 @never_cache
 def index(request):
+    if not settings.ENABLE_SUBSCRIPTIONS:
+        raise Http404("Not enabled")
     highest_subscriber_number = User.get_highest_subscriber_number()
     context = {"next_subscriber_number": highest_subscriber_number + 1}
     return render(request, "payments/index.html", context)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1908,3 +1908,9 @@ SITEMAP_USE_S3 = config("SITEMAP_USE_S3", cast=bool, default=True)
 ADDITIONAL_NEXT_URL_ALLOWED_HOSTS = config(
     "ADDITIONAL_NEXT_URL_ALLOWED_HOSTS", default=None
 )
+
+# As of Oct 2020, we might not enable subscriptions at all. There are certain
+# elements of Kuma that exposes subscriptions even if all the Waffle flags and
+# switches says otherwise. For example, the payments pages are skeletons for
+# React apps. This boolean settings disables all of that.
+ENABLE_SUBSCRIPTIONS = config("ENABLE_SUBSCRIPTIONS", cast=bool, default=False)

--- a/kuma/settings/pytest.py
+++ b/kuma/settings/pytest.py
@@ -105,3 +105,7 @@ CONTRIBUTION_AMOUNT_USD = 4.99
 
 SENDINBLUE_API_KEY = "testing"
 SENDINBLUE_LIST_ID = 7327
+
+# This is False by default, to so we don't have to rewrite all the existing
+# tests, it's True in this context.
+ENABLE_SUBSCRIPTIONS = True


### PR DESCRIPTION
Fixes #7537

Pardon the intrusion @escattone but I think this is a much simpler solution. Basically, a rock-solid simple Django setting that, by default, disables subscriptions. Combined with waffle flags, all traffic to anything "payments" will 404. And this way the tests don't have to change. 