### PR TITLE
fix: remove icon from help MDN

### DIFF
--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -117,7 +117,7 @@
     </div>
     <div class="column-involved">
       <!-- contributions section -->
-      <h2>{% include 'includes/icons/emojis/smile.svg' %} {{ _('Help improve MDN') }}</h2>
+      <h2>{{ _('Help improve MDN') }}</h2>
       <p>{{ _('All parts of MDN (docs and the site itself) are created by an open community of developers. Please join us! Pick one of these ways to help:') }}</p>
       <ul>
         <li><a href="{{ wiki_url('MDN/Getting_started') }}">{{ _('Getting started') }}</a></li>

--- a/kuma/landing/jinja2/landing/react_homepage.html
+++ b/kuma/landing/jinja2/landing/react_homepage.html
@@ -102,7 +102,7 @@
       </div>
       <div class="column-involved">
         <!-- contributions section -->
-        <h2>{% include 'includes/icons/emojis/smile.svg' %} {{ _('Help improve MDN') }}</h2>
+        <h2>{{ _('Help improve MDN') }}</h2>
         <p>{{ _('All parts of MDN (docs and the site itself) are created by an open community of developers. Please join us! Pick one of these ways to help:') }}</p>
         <ul>
           <li><a href="{{ wiki_url('MDN/Getting_started') }}">{{ _('Getting started') }}</a></li>


### PR DESCRIPTION
Remove the smiley icon next to "Help improve MDN" on the homepage

fix #7642 