### PR TITLE
fix: profile view - submenu obscured

### DIFF
--- a/kuma/static/styles/components/users/_user-head.scss
+++ b/kuma/static/styles/components/users/_user-head.scss
@@ -1,7 +1,6 @@
 .user-head {
     background: $light-background-color;
     margin-bottom: $grid-spacing;
-    overflow: hidden;
     padding: $grid-spacing;
     position: relative;
 }


### PR DESCRIPTION
Ensure submenu is fully visible on view profile page

### Before

![Screenshot 2020-12-07 at 14 03 36](https://user-images.githubusercontent.com/10350960/101349163-95d55200-3895-11eb-9a27-7669faf900ae.png)


### After

![Screenshot 2020-12-07 at 14 04 30](https://user-images.githubusercontent.com/10350960/101349169-9968d900-3895-11eb-98b9-9576030ddcb2.png)


fix #7620