### PR TITLE
change language cookie to match yari

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -310,9 +310,10 @@ MT_TO_KUMA_LOCALE_MAP = {
     "fa": "fa",
 }
 
+LANGUAGE_COOKIE_NAME = "preferredlocale"
 LANGUAGE_COOKIE_DOMAIN = DOMAIN
 # The number of seconds we are keeping the language preference cookie. (1 year)
-LANGUAGE_COOKIE_AGE = 365 * 24 * 60 * 60
+LANGUAGE_COOKIE_AGE = 3 * 365 * 24 * 60 * 60
 
 SITE_ID = config("SITE_ID", default=1, cast=int)
 


### PR DESCRIPTION
Change the language cookie name that we respect in Kuma to match what we use in Yari (`preferredlocale`), and also change the language cookie expiration period to match Yari as well (3 years). This PR allows locale-less URLs not handled by Yari's Lambda@Edge function, to be handled the same way when they hit Django. So this would cover requests like `/search`, `/profile`, `/profiles/...`, `/users/...`, `/account`, and `/events`, redirecting them by first trying the `preferredlocale` language cookie, then the `accept-language` header, and finally falling back to `en-US`.

This PR fills in the missing pieces from https://github.com/mdn/yari/issues/1889. 