### PR TITLE
use Django default cookie domain so it matches Yari

### DIFF
--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -41,6 +41,7 @@ def set_language(request):
             max_age=settings.LANGUAGE_COOKIE_AGE,
             path=settings.LANGUAGE_COOKIE_PATH,
             domain=settings.LANGUAGE_COOKIE_DOMAIN,
+            secure=settings.LANGUAGE_COOKIE_SECURE,
         )
 
     return response

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -311,7 +311,6 @@ MT_TO_KUMA_LOCALE_MAP = {
 }
 
 LANGUAGE_COOKIE_NAME = "preferredlocale"
-LANGUAGE_COOKIE_DOMAIN = DOMAIN
 # The number of seconds we are keeping the language preference cookie. (1 year)
 LANGUAGE_COOKIE_AGE = 3 * 365 * 24 * 60 * 60
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -311,8 +311,9 @@ MT_TO_KUMA_LOCALE_MAP = {
 }
 
 LANGUAGE_COOKIE_NAME = "preferredlocale"
-# The number of seconds we are keeping the language preference cookie. (1 year)
+# The number of seconds we are keeping the language preference cookie. (3 years)
 LANGUAGE_COOKIE_AGE = 3 * 365 * 24 * 60 * 60
+LANGUAGE_COOKIE_SECURE = "localhost" not in DOMAIN
 
 SITE_ID = config("SITE_ID", default=1, cast=int)
 

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -481,6 +481,7 @@ def user_edit(request, username):
                     max_age=settings.LANGUAGE_COOKIE_AGE,
                     path=settings.LANGUAGE_COOKIE_PATH,
                     domain=settings.LANGUAGE_COOKIE_DOMAIN,
+                    secure=settings.LANGUAGE_COOKIE_SECURE,
                 )
             return response
 


### PR DESCRIPTION
If we just go with Django's default `LANGUAGE_COOKIE_DOMAIN` (which is `None`) we match the behavior of Yari (i.e., the current domain is specified as the cookie's domain, without any leading `.`).