### PR TITLE
MDN front page "Help improve MDN" links need updating

### DIFF
--- a/kuma/landing/jinja2/landing/react_homepage.html
+++ b/kuma/landing/jinja2/landing/react_homepage.html
@@ -106,10 +106,8 @@
         <p>{{ _('All parts of MDN (docs and the site itself) are created by an open community of developers. Please join us! Pick one of these ways to help:') }}</p>
         <ul>
           <li><a href="{{ wiki_url('MDN/Getting_started') }}">{{ _('Getting started') }}</a></li>
-          <li><a href="{{ wiki_url('MDN/Contribute/Howto/Do_an_editorial_review') }}">{{ _('Editorial review') }}</a></li>
-          <li><a href="{{ wiki_url('MDN/Contribute/Howto/Do_a_technical_review') }}">{{ _('Technical review') }}</a></li>
-          <li><a href="{{ wiki_url('MDN/Contribute/Localize/Translating_pages') }}">{{ _('Translating') }}</a></li>
-          <li><a href="https://github.com/mdn/kuma#readme">{{ _('Contributing to the MDN codebase') }}</a></li>
+          <li><a href="{{ wiki_url('MDN/Contribute') }}">{{ _('Contributing to MDN content') }}</a></li>
+          <li><a href="https://github.com/mdn/yari#readme">{{ _('Contributing to the MDN codebase') }}</a></li>
           <li><a href="https://github.com/mdn/browser-compat-data">{{ _('Updating browser compatibility data') }}</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Fixes #7683

I copied the renderd HTML with the Devtools and it becomes this:
```html

          <li><a href="/en-US/docs/MDN/Getting_started">Getting started</a></li>
          <li><a href="/en-US/docs/MDN/Contribute">Contributing to MDN content</a></li>
          <li><a href="https://github.com/mdn/yari#readme">Contributing to the MDN codebase</a></li>
          <li><a href="https://github.com/mdn/browser-compat-data">Updating browser compatibility data</a></li>
        
```

Looks like this:
<img width="540" alt="Screen Shot 2020-12-16 at 1 25 13 PM" src="https://user-images.githubusercontent.com/26739/102390492-767baa80-3fa2-11eb-9d60-b7384656c5bd.png">
