### PR TITLE
longer caching on file attachments

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -309,7 +309,10 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     response = client.get(url, HTTP_HOST="testserver")
     assert response.status_code == 301
     assert "public" in response["Cache-Control"]
-    assert "max-age=900" in response["Cache-Control"]
+    assert (
+        f"max-age={settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE}"
+        in response["Cache-Control"]
+    )
     assert response["Location"] == url
     assert "Vary" not in response
 
@@ -333,7 +336,10 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert response["x-frame-options"] == f"ALLOW-FROM {settings.DOMAIN}"
     assert response["Last-Modified"] == convert_to_http_date(created)
     assert "public" in response["Cache-Control"]
-    assert "max-age=900" in response["Cache-Control"]
+    assert (
+        f"max-age={settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE}"
+        in response["Cache-Control"]
+    )
 
 
 def test_raw_file_if_modified_since(client, settings, file_attachment):
@@ -351,7 +357,10 @@ def test_raw_file_if_modified_since(client, settings, file_attachment):
     assert response.status_code == 304
     assert response["Last-Modified"] == convert_to_http_date(created)
     assert "public" in response["Cache-Control"]
-    assert "max-age=900" in response["Cache-Control"]
+    assert (
+        f"max-age={settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE}"
+        in response["Cache-Control"]
+    )
 
 
 def test_edit_attachment_redirect(client, root_doc):

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -36,7 +36,7 @@ def guess_extension(_type):
     return OVERRIDE_MIMETYPES.get(_type, mimetypes.guess_extension(_type))
 
 
-@cache_control(public=True, max_age=60 * 15)
+@cache_control(public=True, max_age=settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE)
 def raw_file(request, attachment_id, filename):
     """
     Serve up an attachment's file.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1153,6 +1153,16 @@ ATTACHMENT_SITE_URL = PROTOCOL + ATTACHMENT_HOST
 _PROD_ATTACHMENT_ORIGIN = "demos-origin.mdn.mozit.cloud"
 ATTACHMENT_ORIGIN = config("ATTACHMENT_ORIGIN", default=_PROD_ATTACHMENT_ORIGIN)
 
+# Primary use case if for file attachments that are still served via Kuma.
+# We have settings.ATTACHMENTS_USE_S3 on by default. So a URL like
+# `/files/3710/Test_Form_2.jpg` will trigger a 302 response (to its final
+# public S3 URL). This 302 response can be cached in the CDN. That's what
+# this setting controls.
+# We can make it pretty aggressive, because as of early 2021, you can't
+# edit images by uploading a different one through the Wiki UI.
+ATTACHMENTS_CACHE_CONTROL_MAX_AGE = config(
+    "ATTACHMENTS_CACHE_CONTROL_MAX_AGE", default=60 * 60 * 24, cast=int
+)
 WIKI_HOST = config("WIKI_HOST", default="wiki." + DOMAIN)
 WIKI_SITE_URL = PROTOCOL + WIKI_HOST
 


### PR DESCRIPTION
There are lots of images that we can't easily download and make as part of mdn/content, so we still rely on a Kuma serving URLs like `/files/3710/Test_Form_2.jpg` that are served via Kuma, which returns a 302 to a S3 URL. 

Increasing the cache-control will significantly increase the probability of an end-user getting a warm cache hit on those images. 