### PR TITLE
reinstate search health checks

### DIFF
--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -124,6 +124,7 @@ def status(request):
     # Check that Elasticsearch is reachable and somewhat healthy
     search_data = {"available": None, "populated": None, "health": None, "count": None}
     try:
+        es_connections.create_connection(hosts=settings.ES_URLS)
         connection = es_connections.get_connection()
         search_data["available"] = True
         health = connection.cluster.health()

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -7,8 +7,13 @@ from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_safe
+from elasticsearch.exceptions import ConnectionError as ES_ConnectionError
+from elasticsearch.exceptions import NotFoundError, TransportError
+from elasticsearch_dsl import Search
+from elasticsearch_dsl.connections import connections as es_connections
 from raven.contrib.django.models import client
-from requests.exceptions import ConnectionError as Requests_ConnectionError, ReadTimeout
+from requests.exceptions import ConnectionError as Requests_ConnectionError
+from requests.exceptions import ReadTimeout
 
 from kuma.users.models import User
 from kuma.wiki.kumascript import request_revision_hash
@@ -115,6 +120,24 @@ def status(request):
     else:
         ks_data["revision"] = ks_response.text
     data["services"]["kumascript"] = ks_data
+
+    # Check that Elasticsearch is reachable and somewhat healthy
+    search_data = {"available": None, "populated": None, "health": None, "count": None}
+    try:
+        connection = es_connections.get_connection()
+        search_data["available"] = True
+        health = connection.cluster.health()
+        search_data["health"] = health
+        count = Search(
+            index=settings.SEARCH_INDEX_NAME,
+        ).count()
+        search_data["populated"] = count > 0
+        search_data["count"] = count
+    except (ES_ConnectionError, TransportError):
+        search_data["available"] = False
+    except NotFoundError:
+        search_data["populated"] = False
+    data["services"]["search"] = search_data
 
     # Check if the testing accounts are available
     test_account_data = {"available": False}

--- a/kuma/settings/pytest.py
+++ b/kuma/settings/pytest.py
@@ -7,6 +7,9 @@ CELERY_TASK_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 ES_LIVE_INDEX = config("ES_LIVE_INDEX", default=False, cast=bool)
 
+# Always make sure we never test against a real Elasticsearch server
+ES_URLS = ["1.2.3.4:9200"]
+
 # Disable the Constance database cache
 CONSTANCE_DATABASE_CACHE_BACKEND = False
 


### PR DESCRIPTION
Now http://localhost.org:8000/_kuma_status.json includes search. 
I tested it by doing things like turning off the elasticsearch server, or messing with the index name. 

This "undoes" some of the stuff that got dropped in https://github.com/mdn/kuma/pull/7747/files#diff-6ab9a23c58ba8e2eb4faf8a0031834d663a26064c6f03284f9b7e5145bed941a

But the old unit tests used to not just test the happy path, but also test things like `ConnectionError` and `NotFoundError` etc. I tried to do that too. But after 1h of trial-and-error and hair-tearing I couldn't get it to work. My mock-fu must be a bit lost. I'm not 100% sure but I suspect it's something related to the connection pooling. What I would find is that if I use `pytest .. -k test_status_missing_index` (for example), it would work and my mocking would take effect. And individually each of the 4 (new and relevant) unit tests work. But whenever trying to run all the tests one of them would always fail. Or rather, when I run the whole suite, 1 would work and the other 3 would fail. Order didn't matter. So I think the connection pooling could be related. 
Then I thought, instead of using the connection pooling, let's create a new connection each time. But after 30 min of more debugging and swearing, I still couldn't get it to work. 
At this point, I had spent 10min fully implementing and manually testing a really nice solution. The other 60min was spent endlessly trial-and-error deep debugging mocking and it was just getting me frustrated. 
Given the full context, that the core functionality certainly has been implemented, I just can't justify more time on the mocking unit tests. I don't think it's important enough in the current context to nail those. It was pretty easy to manually test it. Once. And it's not critical that these error handlings work since it's not a functionality that our users would ever see. 