### PR TITLE
search locale should be case insenstive

### DIFF
--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -153,6 +153,8 @@ def _find(params, total_only=False, make_suggestions=False, min_suggestion_score
             # This can happen if the search happened right as the index had
             # just been deleted due to a fresh re-indexing happening in Yari.
             exceptions.NotFoundError,
+            # This can happen when the index simply isn't ready yet.
+            exceptions.TransportError,
         ),
         # The default in redo is 60 seconds. Let's tone that down.
         "sleeptime": settings.ES_RETRY_SLEEPTIME,

--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -155,8 +155,9 @@ def _find(params, total_only=False, make_suggestions=False, min_suggestion_score
             exceptions.NotFoundError,
         ),
         # The default in redo is 60 seconds. Let's tone that down.
-        "sleeptime": 1,
-        "attempts": 5,
+        "sleeptime": settings.ES_RETRY_SLEEPTIME,
+        "attempts": settings.ES_RETRY_ATTEMPTS,
+        "jitter": settings.ES_RETRY_JITTER,
     }
     with retrying(search_query.execute, **retry_options) as retrying_function:
         response = retrying_function()

--- a/kuma/api/v1/search/forms.py
+++ b/kuma/api/v1/search/forms.py
@@ -34,6 +34,18 @@ class SearchForm(forms.Form):
         # See https://www.peterbe.com/plog/initial-values-bound-django-form-rendered
         data = MultiValueDict({**{k: [v] for k, v in initial.items()}, **data})
 
+        # Because the `?locale=en-US&locale=Fr` might come in from the `request.GET`
+        # we can't edit it there. So instead, we mutate it here in the `data`
+        if "locale" in data:
+            # Always force it to lowercase, because that's what the ChoiceField
+            # is configured to. And the searches should always be in lower case.
+            # Remember, Django forms will allow this to be a single string
+            # (e.g. `?locale=Fr`) or a multi-value (`?locale=fr&locale=En-US`).
+            if isinstance(data["locale"], str):
+                data["locale"] = data["locale"].lower()
+            else:
+                data["locale"] = [x.lower() for x in data["locale"]]
+
         # If, for keys we have an initial value for, it was passed an empty string,
         # then swap it for the initial value.
         # For example `?q=searching&page=` you probably meant to omit it

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1621,7 +1621,9 @@ ES_URLS = config("ES_URLS", default="127.0.0.1:9200", cast=Csv())
 # Specify a max length for the q param to avoid unnecessary burden on
 # elasticsearch for queries that are probably either mistakes or junk.
 ES_Q_MAXLENGTH = config("ES_Q_MAXLENGTH", default=200, cast=int)
-
+ES_RETRY_SLEEPTIME = config("ES_RETRY_SLEEPTIME", default=1, cast=int)
+ES_RETRY_ATTEMPTS = config("ES_RETRY_ATTEMPTS", default=5, cast=int)
+ES_RETRY_JITTER = config("ES_RETRY_JITTER", default=1, cast=int)
 
 # Logging is merged with the default logging
 # https://github.com/django/django/blob/stable/1.11.x/django/utils/log.py

--- a/kuma/settings/pytest.py
+++ b/kuma/settings/pytest.py
@@ -7,6 +7,14 @@ CELERY_TASK_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 ES_LIVE_INDEX = config("ES_LIVE_INDEX", default=False, cast=bool)
 
+# Always make sure we never test against a real Elasticsearch server
+ES_URLS = ["1.2.3.4:9200"]
+# This makes sure that if we ever fail to mock the connection,
+# it won't retry for many many seconds.
+ES_RETRY_SLEEPTIME = 0
+ES_RETRY_ATTEMPTS = 1
+ES_RETRY_JITTER = 0
+
 # Disable the Constance database cache
 CONSTANCE_DATABASE_CACHE_BACKEND = False
 


### PR DESCRIPTION
Fixes #7754

Now, these work:
* http://localhost.org:8000/en-US/search?q=foo&locale=en-US
* http://localhost.org:8000/en-US/search?q=foo&locale=en-US&locale=Fr

(they didn't before)

and http://localhost.org:8000/en-US/search?q=foo still works. 
