### PR TITLE
Make /$locale/search.json redirect

### DIFF
--- a/kuma/search/views.py
+++ b/kuma/search/views.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs, urlencode
 
+from django.conf import settings
 from django.shortcuts import render
 from django.urls import reverse_lazy
 from django.views.decorators.cache import never_cache
@@ -115,11 +116,14 @@ class SearchRedirectView(RedirectView):
 
     def get_redirect_url(self, *args, **kwargs):
         query_string = self.request.META.get("QUERY_STRING")
-        url = reverse_lazy(
-            "api.v1.search", kwargs={"locale": self.request.LANGUAGE_CODE}
-        )
-        if query_string:
-            url += "?" + query_string
+        url = reverse_lazy("api.v1.search")
+        qs = parse_qs(query_string)
+        # If you used `/en-Us/search.json` you can skip the `?locale=`
+        # because the default locale in `/api/v1/search` is `en-US`.
+        if self.request.LANGUAGE_CODE.lower() != settings.LANGUAGE_CODE.lower():
+            qs["locale"] = self.request.LANGUAGE_CODE
+        if qs:
+            url += "?" + urlencode(qs, True)
         return url
 
 


### PR DESCRIPTION
Fixes #7758

Because the testing is removed for this legacy Django app, I didn't bother with a new unit test. But to sanity check myself, I wrote a little script to check:
```python
import requests

def T(pathname, expect):
    r = requests.get(f"http://localhost.org:8000{pathname}", allow_redirects=False)
    assert r.status_code == 301, (pathname, r.status_code)
    assert (
        r.headers["location"] == expect
    ), f"WANTED: {expect}\tGOT: {r.headers['location']}"


T("/en-US/search.json?q=bar", "/api/v1/search?q=bar")
T("/en-US/search.json?q=bar&locale=fr", "/api/v1/search?q=bar&locale=fr")
T("/en-US/search.json", "/api/v1/search")
T("/en-US/search.json?locale=fr", "/api/v1/search?locale=fr")
T("/fr/search.json", "/api/v1/search?locale=fr")
```
