### PR TITLE
Let Dependabot upgrade poetry packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Fixes #7745

I just find `poetry` updating bewildering. I struggle to update just one package without it upgrading a bunch of other things. 
Considering that the worst that can happen is that Dependabot makes a PR that fails, let's give this a good start. 