### PR TITLE
slug_prefixes

### DIFF
--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -50,7 +50,8 @@ def search(request, locale=None):
         "size": form.cleaned_data["size"],
         "page": form.cleaned_data["page"],
         "sort": form.cleaned_data["sort"],
-        "slug_prefixes": form.cleaned_data["slug_prefix"],
+        # The `slug` is always stored, as a Keyword index, in lowercase.
+        "slug_prefixes": [x.lower() for x in form.cleaned_data["slug_prefix"]],
     }
     results = _find(
         params,

--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -50,6 +50,7 @@ def search(request, locale=None):
         "size": form.cleaned_data["size"],
         "page": form.cleaned_data["page"],
         "sort": form.cleaned_data["sort"],
+        "slug_prefixes": form.cleaned_data["slug_prefix"],
     }
     results = _find(
         params,
@@ -92,6 +93,10 @@ def _find(params, total_only=False, make_suggestions=False, min_suggestion_score
         search_query = search_query.filter("term", archived=False)
     elif params["archive"] == "only":
         search_query = search_query.filter("term", archived=True)
+
+    if params["slug_prefixes"]:
+        sub_queries = [Q("prefix", slug=x) for x in params["slug_prefixes"]]
+        search_query = search_query.query(query.Bool(should=sub_queries))
 
     search_query = search_query.highlight_options(
         pre_tags=["<mark>"],

--- a/kuma/api/v1/search/forms.py
+++ b/kuma/api/v1/search/forms.py
@@ -3,6 +3,15 @@ from django.conf import settings
 from django.utils.datastructures import MultiValueDict
 
 
+class TypedMultipleValueField(forms.TypedMultipleChoiceField):
+    """Unlike TypedMultipleChoiceField we don't care what the individual values
+    are as long as they're not empty."""
+
+    def valid_value(self, value):
+        # Basically, as long as it's not empty, it's fine
+        return bool(value)
+
+
 class SearchForm(forms.Form):
     q = forms.CharField(max_length=settings.ES_Q_MAXLENGTH)
     locale = forms.MultipleChoiceField(
@@ -24,6 +33,8 @@ class SearchForm(forms.Form):
 
     size = forms.IntegerField(required=True, min_value=1, max_value=100)
     page = forms.IntegerField(required=True, min_value=1, max_value=10)
+
+    slug_prefix = TypedMultipleValueField(required=False)
 
     def __init__(self, data, **kwargs):
         initial = kwargs.get("initial", {})

--- a/kuma/api/v1/tests/test_search.py
+++ b/kuma/api/v1/tests/test_search.py
@@ -40,6 +40,11 @@ def test_search_validation_problems(user_client, settings):
     assert response.status_code == 400
     assert response.json()["errors"]["sort"][0]["code"] == "invalid_choice"
 
+    # 'slug_prefix' has to be anything but empty
+    response = user_client.get(url, {"q": "x", "slug_prefix": ""})
+    assert response.status_code == 400
+    assert response.json()["errors"]["slug_prefix"][0]["code"] == "invalid_choice"
+
 
 class FindEverythingFakeElasticsearch(FakeElasticsearch):
     def search(self, *args, **kwargs):


### PR DESCRIPTION
This is the precursor to be able to filter the site-search to specific tree(s). E.g. searching for the word `float` in the CSS reference doc. Or the word `fetch` in the Learning area. 

There's nothing using this yet. We won't add it to Kuma's UI and it's not the right time to add it to the not-yet-launch Yari site-search. But now it becomes possible. 

One interesting potential with this is that this could be a solution to those monster `Index` pages [E.g.](https://developer.mozilla.org/en-US/docs/Web/API/Index) For example, that macro could be made to only show the top 10 sub-pages but with a link at the bottom that is a search. Granted, our search currently always requires a search free-text input, but that's something we could build on. 

My hope is to add to the site-search UI some advanced field that appears and the user can just click things like "CSS" or "JavaScript" and behind the scenes we hardcode those to mean things like `&slug_prefix=Web/CSS`