### PR TITLE
support sign-up from Yari

### DIFF
--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -68,7 +68,6 @@ def next_url(request):
                     "://" in request.GET["next"]
                     and settings.DEBUG
                     and settings.ADDITIONAL_NEXT_URL_ALLOWED_HOSTS
-                    and settings.ADDITIONAL_NEXT_URL_ALLOWED_HOSTS
                     in request.GET["next"]
                 ):
                     # The reason we don't need to make a much more elaborate

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -200,8 +200,6 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         session_login_data = request.session.get("socialaccount_sociallogin", None)
         request_login = sociallogin
 
-        print("HI! session_login_data:", session_login_data)
-
         # Is there already a sociallogin_provider in the session?
         if session_login_data:
             session_login = SocialLogin.deserialize(session_login_data)
@@ -215,7 +213,6 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
                     level = messages.ERROR
                     message = "socialaccount/messages/account_not_found.txt"
                     get_adapter().add_message(request, level, message)
-                    print("REDIRECTING TO:", redirect("socialaccount_signup"))
                     raise ImmediateHttpResponse(redirect("socialaccount_signup"))
 
         # Is the user banned?

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -263,7 +263,6 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         # class is used when calling this method from the one used when calling
         # is_auto_signup_allowed().
         user = get_existing_user(sociallogin)
-        print(f"get_existing_user({sociallogin}):", get_existing_user(sociallogin))
         if user:
             # We can re-use an existing user instead of creating a new one.
             # Let's guarantee this user has an unusable password, just in case

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -200,6 +200,8 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         session_login_data = request.session.get("socialaccount_sociallogin", None)
         request_login = sociallogin
 
+        print("HI! session_login_data:", session_login_data)
+
         # Is there already a sociallogin_provider in the session?
         if session_login_data:
             session_login = SocialLogin.deserialize(session_login_data)
@@ -213,6 +215,7 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
                     level = messages.ERROR
                     message = "socialaccount/messages/account_not_found.txt"
                     get_adapter().add_message(request, level, message)
+                    print("REDIRECTING TO:", redirect("socialaccount_signup"))
                     raise ImmediateHttpResponse(redirect("socialaccount_signup"))
 
         # Is the user banned?
@@ -263,6 +266,7 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         # class is used when calling this method from the one used when calling
         # is_auto_signup_allowed().
         user = get_existing_user(sociallogin)
+        print(f"get_existing_user({sociallogin}):", get_existing_user(sociallogin))
         if user:
             # We can re-use an existing user instead of creating a new one.
             # Let's guarantee this user has an unusable password, just in case

--- a/kuma/users/providers/github/views.py
+++ b/kuma/users/providers/github/views.py
@@ -51,8 +51,19 @@ class KumaOAuth2LoginView(OAuth2LoginView):
             if urlparse(http_referer).netloc == request.get_host():
                 track_event(CATEGORY_SIGNUP_FLOW, ACTION_AUTH_STARTED, "github")
 
-        next_url = get_next_redirect_url(request) or reverse("users.my_edit_page")
-        request.session["sociallogin_next_url"] = next_url
+        next_url = get_next_redirect_url(request)
+        # This is a temporary solution whilst Kuma needs to work for the prod
+        # old Kuma front-end and at the same time the new redirects-based Yari.
+        # If `allauth` decides to render the `signup` view rather than redirect
+        # back based on the `?next=`, then that view will know this is Yari.
+        # We can remove this hack once Kuma does 0% HTML responses and just
+        # does redirects + JSON to back up Yari.
+        if request.GET.get("yarisignup"):
+            request.session["yari_signup"] = True
+
+        if next_url:
+            request.session["sociallogin_next_url"] = next_url
+
         request.session.modified = True
         return super(KumaOAuth2LoginView, self).dispatch(request)
 

--- a/kuma/users/providers/github/views.py
+++ b/kuma/users/providers/github/views.py
@@ -9,7 +9,6 @@ from allauth.socialaccount.providers.oauth2.views import (
 
 from kuma.core.decorators import redirect_in_maintenance_mode
 from kuma.core.ga_tracking import ACTION_AUTH_STARTED, CATEGORY_SIGNUP_FLOW, track_event
-from kuma.core.urlresolvers import reverse
 from kuma.core.utils import requests_retry_session
 
 

--- a/kuma/users/providers/google/views.py
+++ b/kuma/users/providers/google/views.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
 
+from allauth.account.utils import get_next_redirect_url
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2CallbackView,
@@ -25,6 +26,20 @@ class KumaOAuth2LoginView(OAuth2LoginView):
         if http_referer:
             if urlparse(http_referer).netloc == request.get_host():
                 track_event(CATEGORY_SIGNUP_FLOW, ACTION_AUTH_STARTED, "google")
+
+        # This is a temporary solution whilst Kuma needs to work for the prod
+        # old Kuma front-end and at the same time the new redirects-based Yari.
+        # If `allauth` decides to render the `signup` view rather than redirect
+        # back based on the `?next=`, then that view will know this is Yari.
+        # We can remove this hack once Kuma does 0% HTML responses and just
+        # does redirects + JSON to back up Yari.
+        if request.GET.get("yarisignup"):
+            request.session["yari_signup"] = True
+
+        next_url = get_next_redirect_url(request)
+        if next_url:
+            request.session["sociallogin_next_url"] = next_url
+
         return super().dispatch(request)
 
 

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -687,6 +687,7 @@ class SignupView(BaseSignupView):
         # Once Kuma id divorced from doing any
         is_yari_signup = self.request.session.get("yari_signup", False)
         if is_yari_signup:
+            form.data = form.data.copy()
             for key in form.initial:
                 if key not in form.data and form.initial[key]:
                     form.data[key] = form.initial[key]
@@ -838,10 +839,12 @@ class SignupView(BaseSignupView):
                 safe_user_details["name"] = extra_data["name"]
             if extra_data.get("picture"):  # Google OAuth2
                 safe_user_details["avatar_url"] = extra_data["picture"]
+            elif extra_data.get("avatar_url"):  # GitHub OAuth2
+                safe_user_details["avatar_url"] = extra_data["avatar_url"]
             params = {
                 "next": next_url,
                 "user_details": json.dumps(safe_user_details),
-                "csrfmiddlewaretoken": request.META["CSRF_COOKIE"],
+                "csrfmiddlewaretoken": request.META.get("CSRF_COOKIE"),
                 "provider": account.get("provider"),
             }
             yari_signup_url = f"{next_url_prefix}/{request.LANGUAGE_CODE}/signup"

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -736,6 +736,9 @@ class SignupView(BaseSignupView):
                     "username edit",
                 )
 
+        # This won't be needed once this view is entirely catering to Yari.
+        self.request.session.pop("yari_signup", None)
+
         return helpers.complete_social_signup(self.request, self.sociallogin)
 
     def form_invalid(self, form):

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta
-from urllib.parse import urlencode, urljoin, urlparse
+from urllib.parse import urlencode, urlparse
 
 import stripe
 from allauth.account.adapter import get_adapter


### PR DESCRIPTION
Once this lands, we can start testing the `/en-US/sign-up` SPA in Yari. Even from prod. 
However, one thing that's a bit weird is that Django will still respond with a HTML page if your CSRF cookie expires or you manually muck around with it and not follow the happy-path. 