### PR TITLE
invalid form should yield a JSON 400 response

### DIFF
--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -20,6 +20,7 @@ from django.http import (
     HttpResponseBadRequest,
     HttpResponseForbidden,
     HttpResponseRedirect,
+    JsonResponse,
 )
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect, render
@@ -757,15 +758,7 @@ class SignupView(BaseSignupView):
             )
         is_yari_signup = self.request.session.get("yari_signup", False)
         if is_yari_signup:
-            # Have to redirect instead of rendering HTML.
-            next_url = self.request.session.get("sociallogin_next_url")
-            next_url_prefix = self.get_next_url_prefix(self.request)
-            params = {
-                "next": next_url,
-                "errors": form.errors.as_json(),
-            }
-            yari_signup_url = f"{next_url_prefix}/{self.request.LANGUAGE_CODE}/signup"
-            return redirect(yari_signup_url + "?" + urlencode(params))
+            return JsonResponse({"errors": form.errors.get_json_data()}, status=400)
 
         return super().form_invalid(form)
 


### PR DESCRIPTION
Part of https://github.com/mdn/yari/issues/3377

At least the errors don't fly by silently in the redirect now. 

<img width="1501" alt="Screen Shot 2021-03-29 at 10 03 06 PM" src="https://user-images.githubusercontent.com/26739/112922629-cc500a80-90da-11eb-91fa-e018f01223ab.png">

There's a PR coming for this on the Yari side too. 