### PR TITLE
use port :7777 for mockga service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - SSR_PORT=8000
       - SSR_URL=http://ssr:8000/ssr
       - SSR_TIMEOUT=1
-      - GOOGLE_ANALYTICS_TRACKING_URL=http://mockga:7000/collect
+      - GOOGLE_ANALYTICS_TRACKING_URL=http://mockga:7777/collect
 
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
@@ -160,7 +160,7 @@ services:
       context: mockga
       dockerfile: Dockerfile
     ports:
-      - "7000:7000"
+      - "7777:7777"
 
 volumes:
     miniodata:

--- a/mockga/Dockerfile
+++ b/mockga/Dockerfile
@@ -3,7 +3,7 @@ COPY . /app
 WORKDIR /app
 RUN yarn install
 
-ENV PORT=7000
+ENV PORT=7777
 EXPOSE $PORT
 
 CMD yarn run start

--- a/mockga/README.md
+++ b/mockga/README.md
@@ -9,7 +9,7 @@ does but only for local development.
 
 ## To run
 
-    docker run -t -i --rm -v ${pwd}:/app:rw -p 7000:7000 mockga
+    docker run -t -i --rm -v ${pwd}:/app:rw -p 7777:7777 mockga
 
 You can also, run this outside of Docker if you have `yarn` and `node` etc.
 Simply type:
@@ -18,7 +18,7 @@ Simply type:
 
 ## To `curl` test
 
-Suppose you have the `mockga` server up and running on `localhost:7000` you
+Suppose you have the `mockga` server up and running on `localhost:7777` you
 can send a semi-realistic POST to it with:
 
-    curl -XPOST "http://localhost:7000/collect?v=1&cid=123&tid=UA-XX&ec=category&ea=something&el=foo+bar"
+    curl -XPOST "http://localhost:7777/collect?v=1&cid=123&tid=UA-XX&ec=category&ea=something&el=foo+bar"

--- a/mockga/index.js
+++ b/mockga/index.js
@@ -9,7 +9,7 @@ const express = require('express');
 const chalk = require('chalk');
 
 const app = express();
-const port = parseInt(process.env.PORT || '7000');
+const port = parseInt(process.env.PORT || '7777');
 
 app.get('/', (req, res) => res.send('Hello World!'));
 


### PR DESCRIPTION
I think the culprit is myself. I wrote both the `mockga` service in `kuma` and the test server for `deployer/aws-lambda/content-origin-request` in Yari. They both use port `:7000` but default. That's annoying because every time I start up the `yarn serve` in `deployer/aws-lambda/content-origin-request` I get a conflict and I have to switch to the other window to kill kuma. 
Now, the default port numbers are sufficiently different that this annoying thing won't come up for us. 