### PR TITLE
cache site-search api JSON at 24h instead of 12h

### DIFF
--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -13,7 +13,7 @@ from .forms import SearchForm
 # if the search is successful.
 # We can increase the number as we feel more and more comfortable with how
 # the `/api/v1/search` works.
-SEARCH_CACHE_CONTROL_MAX_AGE = 60 * 60 * 12
+SEARCH_CACHE_CONTROL_MAX_AGE = 60 * 60 * 24
 
 
 class JsonResponse(http.JsonResponse):


### PR DESCRIPTION
Perhaps it's not worth doing this until we can start sending daily cache invalidation requests to the CDN for all things `/api/v1/search*`. 
