### PR TITLE
fix for docker-compose on m1 macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
 
   mysql:
     image: mysql:5.6
+    # This is necessary for platforms using the Apple M1 chip.
     platform: linux/x86_64
     environment:
       - MYSQL_USER=kuma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
 
   mysql:
     image: mysql:5.6
+    platform: linux/x86_64
     environment:
       - MYSQL_USER=kuma
       - MYSQL_PASSWORD=kuma


### PR DESCRIPTION
I just recently upgraded to a MacBook pro with an M1 chip, and needed to do this.