### PR TITLE
Add cloudfront geo country to whoami

### DIFF
--- a/kuma/api/v1/tests/test_forms.py
+++ b/kuma/api/v1/tests/test_forms.py
@@ -27,7 +27,6 @@ def test_search_form_locale_happy_path():
     request = RequestFactory().get("/api/v1/search?q=foo&locale=Fr&locale=de")
     form = SearchForm(request.GET, initial=initial)
     assert form.is_valid()
-    print(form.cleaned_data)
     assert form.cleaned_data["locale"] == ["Fr", "de"]
 
     # Note, same as the initial default

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -60,6 +60,16 @@ def test_whoami_anonymous(client, settings):
 
 
 @pytest.mark.django_db
+def test_whoami_anonymous_cloudfront_geo(client, settings):
+    """Test response for anonymous users."""
+    url = reverse("api.v1.whoami")
+    response = client.get(url, HTTP_CLOUDFRONT_VIEWER_COUNTRY_NAME="US of A")
+    assert response.status_code == 200
+    assert response["content-type"] == "application/json"
+    assert response.json()["geo"] == {"country": "US of A"}
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "is_staff,is_superuser,is_beta_tester",
     [(False, False, False), (True, True, True)],

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -88,7 +88,8 @@ def whoami(request):
     cloudfront_country_value = request.META.get(cloudfront_country_header)
     if cloudfront_country_value:
         geo["country"] = cloudfront_country_value
-    data["geo"] = geo
+    if geo:
+        data["geo"] = geo
 
     data["waffle"] = {
         "flags": {},

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -82,6 +82,14 @@ def whoami(request):
     else:
         data = {}
 
+    geo = {}
+    # https://aws.amazon.com/about-aws/whats-new/2020/07/cloudfront-geolocation-headers/
+    cloudfront_country_header = "HTTP_CLOUDFRONT_VIEWER_COUNTRY_NAME"
+    cloudfront_country_value = request.META.get(cloudfront_country_header)
+    if cloudfront_country_value:
+        geo["country"] = cloudfront_country_value
+    data["geo"] = geo
+
     data["waffle"] = {
         "flags": {},
         "switches": {s.name: True for s in Switch.get_all() if s.is_active()},


### PR DESCRIPTION
Fixes #7848

Once this lands, we can immediately start to do things like this in Yari:

```javascript
const userData = useUserData();
if (userData.geo && userData.geo.country) {
  console.log(`This user is view from ${userData.geo.country}`);
}
```