### PR TITLE
use get_token for csrf instead of header

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -12,6 +12,7 @@ from django.http import (
     HttpResponseForbidden,
     JsonResponse,
 )
+from django.middleware.csrf import get_token
 from django.utils import translation
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -165,7 +166,7 @@ def account_settings(request):
         return response
 
     context = {
-        "csrfmiddlewaretoken": request.META.get("CSRF_COOKIE"),
+        "csrfmiddlewaretoken": get_token(request),
         "locale": user.locale,
     }
     return JsonResponse(context)


### PR DESCRIPTION
Remember this? https://github.com/mdn/kuma/pull/7815
You can't rely on `request.META['CSRF_COOKIE']` on the initial load but technically this view function clearly checks, on line 129, that you can't even get that far if you're not signed in. 

But it just doesn't feel right relying on returning something that might be null. `get_token` feels like the more appropriate API to use. 