### PR TITLE
start Dependabot to check docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/images/kuma_base"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem

Don't know if this is going to work. Or how to test it. 