### PR TITLE
drop libtidy-dev from apt install

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -16,7 +16,6 @@ RUN set -x \
     gettext \
     mime-support \
     build-essential \
-    libtidy-dev \
     libxml2-dev \
     libxslt1-dev \
     libffi-dev \


### PR DESCRIPTION
I suspect in the olden days we used to depend on a python lib, like [django-tidy](https://pypi.org/project/django-tidy/) to post-process HTML in the Wiki. 