### PR TITLE
drop libjpeg-dev from apt install

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -20,7 +20,6 @@ RUN set -x \
     libxml2-dev \
     libxslt1-dev \
     libffi-dev \
-    libjpeg-dev \
     libmagic-dev \
     default-libmysqlclient-dev \
     default-mysql-client


### PR DESCRIPTION
I have no idea why we had this. Either way, Kuma no longer deals with images. There are no more uploads going through. We do still deal with file attachments but Kuma doesn't go near the actual binary content. Just a matter of redirects to the S3 bucket. 