### PR TITLE
favor title a bit more in site-search

### DIFF
--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -110,15 +110,29 @@ def _find(params, total_only=False, make_suggestions=False, min_suggestion_score
             "body_suggestions", params["query"], term={"field": "body"}
         )
 
+    # The business logic here that we search for things different ways,
+    # and each different way as a different boost which dictates its importance.
+    # The importance order is as follows:
+    #
+    #  1. Title match-phrase
+    #  2. Title match
+    #  3. Body match-phrase
+    #  4. Body match
+    #
+    # The order is determined by the `boost` number in the code below.
+    # Remember that sort order is a combination of "match" and popularity, but
+    # ideally the popularity should complement. Try to get a pretty good
+    # sort by pure relevance first, and let popularity just make it better.
+    #
     sub_queries = []
-    sub_queries.append(Q("match", title={"query": params["query"], "boost": 2.0}))
+    sub_queries.append(Q("match", title={"query": params["query"], "boost": 3.0}))
     sub_queries.append(Q("match", body={"query": params["query"], "boost": 1.0}))
     if " " in params["query"]:
         sub_queries.append(
             Q("match_phrase", title={"query": params["query"], "boost": 10.0})
         )
         sub_queries.append(
-            Q("match_phrase", body={"query": params["query"], "boost": 5.0})
+            Q("match_phrase", body={"query": params["query"], "boost": 2.0})
         )
 
     sub_query = query.Bool(should=sub_queries)

--- a/kuma/api/v1/search/__init__.py
+++ b/kuma/api/v1/search/__init__.py
@@ -125,7 +125,7 @@ def _find(params, total_only=False, make_suggestions=False, min_suggestion_score
     # sort by pure relevance first, and let popularity just make it better.
     #
     sub_queries = []
-    sub_queries.append(Q("match", title={"query": params["query"], "boost": 3.0}))
+    sub_queries.append(Q("match", title={"query": params["query"], "boost": 5.0}))
     sub_queries.append(Q("match", body={"query": params["query"], "boost": 1.0}))
     if " " in params["query"]:
         sub_queries.append(


### PR DESCRIPTION
Fixes #4024

I tinkered and tinkered until I started getting much better relevance. 

Some documents' body contains certain keywords like `array` and `slice` very often (aka. term frequency), which makes Elasticsearch think they're very relevant. But the title is almost always more important and from my gut, what you'd expect to see higher up in the search results. 

This PR just adjusts the knobs very gently to give slightly more favor to the `title` matches instead of the `body` because `body` matches can get unrealistically high match score because they repeat certain keywords. 