### PR TITLE
make subscription_config depend on subscription flag

### DIFF
--- a/kuma/api/v1/subscription.py
+++ b/kuma/api/v1/subscription.py
@@ -27,6 +27,9 @@ from kuma.users.stripe_utils import retrieve_stripe_prices
 @require_GET
 @never_cache
 def subscription_config(request):
+    if not flag_is_active(request, "subscription"):
+        return HttpResponseForbidden("subscription is not enabled")
+
     prices = []
 
     for price in retrieve_stripe_prices():

--- a/kuma/api/v1/tests/test_subscription.py
+++ b/kuma/api/v1/tests/test_subscription.py
@@ -137,6 +137,7 @@ def test_stripe_subscription_canceled_sends_ga_tracking(
 
 
 @mock.patch("stripe.Price.retrieve")
+@pytest.mark.django_db
 def test_subscription_config(mock_retrieve, client, settings):
     def mocked_get_price(id):
         assert id in settings.STRIPE_PRICE_IDS

--- a/kuma/api/v1/tests/test_subscription.py
+++ b/kuma/api/v1/tests/test_subscription.py
@@ -155,17 +155,18 @@ def test_subscription_config(mock_retrieve, client, settings):
 
     mock_retrieve.side_effect = mocked_get_price
     url = reverse("api.v1.subscriptions.config")
-    response = client.get(url)
-    assert response.status_code == 200
-    assert response.json()["public_key"] == settings.STRIPE_PUBLIC_KEY
-    assert response.json()["prices"] == [
-        {"currency": "sek", "unit_amount": 555, "id": settings.STRIPE_PRICE_IDS[0]},
-        {
-            "currency": "sek",
-            "unit_amount": 555 * 10,
-            "id": settings.STRIPE_PRICE_IDS[1],
-        },
-    ]
+    with override_flag("subscription", active=True):
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.json()["public_key"] == settings.STRIPE_PUBLIC_KEY
+        assert response.json()["prices"] == [
+            {"currency": "sek", "unit_amount": 555, "id": settings.STRIPE_PRICE_IDS[0]},
+            {
+                "currency": "sek",
+                "unit_amount": 555 * 10,
+                "id": settings.STRIPE_PRICE_IDS[1],
+            },
+        ]
 
 
 @mock.patch("stripe.billing_portal.Session.create")


### PR DESCRIPTION
Now all stripe related API endpoints depend on `subscription` waffle flag. 