### PR TITLE
unbreak black and Dependabot upgrades

### DIFF
--- a/.github/workflows/python-lints.yml
+++ b/.github/workflows/python-lints.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "kuma/**/*.py"
       - .github/workflows/python-lints.yml
+      # This is in case Dependabot updates 'black'
+      - pyproject.toml
 
 jobs:
   build:
@@ -13,15 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2.2.2
+      - uses: actions/setup-python@v2.2.2
         with:
           python-version: "3.8"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --disable-pip-version-check black==20.8b1 flake8 flake8-import-order
+          pip install --disable-pip-version-check black flake8 flake8-import-order
+          echo "Version of black installed:"
+          black --version
+          echo "Version of flake8 installed:"
+          flake8 --version
 
       - name: Lint with flake8
         run: |

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -19,7 +19,7 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
     rf = RequestFactory()
 
     def setUp(self):
-        """ extra setUp to make a working session """
+        """extra setUp to make a working session"""
         super(KumaSocialAccountAdapterTestCase, self).setUp()
         self.adapter = KumaSocialAccountAdapter()
 


### PR DESCRIPTION
At some point, `pyproject.toml` and `poetry.lock` got a new version of black. 
E.g. https://github.com/mdn/kuma/commit/c705739a2596b0d8af7e47ad35a3c79f865bb4d6
What happened was that `.github/workflows/python-lints.yml` never ran. Now what happens is that the version of `black` you get inside the docker container *doesn't match the version* of `black` used in `python-lints.yml`. 
Worse, because it wouldn't even have noticed because a change to `pyproject.toml` our `.py` files no longer match that version that you get inside the docker container. So, when you run `black` inside `bash` on your docker container, it says some files aren't formatted even though nobody's touched them for ages. 
This PR solves both problems. 