### PR TITLE
calm down Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/docker/images/kuma_base"


### PR DESCRIPTION
It's just too chatty at the moment. 
There's too little value to upgrade these more frequently than weekly. 
And for the record, one can always push for a refresh by going to https://github.com/mdn/kuma/network/updates/175308387