### PR TITLE
subplat integration

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -336,6 +336,22 @@ OIDC_RP_CLIENT_SECRET = config("OIDC_RP_CLIENT_SECRET", default=None)
 # Function that gets called
 OIDC_OP_LOGOUT_URL_METHOD = "kuma.users.auth.logout_url"
 
+# This is the default URL that mozilla_django_oidc will use if there is no
+# appropriate `?next=...` it can use.
+LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL_FAILURE = "/?login=failure"
+
+# This will HEAD request `SUBSCRIPTION_SUBSCRIBE_URL` and
+# `SUBSCRIPTION_SETTINGS_URL` to see if they're reachable at all.
+SUBPLAT_CONFIGURATION_CHECK = config(
+    "SUBPLAT_CONFIGURATION_CHECK", cast=bool, default=not DEBUG
+)
+# This is the URL used to send people to become MDN Plus subscribers
+# E.g. https://accounts.stage.mozaws.net/subscriptions/products/prod_Jtbg9tyGyLRuB0?plan=price_1JFoTYKb9q6OnNsLalexa03p
+SUBSCRIPTION_SUBSCRIBE_URL = config("SUBSCRIPTION_SUBSCRIBE_URL", default=None)
+# E.g. https://accounts.stage.mozaws.net/subscriptions
+SUBSCRIPTION_SETTINGS_URL = config("SUBSCRIPTION_SETTINGS_URL", default=None)
+
 # Session cookies
 SESSION_COOKIE_DOMAIN = DOMAIN
 SESSION_COOKIE_SECURE = config("SESSION_COOKIE_SECURE", default=True, cast=bool)

--- a/kuma/settings/pytest.py
+++ b/kuma/settings/pytest.py
@@ -89,3 +89,7 @@ OIDC_OP_JWKS_ENDPOINT = f"{OIDC_CONFIGURATION_URL}/v1/jwks"
 OIDC_RP_SIGN_ALGO = "XYZ"
 OIDC_USE_NONCE = False
 OIDC_RP_SCOPES = "openid profile email"
+
+SUBSCRIPTION_SUBSCRIBE_URL = "https://accounts.example.com/subscriptions/products/"
+SUBSCRIPTION_SETTINGS_URL = "https://accounts.example.com/subscriptions/settings/"
+SUBPLAT_CONFIGURATION_CHECK = True

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -34,6 +34,7 @@ else:
 urlpatterns += [re_path("", include("kuma.attachments.urls"))]
 urlpatterns += [
     path("users/fxa/login/", include("mozilla_django_oidc.urls")),
+    path("users/", include("kuma.users.urls")),
 ]
 
 urlpatterns += [

--- a/kuma/users/apps.py
+++ b/kuma/users/apps.py
@@ -12,5 +12,7 @@ class UsersConfig(AppConfig):
 
     def register_checks(self):
         from .checks import oidc_config_check
+        from .checks import subplat_config_check
 
         register(oidc_config_check)
+        register(subplat_config_check)

--- a/kuma/users/urls.py
+++ b/kuma/users/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import subplat
+
+
+urlpatterns = [
+    path("subplat/subscribe/", subplat.subscribe, name="kuma.users.subplat.subscribe"),
+    path("subplat/settings/", subplat.settings_, name="kuma.users.subplat.settings"),
+    path("subplat/download/", subplat.download, name="kuma.users.subplat.download"),
+]

--- a/kuma/users/views/subplat.py
+++ b/kuma/users/views/subplat.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.utils.http import urlencode
+
+
+def subscribe(request):
+    return redirect(settings.SUBSCRIPTION_SUBSCRIBE_URL)
+
+
+def settings_(request):
+    return redirect(settings.SUBSCRIPTION_SETTINGS_URL)
+
+
+def download(request):
+    """If you view this, that means you probably clicked the 'Click here to download'
+    on the sub plat page. That means, most possibly, that you have just recently
+    typed in your credit card and you're now a FxA Sub Plat subscriber.
+    But Kuma might not know, so lets send the user to authenticate one more time.
+    """
+    params = {"prompt": "none"}
+    qs = urlencode(params)
+    return redirect(f"/users/fxa/login/authenticate/?{qs}")


### PR DESCRIPTION
As of this, imagine you tell the sub plat that our "download URL" is `https://developer.mozilla.org/users/subplat/download/` then, after a user has paid, they click that green ("Click here to download") button. 
What that will do is force the user to sign in again, but with "silent authentication" which means it redirects them to `/users/fxa/login/authenticate/?prompt=none` (it should be fast) and this time, in the FxA OIDC callback it should get a "second chance" to see that the user has indeed signed in and has paid. 

To test, add this to your kuma `.env`:

```
SUBSCRIPTION_SUBSCRIBE_URL=https://accounts.stage.mozaws.net/subscriptions/products/prod_Jtbg9tyGyLRuB0?plan=price_1JFoTYKb9q6OnNsLalexa03p
SUBSCRIPTION_SETTINGS_URL=https://accounts.stage.mozaws.net/subscriptions

SUBPLAT_CONFIGURATION_CHECK=true
```
You also, need to check out https://github.com/mdn/yari/pull/4498 in Yari so you can get the link. 
But you can also ignore Yari entirely and just manually type in <http://localhost:8000/users/subplat/subscribe/> independent of being signed in or not. 