### PR TITLE
feat(notifications): process Content Updates via /update/ route

### DIFF
--- a/kuma/api/tests/test_admin.py
+++ b/kuma/api/tests/test_admin.py
@@ -1,0 +1,46 @@
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from model_bakery import baker
+
+from kuma.notifications import models
+
+
+def test_admin_update_content(user_client, wiki_user):
+    # Prepare: Watch page.
+    page_title = "<dialog>: The Dialog element"
+    page_url = "/en-us/docs/web/html/element/dialog"
+    baker.make(models.Watch, users=[wiki_user], title=page_title, url=page_url)
+
+    # Test: Trigger content update.
+    url = reverse("admin_api:admin.update_content")
+    auth_headers = {
+        "HTTP_AUTHORIZATION": f"Bearer {settings.NOTIFICATIONS_ADMIN_TOKEN}",
+    }
+    response = user_client.post(
+        url,
+        json.dumps(
+            {
+                "page": "/en-US/docs/Web/HTML/Element/dialog",
+                "pr": "https://github.com/mdn/content/pull/14607",
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+
+    assert response.status_code == 200
+
+    # Verify: Notification was created.
+    url = reverse("api-v1:plus.notifications")
+    response = user_client.get(url)
+    assert response.status_code == 200
+
+    notifications = json.loads(response.content)["items"]
+    assert len(notifications) == 1
+
+    notification = notifications[0]
+    assert notification["title"] == page_title
+    assert notification["url"] == page_url
+    assert notification["text"] == "Page updated (see PR!mdn/content!14607!!)"

--- a/kuma/api/v1/plus/notifications.py
+++ b/kuma/api/v1/plus/notifications.py
@@ -397,21 +397,20 @@ def update(request, body: UpdateNotificationSchema):
     return 200, True
 
 
-class CreatePRNotificationSchema(Schema):
+class ContentUpdateNotificationSchema(Schema):
     raw_url: str = Field(..., alias="page")
-    repo: str = Field(..., alias="repo")
-    pr: int
+    pr_url: str = Field(..., alias="pr")
 
 
-@admin_router.post("/create/pr/", response={200: Ok, 400: NotOk, 401: NotOk})
-def create_pr(request, body: CreatePRNotificationSchema):
+@admin_router.post("/update/content/", response={200: Ok, 400: NotOk, 401: NotOk})
+def create_pr(request, body: ContentUpdateNotificationSchema):
     try:
         url = DocumentURL.normalize_uri(body.raw_url)
         changes = [
             {
                 "event": "content_updated",
-                "url": url,
-                "pr": {"url": f"{body.repo.strip('/')}/pull/{body.pr}"},
+                "page_url": url,
+                "pr_url": body.pr_url,
             }
         ]
         process_changes(changes)

--- a/kuma/api/v1/plus/notifications.py
+++ b/kuma/api/v1/plus/notifications.py
@@ -402,7 +402,11 @@ class ContentUpdateNotificationSchema(Schema):
     pr_url: str = Field(..., alias="pr")
 
 
-@admin_router.post("/update/content/", response={200: Ok, 400: NotOk, 401: NotOk})
+@admin_router.post(
+    "/update/content/",
+    response={200: Ok, 400: NotOk, 401: NotOk},
+    url_name="admin.update_content",
+)
 def create_pr(request, body: ContentUpdateNotificationSchema):
     try:
         url = DocumentURL.normalize_uri(body.raw_url)

--- a/kuma/api/v1/plus/notifications.py
+++ b/kuma/api/v1/plus/notifications.py
@@ -407,7 +407,7 @@ class ContentUpdateNotificationSchema(Schema):
     response={200: Ok, 400: NotOk, 401: NotOk},
     url_name="admin.update_content",
 )
-def create_pr(request, body: ContentUpdateNotificationSchema):
+def update_content(request, body: ContentUpdateNotificationSchema):
     try:
         url = DocumentURL.normalize_uri(body.raw_url)
         changes = [

--- a/kuma/notifications/management/commands/extract_notifications.py
+++ b/kuma/notifications/management/commands/extract_notifications.py
@@ -9,9 +9,8 @@ class Command(BaseCommand):
     help = "Extracts notifications from a changes.json file"
 
     def add_arguments(self, parser):
-        parser.add_argument("--dry-run", default=False, action="store_true")
         parser.add_argument("file", type=open)
 
     def handle(self, *args, **options):
         changes = json.loads(options["file"].read())
-        process_changes(changes, options.get("dry_run"))
+        process_changes(changes)

--- a/kuma/notifications/utils.py
+++ b/kuma/notifications/utils.py
@@ -76,7 +76,7 @@ COPY = {
 }
 
 
-def publish_content_notification(url, text, dry_run=False, data=None):
+def publish_content_notification(url, text, dry_run=False):
     watchers = Watch.objects.filter(url=url)
 
     if not watchers:
@@ -151,7 +151,6 @@ def process_changes(changes, dry_run=False):
                 {
                     "url": change["page_url"],
                     "text": f"Page updated (see PR!{m.group(1)}!{m.group(2)}!!)",
-                    "data": change,
                 }
             )
 

--- a/kuma/notifications/utils.py
+++ b/kuma/notifications/utils.py
@@ -76,8 +76,8 @@ COPY = {
 }
 
 
-def publish_content_notification(slug, text, dry_run=False, data=None):
-    watchers = Watch.objects.filter(url=slug)
+def publish_content_notification(url, text, dry_run=False, data=None):
+    watchers = Watch.objects.filter(url=url)
 
     if not watchers:
         return
@@ -86,7 +86,7 @@ def publish_content_notification(slug, text, dry_run=False, data=None):
         return
 
     notification_data, _ = NotificationData.objects.get_or_create(
-        text=text, title=watchers[0].title, type="content", page_url=slug
+        text=text, title=watchers[0].title, type="content", page_url=url
     )
 
     for watcher in watchers:
@@ -146,10 +146,10 @@ def process_changes(changes, dry_run=False):
             )
 
         elif change["event"] == "content_updated":
-            m = re.match(r"^https://github.com/(.+)/pull/(\d+)$", change["pr"]["url"])
+            m = re.match(r"^https://github.com/(.+)/pull/(\d+)$", change["pr_url"])
             content_notifications.append(
                 {
-                    "url": change["url"],
+                    "url": change["page_url"],
                     "text": f"Page updated (see PR!{m.group(1)}!{m.group(2)}!!)",
                     "data": change,
                 }

--- a/kuma/notifications/utils.py
+++ b/kuma/notifications/utils.py
@@ -4,7 +4,7 @@ from kuma.notifications.browsers import browsers
 from kuma.notifications.models import Notification, NotificationData, Watch
 
 
-def publish_notification(path, text, dry_run=False, data=None):
+def publish_bcd_notification(path, text, dry_run=False, data=None):
     # This traverses down the path to see if there's top level watchers
     parts = path.split(".")
     suffix = []
@@ -76,7 +76,7 @@ COPY = {
 
 
 def process_changes(changes, dry_run=False):
-    notifications = []
+    bcd_notifications = []
     for change in changes:
         if change["event"] in ["added_stable", "removed_stable", "added_preview"]:
             groups = defaultdict(list)
@@ -93,7 +93,7 @@ def process_changes(changes, dry_run=False):
                 )
             for group in groups.values():
                 browser_list = pluralize([i["browser"] for i in group])
-                notifications.append(
+                bcd_notifications.append(
                     {
                         "path": change["path"],
                         "text": COPY[change["event"]] + browser_list,
@@ -103,7 +103,7 @@ def process_changes(changes, dry_run=False):
 
         elif change["event"] == "added_subfeatures":
             n = len(change["subfeatures"])
-            notifications.append(
+            bcd_notifications.append(
                 {
                     "path": change["path"],
                     "text": f"{n} compatibility subfeature{'s'[:n ^ 1]} added",
@@ -115,7 +115,7 @@ def process_changes(changes, dry_run=False):
                 get_browser_info(i["browser"]) for i in change["support_changes"]
             ]
             text = pluralize(browser_list)
-            notifications.append(
+            bcd_notifications.append(
                 {
                     "path": change["path"],
                     "text": f"More complete compatibility data added for {text}",
@@ -123,5 +123,5 @@ def process_changes(changes, dry_run=False):
                 }
             )
 
-    for notification in notifications:
-        publish_notification(**notification, dry_run=dry_run)
+    for notification in bcd_notifications:
+        publish_bcd_notification(**notification, dry_run=dry_run)

--- a/kuma/notifications/utils.py
+++ b/kuma/notifications/utils.py
@@ -1,6 +1,7 @@
 import re
 from collections import defaultdict
 
+from kuma.documenturls.models import DocumentURL
 from kuma.notifications.browsers import browsers
 from kuma.notifications.models import Notification, NotificationData, Watch
 
@@ -146,10 +147,11 @@ def process_changes(changes, dry_run=False):
             )
 
         elif change["event"] == "content_updated":
+            url = DocumentURL.normalize_uri(change["page_url"])
             m = re.match(r"^https://github.com/(.+)/pull/(\d+)$", change["pr_url"])
             content_notifications.append(
                 {
-                    "url": change["page_url"],
+                    "url": url,
                     "text": f"Page updated (see PR!{m.group(1)}!{m.group(2)}!!)",
                 }
             )

--- a/kuma/notifications/utils.py
+++ b/kuma/notifications/utils.py
@@ -6,7 +6,7 @@ from kuma.notifications.browsers import browsers
 from kuma.notifications.models import Notification, NotificationData, Watch
 
 
-def publish_bcd_notification(path, text, dry_run=False, data=None):
+def publish_bcd_notification(path, text, data=None):
     # This traverses down the path to see if there's top level watchers
     parts = path.split(".")
     suffix = []
@@ -23,16 +23,16 @@ def publish_bcd_notification(path, text, dry_run=False, data=None):
         # we use the suffix as title (after reversing the order).
         title = reversed(suffix)
         title = ".".join(title)
-        if not dry_run:
-            notification_data, _ = NotificationData.objects.get_or_create(
-                title=title,
-                text=text,
-                data=data,
-                type="compat",
-                page_url=watcher.url,
-            )
-            for user in watcher.users.all():
-                Notification.objects.create(notification=notification_data, user=user)
+
+        notification_data, _ = NotificationData.objects.get_or_create(
+            title=title,
+            text=text,
+            data=data,
+            type="compat",
+            page_url=watcher.url,
+        )
+        for user in watcher.users.all():
+            Notification.objects.create(notification=notification_data, user=user)
 
 
 def get_browser_info(browser, preview=False):
@@ -77,13 +77,10 @@ COPY = {
 }
 
 
-def publish_content_notification(url, text, dry_run=False):
+def publish_content_notification(url, text):
     watchers = Watch.objects.filter(url=url)
 
     if not watchers:
-        return
-
-    if dry_run:
         return
 
     notification_data, _ = NotificationData.objects.get_or_create(
@@ -96,7 +93,7 @@ def publish_content_notification(url, text, dry_run=False):
             Notification.objects.create(notification=notification_data, user=user)
 
 
-def process_changes(changes, dry_run=False):
+def process_changes(changes):
     bcd_notifications = []
     content_notifications = []
 
@@ -157,7 +154,7 @@ def process_changes(changes, dry_run=False):
             )
 
     for notification in bcd_notifications:
-        publish_bcd_notification(**notification, dry_run=dry_run)
+        publish_bcd_notification(**notification)
 
     for notification in content_notifications:
-        publish_content_notification(**notification, dry_run=dry_run)
+        publish_content_notification(**notification)


### PR DESCRIPTION
Part of https://github.com/mdn/yari-private/issues/981.

## Before

1. `/update/` created only BCD Update Notifications.
2. `/create/pr/` created a single Content Update Notification independently.

## After

1. `/update/` creates both BCD **and Content** Update Notifications.
2. `/create/pr/` creates a single Content Update Notification **by reusing the same logic**.